### PR TITLE
Updating REST interface for clearer hierarchy

### DIFF
--- a/rest-servlet/README.adoc
+++ b/rest-servlet/README.adoc
@@ -30,7 +30,7 @@ The API offers the following endpoints:
 Example
 [source, shell]
 ----
-curl -i http://localhost:8080/hawkular/inventory/rest-test/resource/x1422733176502 -HAccepts:application/json
+curl -i http://localhost:8080/hawkular/inventory/rest-test/resources/x1422733176502 -HAccepts:application/json
 HTTP/1.1 200 OK
 Connection: keep-alive
 X-Powered-By: Undertow/1
@@ -45,7 +45,7 @@ Date: Sat, 31 Jan 2015 19:40:13 GMT
 == Delete Resource
 
 * Method DELETE
-* Url-Template /{tenant}/resource/{id}
+* Url-Template /{tenant}/resources/{id}
 
 
 == List Resources by Type
@@ -59,7 +59,7 @@ are returned
 == Add Metrics To Resource
 
 * Method PUT
-* Url-Template /{tenant}/resource/{resourceId}/metrics
+* Url-Template /{tenant}/resources/{resourceId}/metrics
 * Payload: list of `MetricDefinition`
 
 [source]
@@ -79,13 +79,13 @@ Note: when adding multiple metrics with the same name to a resource, the first d
 == List Metrics of Resource
 
 * Method GET
-* Url-Template /{tenant}/resource/{rid}/metrics
+* Url-Template /{tenant}/resources/{rid}/metrics
 
 Example:
 
 [source,shell]
 ----
-curl -i http://localhost:8080/hawkular/inventory/rest-test/resource/x1422733176502/metrics -HAccepts:application/json
+curl -i http://localhost:8080/hawkular/inventory/rest-test/resources/x1422733176502/metrics -HAccepts:application/json
 HTTP/1.1 200 OK
 Connection: keep-alive
 X-Powered-By: Undertow/1
@@ -104,13 +104,13 @@ Date: Sat, 31 Jan 2015 19:40:58 GMT
 == Get one Metric
 
 * Method GET
-* URL-Template /{tenant}/resource/{rid}/metric/{mid}
+* URL-Template /{tenant}/resources/{rid}/metrics/{mid}
 
 Example:
 
 [source,shell]
 ----
-$ curl -i http://localhost:8080/hawkular/inventory/rest-test/resource/x1422867147296/metric/cpu.load1
+$ curl -i http://localhost:8080/hawkular/inventory/rest-test/resources/x1422867147296/metrics/cpu.load1
 HTTP/1.1 200 OK
 Connection: keep-alive
 X-Powered-By: Undertow/1
@@ -125,7 +125,7 @@ Date: Mon, 02 Feb 2015 08:57:39 GMT
 == Update one Metric
 
 * Method PUT
-* Url-Template  /{tenant}/resource/{rid}/metric/{mid}
+* Url-Template  /{tenant}/resources/{rid}/metrics/{mid}
 * Payload: One `MetricDefinition`
 
 [source]

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/RestApi.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/RestApi.java
@@ -93,7 +93,7 @@ public class RestApi {
     }
 
     @GET
-    @Path("/{tenantId}/resource/{uid}")
+    @Path("/{tenantId}/resources/{uid}")
     public Response getResource(@PathParam("tenantId") String tenantId, @PathParam
             ("uid") String uid) {
 
@@ -114,7 +114,7 @@ public class RestApi {
 
 
     @DELETE
-    @Path("/{tenantId}/resource/{uid}")
+    @Path("/{tenantId}/resources/{uid}")
     public Response deleteResource(@PathParam("tenantId") String tenantId, @PathParam
             ("uid") String uid) {
 
@@ -134,8 +134,8 @@ public class RestApi {
     }
 
 
-    @PUT
-    @Path("/{tenantId}/resource/{resourceId}/metrics/")
+    @POST
+    @Path("/{tenantId}/resources/{resourceId}/metrics")
     public Response addMetricToResource(@PathParam("tenantId") String tenantId,
                                         @PathParam("resourceId") String resourceId,
                                         Collection<MetricDefinition> payload) {
@@ -166,7 +166,7 @@ public class RestApi {
     }
 
     @GET
-    @Path("/{tenantId}/resource/{resourceId}/metrics")
+    @Path("/{tenantId}/resources/{resourceId}/metrics")
     public Response listMetricsOfResource(@PathParam("tenantId") String tenantId,
                                             @PathParam("resourceId") String resourceId) {
 
@@ -187,7 +187,7 @@ public class RestApi {
     }
 
     @GET
-    @Path("/{tenantId}/resource/{resourceId}/metric/{metricId}")
+    @Path("/{tenantId}/resources/{resourceId}/metrics/{metricId}")
     public Response getMetricOfResource(@PathParam("tenantId") String tenantId,
                                             @PathParam("resourceId") String resourceId,
                                             @PathParam("metricId") String metricId
@@ -214,7 +214,7 @@ public class RestApi {
     }
 
     @PUT
-    @Path("/{tenantId}/resource/{resourceId}/metric/{metricId}")
+    @Path("/{tenantId}/resources/{resourceId}/metrics/{metricId}")
     public Response getMetricOfResource(@PathParam("tenantId") String tenantId,
                                             @PathParam("resourceId") String resourceId,
                                             MetricDefinition payload) {

--- a/rest-test/src/test/groovy/org/hawkular/inventory/rest/test/RestTest.groovy
+++ b/rest-test/src/test/groovy/org/hawkular/inventory/rest/test/RestTest.groovy
@@ -58,7 +58,7 @@ class RestTest extends AbstractTestBase{
 
         assertNotEquals("", id, "Id should not be empty")
 
-        response = client.get(path: "$tenantId/resource/$id")
+        response = client.get(path: "$tenantId/resources/$id")
 
         assertEquals(200, response.status)
         assertEquals(id,response.data.id)
@@ -88,7 +88,7 @@ class RestTest extends AbstractTestBase{
             assert response.data.size() > 0
             assertEquals(id,response.data[0].id)
         } finally {
-            response = client.delete(path: "$tenantId/resource/$id");
+            response = client.delete(path: "$tenantId/resources/$id");
             assertEquals(200, response.status)
         }
 
@@ -119,7 +119,7 @@ class RestTest extends AbstractTestBase{
             assert response.data.size() > 0
             assertEquals(id,response.data[0].id)
         } finally {
-            response = client.delete(path: "$tenantId/resource/$id");
+            response = client.delete(path: "$tenantId/resources/$id");
             assertEquals(200, response.status)
 
         }
@@ -146,7 +146,7 @@ class RestTest extends AbstractTestBase{
         assertNotEquals("", id, "Id should not be empty")
 
         try {
-            client.get(path: "XX$tenantId/resource/$id")
+            client.get(path: "XX$tenantId/resources/$id")
             // We should never hit the next line
             assert false;
         } catch (HttpResponseException e) {
@@ -174,16 +174,16 @@ class RestTest extends AbstractTestBase{
 
         assertNotEquals("", id, "Id should not be empty")
 
-        response = client.get(path: "$tenantId/resource/$id")
+        response = client.get(path: "$tenantId/resources/$id")
 
         assertEquals(200, response.status)
         assertEquals(id,response.data.id)
 
-        response = client.delete(path: "$tenantId/resource/$id")
+        response = client.delete(path: "$tenantId/resources/$id")
         assertEquals(200, response.status)
 
         try {
-            client.get(path: "$tenantId/resource/$id")
+            client.get(path: "$tenantId/resources/$id")
             assert false;
         } catch (HttpResponseException e) {
             ; // this is good
@@ -205,14 +205,14 @@ class RestTest extends AbstractTestBase{
 
         def rid = response.data.id
 
-        client.put(path: "$tenantId/resource/$rid/metrics", body: ["cpu.load1"])
-        client.put(path: "$tenantId/resource/$rid/metrics", body: ["cpu.load5", "cpu.load15"])
+        client.post(path: "$tenantId/resources/$rid/metrics", body: ["cpu.load1"])
+        client.post(path: "$tenantId/resources/$rid/metrics", body: ["cpu.load5", "cpu.load15"])
 
         def metricDefinition = new MetricDefinition("cpu.load1",MetricUnit.NONE); // name is on purpose like above
         metricDefinition.description = "This is the one minute load of the CPU"
-        client.put(path: "$tenantId/resource/$rid/metrics", body: [ metricDefinition ])
+        client.post(path: "$tenantId/resources/$rid/metrics", body: [ metricDefinition ])
 
-        response = client.get(path: "$tenantId/resource/$rid/metrics")
+        response = client.get(path: "$tenantId/resources/$rid/metrics")
 
         assertEquals(200,response.status)
         def data = response.data
@@ -222,11 +222,11 @@ class RestTest extends AbstractTestBase{
         println(rid)
 
         metricDefinition.unit = MetricUnit.BYTE;
-        response = client.put(path: "$tenantId/resource/$rid/metric/cpu.load1", body: metricDefinition);
+        response = client.put(path: "$tenantId/resources/$rid/metrics/cpu.load1", body: metricDefinition);
 
         assertEquals(200, response.status)
 
-        response = client.get(path: "$tenantId/resource/$rid/metric/cpu.load1")
+        response = client.get(path: "$tenantId/resources/$rid/metrics/cpu.load1")
         assertEquals(200, response.status)
 
         assertEquals("BYTE", response.data.unit)
@@ -239,7 +239,7 @@ class RestTest extends AbstractTestBase{
         def tenantId = "bla"
         def rid = "-1"
         try {
-            client.put(path: "$tenantId/resource/$rid/metrics", body: ["cpu.load1"])
+            client.post(path: "$tenantId/resources/$rid/metrics", body: ["cpu.load1"])
             assert false : "We should have gotten a 404, but obviously didnt"
         } catch (HttpResponseException e) {
             ; // This is good


### PR DESCRIPTION
I've unified the "resources" and "resource" end-points + used PUT where id was specified in URL.
