### PR TITLE
POM-work to prevent compiler bug with Annotation processor.

### DIFF
--- a/.travis.maven.settings.xml
+++ b/.travis.maven.settings.xml
@@ -1,0 +1,93 @@
+<!--
+
+    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <interactiveMode>false</interactiveMode>
+
+  <profiles>
+    <profile>
+      <id>securecentral</id>
+      <!--Override the repository (and pluginRepository) "central" from the
+         Maven Super POM -->
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+    <profile>
+      <id>jboss-public-repository</id>
+      <repositories>
+        <repository>
+          <id>jboss-public-repository-group</id>
+          <name>JBoss Public Maven Repository Group</name>
+          <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>jboss-public-repository-group</id>
+          <name>JBoss Public Maven Repository Group</name>
+          <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>securecentral</activeProfile>
+    <activeProfile>jboss-public-repository</activeProfile>
+  </activeProfiles>
+
+</settings>
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,8 @@ language: java
 jdk:
   - oraclejdk8
 
-install: mvn clean install
+install:
+  - mvn -s .travis.maven.settings.xml -version -B
+
+script:
+  - mvn -fae -s .travis.maven.settings.xml clean install

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hawkular-parent</artifactId>
     <groupId>org.hawkular</groupId>
-    <version>4</version>
+    <version>5</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.hawkular</groupId>
     <artifactId>hawkular-parent</artifactId>
-    <version>4</version>
+    <version>5</version>
   </parent>
 
 
@@ -46,16 +46,29 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
-      <version>${version.org.jboss.logging}</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
@@ -71,7 +84,6 @@
     <dependency>
       <groupId>org.jboss.spec.javax.ejb</groupId>
       <artifactId>jboss-ejb-api_3.1_spec</artifactId>
-      <version>1.0.2.Final</version>
     </dependency>
   </dependencies>
 
@@ -79,37 +91,6 @@
   <build>
     <finalName>inventory-impl</finalName>
 
-<!--
-    <plugins>
-      <plugin>
-        <groupId>org.bsc.maven</groupId>
-        <artifactId>maven-processor-plugin</artifactId>
-        <version>2.2.4</version> &lt;!&ndash; TODO change once available in parent pom &ndash;&gt;
-        <executions>
-          <execution>
-            <id>process</id>
-            <goals>
-              <goal>process</goal>
-            </goals>
-            <phase>generate-sources</phase>
-            <configuration>
-              <processors>
-                <processor>org.jboss.logging.processor.apt.LoggingToolsProcessor</processor>
-              </processors>
-            </configuration>
-          </execution>
-        </executions>
-        <dependencies>
-          <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <version>${version.org.jboss.logging.processor}</version>
-            <scope>compile</scope>
-          </dependency>
-        </dependencies>
-      </plugin>
-    </plugins>
--->
   </build>
 
 </project>

--- a/impl/src/main/java/org/hawkular/inventory/impl/Log.java
+++ b/impl/src/main/java/org/hawkular/inventory/impl/Log.java
@@ -16,10 +16,10 @@
  */
 package org.hawkular.inventory.impl;
 
-import org.jboss.logging.LogMessage;
 import org.jboss.logging.Logger;
-import org.jboss.logging.Message;
-import org.jboss.logging.MessageLogger;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
 
 /**
  * Logger for the Inventory impl.
@@ -31,7 +31,7 @@ import org.jboss.logging.MessageLogger;
 @MessageLogger(projectCode = "HAWKINV")
 public interface Log {
 
-    Log LOG = Logger.getMessageLogger(Log.class,"org.hawkular.inventory.impl");
+    Log LOG = Logger.getMessageLogger(Log.class, "org.hawkular.inventory.impl");
 
     @LogMessage(level = Logger.Level.WARN)
     @Message(id = 1000, value = "Something bad has happened: %s")

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.hawkular</groupId>
     <artifactId>hawkular-parent</artifactId>
-    <version>4</version>
+    <version>5</version>
   </parent>
 
   <modules>

--- a/rest-servlet/pom.xml
+++ b/rest-servlet/pom.xml
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.hawkular</groupId>
     <artifactId>hawkular-parent</artifactId>
-    <version>4</version>
+    <version>5</version>
   </parent>
 
   <dependencyManagement>
@@ -53,8 +53,14 @@
     <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
-      <version>${version.org.jboss.logging}</version>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
 
     <dependency>
@@ -73,7 +79,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
 
@@ -98,6 +103,12 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
 
   </dependencies>
 

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/RestApiLogger.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/RestApiLogger.java
@@ -17,11 +17,11 @@
 package org.hawkular.inventory.rest;
 
 
-import org.jboss.logging.Cause;
-import org.jboss.logging.LogMessage;
 import org.jboss.logging.Logger;
-import org.jboss.logging.Message;
-import org.jboss.logging.MessageLogger;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
 
 /**
  * Logger definitions for Jboss Logging for the rest api

--- a/rest-test/pom.xml
+++ b/rest-test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular</groupId>
     <artifactId>hawkular-parent</artifactId>
-    <version>4</version>
+    <version>5</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -42,45 +42,20 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
-      <version>${version.org.codehaus.groovy}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy.modules.http-builder</groupId>
       <artifactId>http-builder</artifactId>
-      <version>${version.org.codehaus.groovy.modules.http-builder}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.gmavenplus</groupId>
-        <artifactId>gmavenplus-plugin</artifactId>
-        <version>${version.org.codehaus.gmavenplus.gmavenplus-plugin}</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>addSources</goal>
-              <goal>addTestSources</goal>
-              <goal>compile</goal>
-              <goal>testCompile</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-    </plugins>
-
-  </build>
 
   <profiles>
     <profile>


### PR DESCRIPTION
This requires parent pom v5, which is not yet on central, so the first CI run will fail.

If you have the jboss nexus in ~/.m2/settings.xml you can build it , as the jboss releases repo already has v5
