### PR TITLE
HWKINVENT-15 Relationship service

### DIFF
--- a/api/src/main/java/org/hawkular/inventory/api/Environments.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Environments.java
@@ -74,4 +74,6 @@ public final class Environments {
     public interface ReadWrite extends ReadWriteInterface<Environment, String, Single, Multiple> {
         void copy(String sourceEnvironmentId, String targetEnvironmentId);
     }
+
+    public interface ReadRelate extends ReadInterface<Single, Multiple>, RelateInterface {}
 }

--- a/api/src/main/java/org/hawkular/inventory/api/Feeds.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Feeds.java
@@ -41,4 +41,6 @@ public final class Feeds {
     public interface ReadAndRegister extends ReadInterface<Single, Multiple> {
         Single register(String proposedId);
     }
+
+    public interface ReadRelate extends ReadInterface<Single, Multiple>, RelateInterface {}
 }

--- a/api/src/main/java/org/hawkular/inventory/api/Relationships.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Relationships.java
@@ -71,14 +71,11 @@ public final class Relationships {
     }
 
     /**
-     * TODO this is wrong - we should provide the ReadRelate ifaces instead of ReadWrite - meaning that we should be
-     * able to add new entities into a relationship with the current one but not create brand new "target" entities.
-     *
      * Interface for accessing a single relationship in a writable manner
      */
     public interface Single extends ResolvableToSingle<Relationship>,
-            BrowserBase<Tenants.ReadWrite, Environments.ReadWrite, Feeds.ReadAndRegister, MetricTypes.ReadWrite,
-                    Metrics.ReadWrite, Resources.ReadWrite, ResourceTypes.ReadWrite> {}
+            BrowserBase<Tenants.ReadRelate, Environments.ReadRelate, Feeds.ReadRelate, MetricTypes.ReadRelate,
+                    Metrics.ReadRelate, Resources.ReadRelate, ResourceTypes.ReadRelate> {}
 
     /**
      * Interface for traversing over a set of relationships.
@@ -95,10 +92,13 @@ public final class Relationships {
      * Provides read-write access to relationships.
      */
     public interface ReadWrite extends ReadWriteInterface<Relationship, Relationship.Blueprint, Single, Multiple> {
+        Multiple named(String name);
     }
 
     /**
      * Provides read access to relationships.
      */
-    public interface Read extends ReadInterface<Single, Multiple> {}
+    public interface Read extends ReadInterface<Single, Multiple> {
+        Multiple named(String name);
+    }
 }

--- a/api/src/main/java/org/hawkular/inventory/api/ResourceTypes.java
+++ b/api/src/main/java/org/hawkular/inventory/api/ResourceTypes.java
@@ -67,4 +67,5 @@ public final class ResourceTypes {
      * Provides read-write access to resource types.
      */
     public interface ReadWrite extends ReadWriteInterface<ResourceType, ResourceType.Blueprint, Single, Multiple> {}
+    public interface ReadRelate extends ReadInterface<Single, Multiple>, RelateInterface {}
 }

--- a/api/src/main/java/org/hawkular/inventory/api/Resources.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Resources.java
@@ -59,4 +59,9 @@ public final class Resources {
      * Provides read-write access to resources.
      */
     public interface ReadWrite extends ReadWriteInterface<Resource, Resource.Blueprint, Single, Multiple> {}
+
+    /**
+     * Provides read access to relationships of resource.
+     */
+    public interface ReadRelate extends ReadInterface<Single, Multiple>, RelateInterface {}
 }

--- a/api/src/main/java/org/hawkular/inventory/api/Tenants.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Tenants.java
@@ -72,4 +72,6 @@ public final class Tenants {
      * Provides methods for read-write access to tenants.
      */
     public interface ReadWrite extends ReadWriteInterface<Tenant, String, Single, Multiple> {}
+
+    public interface ReadRelate extends ReadInterface<Single, Multiple>, RelateInterface {}
 }

--- a/api/src/main/java/org/hawkular/inventory/api/filters/Related.java
+++ b/api/src/main/java/org/hawkular/inventory/api/filters/Related.java
@@ -31,7 +31,7 @@ public class Related<T extends Entity> extends Filter {
 
     private final T entity;
     private final String relationshipName;
-    private final String edgeId;
+    private final String relationshipId;
     private final EntityRole entityRole;
 
     /**
@@ -85,11 +85,11 @@ public class Related<T extends Entity> extends Filter {
      * Creates a filter for entities that are sources of at least one relationship with the specified id. The target
      * entity is not specified and can be anything.
      *
-     * @param edgeId the id of the edge
+     * @param relationshipId the id of the relationship
      * @return a new "related" filter instance
      */
-    public static Related<?> byEdgeWithId(String edgeId) {
-        return new Related<>(null, null, edgeId, EntityRole.SOURCE);
+    public static Related<?> byRelationshipWithId(String relationshipId) {
+        return new Related<>(null, null, relationshipId, EntityRole.SOURCE);
     }
 
     /**
@@ -139,10 +139,10 @@ public class Related<T extends Entity> extends Filter {
         return new Related<>(null, relationship.name(), EntityRole.TARGET);
     }
 
-    protected Related(T entity, String relationshipName, String edgeId, EntityRole entityRole) {
+    protected Related(T entity, String relationshipName, String relationshipId, EntityRole entityRole) {
         this.entity = entity;
         this.relationshipName = relationshipName;
-        this.edgeId = edgeId;
+        this.relationshipId = relationshipId;
         this.entityRole = entityRole;
     }
 
@@ -167,8 +167,8 @@ public class Related<T extends Entity> extends Filter {
     /**
      * @return the id of the relationship
      */
-    public String getEdgeId() {
-        return edgeId;
+    public String getRelationshipId() {
+        return relationshipId;
     }
 
     /**

--- a/api/src/main/java/org/hawkular/inventory/api/filters/Related.java
+++ b/api/src/main/java/org/hawkular/inventory/api/filters/Related.java
@@ -31,6 +31,7 @@ public class Related<T extends Entity> extends Filter {
 
     private final T entity;
     private final String relationshipName;
+    private final String edgeId;
     private final EntityRole entityRole;
 
     /**
@@ -81,6 +82,17 @@ public class Related<T extends Entity> extends Filter {
     }
 
     /**
+     * Creates a filter for entities that are sources of at least one relationship with the specified id. The target
+     * entity is not specified and can be anything.
+     *
+     * @param edgeId the id of the edge
+     * @return a new "related" filter instance
+     */
+    public static Related<?> byEdgeWithId(String edgeId) {
+        return new Related<>(null, null, edgeId, EntityRole.SOURCE);
+    }
+
+    /**
      * Specifies a filter for entities that are targets of a relationship with the specified entity.
      *
      * @param entity the entity that is the source of the relationship
@@ -127,10 +139,15 @@ public class Related<T extends Entity> extends Filter {
         return new Related<>(null, relationship.name(), EntityRole.TARGET);
     }
 
-    protected Related(T entity, String relationshipName, EntityRole entityRole) {
+    protected Related(T entity, String relationshipName, String edgeId, EntityRole entityRole) {
         this.entity = entity;
         this.relationshipName = relationshipName;
+        this.edgeId = edgeId;
         this.entityRole = entityRole;
+    }
+
+    protected Related(T entity, String relationshipName, EntityRole entityRole) {
+        this(entity, relationshipName, null, entityRole);
     }
 
     /**
@@ -145,6 +162,13 @@ public class Related<T extends Entity> extends Filter {
      */
     public String getRelationshipName() {
         return relationshipName;
+    }
+
+    /**
+     * @return the id of the relationship
+     */
+    public String getEdgeId() {
+        return edgeId;
     }
 
     /**

--- a/api/src/main/java/org/hawkular/inventory/api/filters/With.java
+++ b/api/src/main/java/org/hawkular/inventory/api/filters/With.java
@@ -37,13 +37,13 @@ public final class With {
         return new Ids(ids);
     }
 
-    public static Types type(Class<? extends Entity> type) {
-        return new Types(type);
-    }
-
     @SafeVarargs
     public static Types types(Class<? extends Entity>... types) {
         return new Types(types);
+    }
+
+    public static Types type(Class<? extends Entity> type) {
+        return new Types(type);
     }
 
     public static final class Ids extends Filter {

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/AbstractBrowser.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/AbstractBrowser.java
@@ -54,7 +54,7 @@ abstract class AbstractBrowser<E extends Entity> extends AbstractSourcedGraphSer
     }
 
     public RelationshipService relationships() {
-        return new RelationshipService(context.getGraph(), new PathContext(path, Filter.all()), entityClass);
+        return new RelationshipService(context, new PathContext(path, Filter.all()), entityClass);
     }
 
     @Override

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/AbstractBrowser.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/AbstractBrowser.java
@@ -30,6 +30,7 @@ import java.util.Set;
  * @since 1.0
  */
 abstract class AbstractBrowser<E extends Entity> extends AbstractSourcedGraphService<Void, Void, E, Void> {
+
     AbstractBrowser(InventoryContext context, Class<E> entityClass, FilterApplicator... path) {
         super(context, entityClass, new PathContext(path, null));
     }
@@ -53,7 +54,7 @@ abstract class AbstractBrowser<E extends Entity> extends AbstractSourcedGraphSer
     }
 
     public RelationshipService relationships() {
-        return new RelationshipService(context.getGraph(), source().next());
+        return new RelationshipService(context.getGraph(), new PathContext(path, Filter.all()), entityClass);
     }
 
     @Override

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/AbstractGraphService.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/AbstractGraphService.java
@@ -18,7 +18,6 @@ package org.hawkular.inventory.impl.tinkerpop;
 
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
-import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.blueprints.Vertex;
 import org.hawkular.inventory.api.filters.Filter;
 import org.hawkular.inventory.api.model.Entity;

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/AbstractGraphService.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/AbstractGraphService.java
@@ -17,6 +17,8 @@
 package org.hawkular.inventory.impl.tinkerpop;
 
 import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.blueprints.Vertex;
 import org.hawkular.inventory.api.filters.Filter;
 import org.hawkular.inventory.api.model.Entity;
@@ -35,7 +37,7 @@ import org.hawkular.inventory.api.model.Tenant;
  */
 abstract class AbstractGraphService {
     protected final InventoryContext context;
-    private final FilterApplicator[] path;
+    protected final FilterApplicator[] path;
 
     AbstractGraphService(InventoryContext context, FilterApplicator... path) {
         this.context = context;
@@ -58,6 +60,10 @@ abstract class AbstractGraphService {
     }
 
     protected FilterApplicator.Builder pathWith(Filter... filters) {
+        return pathWith(path, filters);
+    }
+
+    public static FilterApplicator.Builder pathWith(FilterApplicator[] path, Filter... filters) {
         return FilterApplicator.from(path).and(FilterApplicator.Type.PATH, filters);
     }
 
@@ -67,6 +73,10 @@ abstract class AbstractGraphService {
 
     static String getUid(Vertex v) {
         return getProperty(v, Constants.Property.uid);
+    }
+
+    static String getUid(Edge e) {
+        return e.getProperty(Constants.Property.uid.name());
     }
 
     static String getType(Vertex v) {

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/EnvironmentsService.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/EnvironmentsService.java
@@ -33,7 +33,7 @@ import static org.hawkular.inventory.impl.tinkerpop.Constants.Type.tenant;
  */
 final class EnvironmentsService extends
         AbstractSourcedGraphService<Environments.Single, Environments.Multiple, Environment, String>
-        implements Environments.ReadWrite, Environments.Read {
+        implements Environments.ReadWrite, Environments.Read, Environments.ReadRelate {
 
     public EnvironmentsService(InventoryContext context, PathContext ctx) {
         super(context, Environment.class, ctx);
@@ -82,5 +82,15 @@ final class EnvironmentsService extends
     public void delete(String id) {
         //TODO implement
 
+    }
+
+    @Override
+    public void add(String id) {
+        //TODO implement
+    }
+
+    @Override
+    public void remove(String id) {
+        //TODO implement
     }
 }

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FeedsService.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FeedsService.java
@@ -33,7 +33,7 @@ import static org.hawkular.inventory.impl.tinkerpop.Constants.Type.environment;
  * @since 1.0
  */
 final class FeedsService extends AbstractSourcedGraphService<Feeds.Single, Feeds.Multiple, Feed, String>
-        implements Feeds.ReadAndRegister, Feeds.Read {
+        implements Feeds.ReadAndRegister, Feeds.Read, Feeds.ReadRelate {
 
     FeedsService(InventoryContext context, PathContext ctx) {
         super(context, Feed.class, ctx);
@@ -81,5 +81,15 @@ final class FeedsService extends AbstractSourcedGraphService<Feeds.Single, Feeds
     @Override
     public Feeds.Single register(String proposedId) {
         return super.create(proposedId);
+    }
+
+    @Override
+    public void add(String id) {
+        //TODO implement
+    }
+
+    @Override
+    public void remove(String id) {
+        //TODO implement
     }
 }

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterVisitor.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterVisitor.java
@@ -44,27 +44,27 @@ class FilterVisitor {
                 if (null != related.getRelationshipName()) {
                     query.in(related.getRelationshipName());
                 }
-                if (null != related.getEdgeId()) {
+                if (null != related.getRelationshipId()) {
                     // TODO test
-                    query.inE().has("id", related.getEdgeId()).inV();
+                    query.inE().has("id", related.getRelationshipId()).inV();
                 }
                 break;
             case SOURCE:
                 if (null != related.getRelationshipName()) {
                     query.out(related.getRelationshipName());
                 }
-                if (null != related.getEdgeId()) {
+                if (null != related.getRelationshipId()) {
                     // TODO test
-                    query.outE().has("id", related.getEdgeId()).outV();
+                    query.outE().has("id", related.getRelationshipId()).outV();
                 }
                 break;
             case ANY:
                 if (null != related.getRelationshipName()) {
                     query.both(related.getRelationshipName());
                 }
-                if (null != related.getEdgeId()) {
+                if (null != related.getRelationshipId()) {
                     // TODO test
-                    query.bothE().has("id", related.getEdgeId()).bothV();
+                    query.bothE().has("id", related.getRelationshipId()).bothV();
                 }
         }
 

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterVisitor.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterVisitor.java
@@ -41,13 +41,31 @@ class FilterVisitor {
 
         switch (related.getEntityRole()) {
             case TARGET:
-                query.in(related.getRelationshipName());
+                if (null != related.getRelationshipName()) {
+                    query.in(related.getRelationshipName());
+                }
+                if (null != related.getEdgeId()) {
+                    // TODO test
+                    query.inE().has("id", related.getEdgeId()).inV();
+                }
                 break;
             case SOURCE:
-                query.out(related.getRelationshipName());
+                if (null != related.getRelationshipName()) {
+                    query.out(related.getRelationshipName());
+                }
+                if (null != related.getEdgeId()) {
+                    // TODO test
+                    query.outE().has("id", related.getEdgeId()).outV();
+                }
                 break;
             case ANY:
-                query.both(related.getRelationshipName());
+                if (null != related.getRelationshipName()) {
+                    query.both(related.getRelationshipName());
+                }
+                if (null != related.getEdgeId()) {
+                    // TODO test
+                    query.bothE().has("id", related.getEdgeId()).bothV();
+                }
         }
 
         if (related.getEntity() != null) {

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricTypesService.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricTypesService.java
@@ -36,8 +36,7 @@ import static org.hawkular.inventory.impl.tinkerpop.Constants.Type.tenant;
  */
 final class MetricTypesService
         extends AbstractSourcedGraphService<MetricTypes.Single, MetricTypes.Multiple,
-        MetricType, MetricType.Blueprint>
-        implements MetricTypes.ReadWrite, MetricTypes.ReadRelate {
+        MetricType, MetricType.Blueprint> implements MetricTypes.ReadWrite, MetricTypes.ReadRelate {
 
     MetricTypesService(InventoryContext context, PathContext ctx) {
         super(context, MetricType.class, ctx);

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/PathVisitor.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/PathVisitor.java
@@ -32,27 +32,27 @@ class PathVisitor extends FilterVisitor {
                 if (null != related.getRelationshipName()) {
                     query.in(related.getRelationshipName());
                 }
-                if (null != related.getEdgeId()) {
+                if (null != related.getRelationshipId()) {
                     // TODO test
-                    query.inE().has("id", related.getEdgeId()).inV();
+                    query.inE().has("id", related.getRelationshipId()).inV();
                 }
                 break;
             case SOURCE:
                 if (null != related.getRelationshipName()) {
                     query.out(related.getRelationshipName());
                 }
-                if (null != related.getEdgeId()) {
+                if (null != related.getRelationshipId()) {
                     // TODO test
-                    query.outE().has("id", related.getEdgeId()).outV();
+                    query.outE().has("id", related.getRelationshipId()).outV();
                 }
                 break;
             case ANY:
                 if (null != related.getRelationshipName()) {
                     query.both(related.getRelationshipName());
                 }
-                if (null != related.getEdgeId()) {
+                if (null != related.getRelationshipId()) {
                     // TODO test
-                    query.bothE().has("id", related.getEdgeId()).bothV();
+                    query.bothE().has("id", related.getRelationshipId()).bothV();
                 }
         }
 

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/PathVisitor.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/PathVisitor.java
@@ -29,13 +29,31 @@ class PathVisitor extends FilterVisitor {
     public void visit(HawkularPipeline<?, ?> query, Related<? extends Entity> related) {
         switch (related.getEntityRole()) {
             case TARGET:
-                query.in(related.getRelationshipName());
+                if (null != related.getRelationshipName()) {
+                    query.in(related.getRelationshipName());
+                }
+                if (null != related.getEdgeId()) {
+                    // TODO test
+                    query.inE().has("id", related.getEdgeId()).inV();
+                }
                 break;
             case SOURCE:
-                query.out(related.getRelationshipName());
+                if (null != related.getRelationshipName()) {
+                    query.out(related.getRelationshipName());
+                }
+                if (null != related.getEdgeId()) {
+                    // TODO test
+                    query.outE().has("id", related.getEdgeId()).outV();
+                }
                 break;
             case ANY:
-                query.both(related.getRelationshipName());
+                if (null != related.getRelationshipName()) {
+                    query.both(related.getRelationshipName());
+                }
+                if (null != related.getEdgeId()) {
+                    // TODO test
+                    query.bothE().has("id", related.getEdgeId()).bothV();
+                }
         }
 
         if (related.getEntity() != null) {

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/RelationshipBrowser.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/RelationshipBrowser.java
@@ -186,7 +186,7 @@ final class RelationshipBrowser<E extends Entity> extends AbstractBrowser<E> {
         Filter.Accumulator acc = Filter.by(EdgeFilter.NAMED == filter ? Related.by(value) : Related.byRelationshipWithId
                 (value), With.type(clazz1));
         try {
-            Constructor<S> constructor = clazz2.getConstructor(InventoryContext.class, PathContext.class);
+            Constructor<S> constructor = clazz2.getDeclaredConstructor(InventoryContext.class, PathContext.class);
             return constructor.newInstance(context, pathToHereWithSelect(acc));
         } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException
                 e) {
@@ -202,6 +202,6 @@ final class RelationshipBrowser<E extends Entity> extends AbstractBrowser<E> {
     }
 
     private enum EdgeFilter {
-        ID, NAMED;
+        ID, NAMED
     }
 }

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/RelationshipBrowser.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/RelationshipBrowser.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.impl.tinkerpop;
+
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.TransactionalGraph;
+import com.tinkerpop.blueprints.Vertex;
+import org.hawkular.inventory.api.Environments;
+import org.hawkular.inventory.api.Feeds;
+import org.hawkular.inventory.api.MetricTypes;
+import org.hawkular.inventory.api.Metrics;
+import org.hawkular.inventory.api.Relationships;
+import org.hawkular.inventory.api.ResourceTypes;
+import org.hawkular.inventory.api.Resources;
+import org.hawkular.inventory.api.Tenants;
+import org.hawkular.inventory.api.filters.Filter;
+import org.hawkular.inventory.api.filters.Related;
+import org.hawkular.inventory.api.filters.With;
+import org.hawkular.inventory.api.model.Entity;
+import org.hawkular.inventory.api.model.Environment;
+import org.hawkular.inventory.api.model.Feed;
+import org.hawkular.inventory.api.model.MetricType;
+import org.hawkular.inventory.api.model.Relationship;
+import org.hawkular.inventory.api.model.Resource;
+import org.hawkular.inventory.api.model.ResourceType;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * @author Jirka Kremser
+ * @since 1.0
+ */
+final class RelationshipBrowser<E extends Entity> extends AbstractBrowser<E> {
+
+    private RelationshipBrowser(Class<E> sourceClass, TransactionalGraph graph, FilterApplicator... path) {
+        super(graph, sourceClass, path);
+    }
+
+    public static Relationships.Single single(String id, HawkularPipeline<?, Vertex> source, Class<? extends Entity>
+            sourceClass, TransactionalGraph graph, FilterApplicator... path) {
+        if (null == id) {
+            throw new NullPointerException("unable to create Relationships.Single without the edge id.");
+        }
+        RelationshipBrowser b = new RelationshipBrowser(sourceClass, graph, path);
+
+        return new Relationships.Single() {
+
+            @Override
+            public Relationship entity() {
+                HawkularPipeline<?, Edge> edges = b.source().outE().has("id", id).cast(Edge.class);
+                if (!edges.hasNext()) {
+                    return null;
+                }
+                Edge edge = edges.next();
+                return new Relationship(edge.getId().toString(), edge.getLabel(), convert(edge.getVertex(Direction
+                        .OUT)), convert(edge.getVertex(Direction.IN)));
+            }
+
+            @Override
+            public Tenants.ReadRelate tenants() {
+                return b.tenants(EdgeFilter.ID, id);
+            }
+
+            @Override
+            public Environments.ReadRelate environments() {
+                return (Environments.ReadRelate)b.<EnvironmentsService>getService(EdgeFilter.ID, id, Environment
+                        .class, EnvironmentsService.class);
+            }
+
+            @Override
+            public Feeds.ReadRelate feeds() {
+                return (Feeds.ReadRelate)b.<FeedsService>getService(EdgeFilter.ID, id, Feed.class, FeedsService.class);
+            }
+
+            @Override
+            public MetricTypes.ReadRelate metricTypes() {
+                return (MetricTypes.ReadRelate)b.<MetricTypesService>getService(EdgeFilter.ID, id, MetricType.class,
+                        MetricTypesService.class);
+            }
+
+            @Override
+            public Metrics.ReadRelate metrics() {
+                return (Metrics.ReadRelate)b.<MetricsService>getService(EdgeFilter.ID, id, Metrics.class,
+                        MetricsService.class);
+            }
+
+            @Override
+            public Resources.ReadRelate resources() {
+                return (Resources.ReadRelate)b.<ResourcesService>getService(EdgeFilter.ID, id, Resource.class,
+                        ResourcesService.class);
+            }
+
+            @Override
+            public ResourceTypes.ReadRelate resourceTypes() {
+                return (ResourceTypes.ReadRelate)b.<TypesService>getService(EdgeFilter.ID, id, ResourceType.class,
+                        TypesService.class);
+            }
+        };
+    }
+
+    public static Relationships.Multiple multiple(String named, HawkularPipeline<?, Vertex> source, Class<? extends
+            Entity> sourceClass, TransactionalGraph graph, FilterApplicator... path) {
+
+        RelationshipBrowser b = new RelationshipBrowser(sourceClass, graph, path);
+
+        return new Relationships.Multiple() {
+            @Override
+            public Set<Relationship> entities() {
+                // TODO process filters
+
+                System.out.println("eeeee");
+                HawkularPipeline<?, Edge> edges = null == named ? b.source().bothE() : b.source().bothE(named);
+                Stream<Relationship> relationshipStream = StreamSupport
+                        .stream(edges.spliterator(), false)
+                        .map(edge -> new Relationship(edge.getId().toString(), edge.getLabel(),
+                                convert(edge.getVertex(Direction.OUT)), convert(edge.getVertex(Direction.IN))));
+                return relationshipStream.collect(Collectors.toSet());
+            }
+
+            @Override
+            public Tenants.Read tenants() {
+                // TODO implement
+                return null;
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public Environments.Read environments() {
+                return (Environments.Read)b.<EnvironmentsService>getService(EdgeFilter.NAMED, named, Environment.class,
+                        EnvironmentsService.class);
+            }
+
+            @Override
+            public Feeds.Read feeds() {
+                return (Feeds.Read)b.<FeedsService>getService(EdgeFilter.NAMED, named, Feed.class, FeedsService.class);
+            }
+
+            @Override
+            public MetricTypes.Read metricTypes() {
+                return (MetricTypes.Read)b.<MetricTypesService>getService(EdgeFilter.NAMED, named, MetricType.class,
+                        MetricTypesService.class);
+            }
+
+            @Override
+            public Metrics.Read metrics() {
+                return (Metrics.Read)b.<MetricsService>getService(EdgeFilter.NAMED, named, Metrics.class,
+                        MetricsService.class);
+            }
+
+            @Override
+            public Resources.Read resources() {
+                return (Resources.Read)b.<ResourcesService>getService(EdgeFilter.NAMED, named, Resource.class,
+                        ResourcesService.class);
+            }
+
+            @Override
+            public ResourceTypes.Read resourceTypes() {
+                return (ResourceTypes.Read)b.<TypesService>getService(EdgeFilter.NAMED, named, ResourceType.class,
+                        TypesService.class);
+            }
+        };
+    }
+
+
+    private <S extends AbstractSourcedGraphService> S getService(EdgeFilter filter, String value, Class<? extends
+            Entity> clazz1, Class<S> clazz2) {
+        Filter.Accumulator acc = Filter.by(EdgeFilter.NAMED == filter ? Related.by(value) : Related.byEdgeWithId
+                (value), With.type(clazz1));
+        try {
+            Constructor<S> constructor = clazz2.getConstructor(TransactionalGraph.class, PathContext.class);
+            return constructor.newInstance(graph, pathToHereWithSelect(acc));
+        } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException
+                e) {
+            throw new IllegalStateException("Unable to create new instance of " + clazz2.getCanonicalName(), e);
+        }
+    }
+
+    public TenantsService tenants(EdgeFilter filter, String value) {
+        //return new TenantsService(graph, pathToHereWithSelect(Filter.by(Related.by(id),
+        //        With.type(Tenant.class))));
+        // TODO implement
+        return null;
+    }
+
+    private enum EdgeFilter {
+        ID, NAMED;
+    }
+}

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/RelationshipService.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/RelationshipService.java
@@ -16,7 +16,6 @@
  */
 package org.hawkular.inventory.impl.tinkerpop;
 
-import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.blueprints.Vertex;
 import org.hawkular.inventory.api.EntityAlreadyExistsException;
 import org.hawkular.inventory.api.EntityNotFoundException;
@@ -33,8 +32,8 @@ import org.hawkular.inventory.api.model.Relationship;
 final class RelationshipService<E extends Entity> extends AbstractSourcedGraphService<Relationships.Single,
         Relationships.Multiple, E, Relationship.Blueprint> implements Relationships.ReadWrite, Relationships.Read {
 
-    RelationshipService(TransactionalGraph graph, PathContext ctx, Class<E> sourceClass) {
-        super(graph, sourceClass, ctx);
+    RelationshipService(InventoryContext iContext, PathContext ctx, Class<E> sourceClass) {
+        super(iContext, sourceClass, ctx);
     }
 
     @Override
@@ -53,7 +52,7 @@ final class RelationshipService<E extends Entity> extends AbstractSourcedGraphSe
     }
 
     private Relationships.Single createSingleBrowser(String id, FilterApplicator... path) {
-        return RelationshipBrowser.single(id, source(), entityClass, graph, path);
+        return RelationshipBrowser.single(id, context, entityClass, path);
     }
 
     @Override
@@ -63,7 +62,7 @@ final class RelationshipService<E extends Entity> extends AbstractSourcedGraphSe
 
     private Relationships.Multiple createMultiBrowser(String named, FilterApplicator... path) {
         // TODO foo
-        return RelationshipBrowser.multiple(named, source(), entityClass, graph, path);
+        return RelationshipBrowser.multiple(named, context, entityClass, path);
     }
 
     @Override

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/RelationshipService.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/RelationshipService.java
@@ -18,51 +18,85 @@ package org.hawkular.inventory.impl.tinkerpop;
 
 import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.blueprints.Vertex;
+import org.hawkular.inventory.api.EntityAlreadyExistsException;
+import org.hawkular.inventory.api.EntityNotFoundException;
 import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.filters.Filter;
+import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.model.Relationship;
 
 /**
  * @author Lukas Krejci
+ * @author Jiri Kremser
  * @since 1.0
  */
-final class RelationshipService implements Relationships.ReadWrite, Relationships.Read {
-    private final TransactionalGraph graph;
-    private final Vertex startVertex;
+final class RelationshipService<E extends Entity> extends AbstractSourcedGraphService<Relationships.Single,
+        Relationships.Multiple, E, Relationship.Blueprint> implements Relationships.ReadWrite, Relationships.Read {
 
-
-    RelationshipService(TransactionalGraph graph, Vertex startVertex) {
-        this.graph = graph;
-        this.startVertex = startVertex;
+    RelationshipService(TransactionalGraph graph, PathContext ctx, Class<E> sourceClass) {
+        super(graph, sourceClass, ctx);
     }
 
     @Override
     public Relationships.Single get(String id) {
-        //TODO implement
-        return null;
+        return createSingleBrowser(id, pathWith(selectCandidates()).get());
     }
 
     @Override
     public Relationships.Multiple getAll(Filter... filters) {
-        //TODO implement
-        return null;
+        return createMultiBrowser(null, pathWith(selectCandidates()).get());
     }
 
     @Override
-    public Relationships.Single create(Relationship.Blueprint blueprint) {
-        //TODO implement
-        return null;
+    protected Relationships.Single createSingleBrowser(FilterApplicator... path) {
+        return createSingleBrowser(null, path);
+    }
+
+    private Relationships.Single createSingleBrowser(String id, FilterApplicator... path) {
+        return RelationshipBrowser.single(id, source(), entityClass, graph, path);
     }
 
     @Override
-    public void update(Relationship entity) {
-        //TODO implement
+    protected Relationships.Multiple createMultiBrowser(FilterApplicator... path) {
+        return createMultiBrowser(null, path);
+    }
 
+    private Relationships.Multiple createMultiBrowser(String named, FilterApplicator... path) {
+        // TODO foo
+        return RelationshipBrowser.multiple(named, source(), entityClass, graph, path);
     }
 
     @Override
-    public void delete(String id) {
+    protected String getProposedId(Relationship.Blueprint b) {
         //TODO implement
+        throw new UnsupportedOperationException();
+    }
 
+    @Override
+    protected Filter[] initNewEntity(Vertex newEntity, Relationship.Blueprint s) {
+        return new Filter[0];
+    }
+
+    @Override
+    public Relationships.Multiple named(String name) {
+        return createMultiBrowser(name, path);
+    }
+
+    @Override
+    public Relationships.Single create(Relationship.Blueprint blueprint) throws EntityAlreadyExistsException {
+        //TODO implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void update(Relationship relationship) throws EntityNotFoundException {
+        //TODO implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void delete(String id) throws EntityNotFoundException {
+        //TODO implement
+        throw new UnsupportedOperationException();
     }
 }

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/ResourceTypesService.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/ResourceTypesService.java
@@ -31,11 +31,11 @@ import static org.hawkular.inventory.impl.tinkerpop.Constants.Type.tenant;
  * @author Lukas Krejci
  * @since 1.0
  */
-final class TypesService extends
+final class ResourceTypesService extends
         AbstractSourcedGraphService<ResourceTypes.Single, ResourceTypes.Multiple, ResourceType, ResourceType.Blueprint>
         implements ResourceTypes.ReadWrite, ResourceTypes.Read, ResourceTypes.ReadRelate {
 
-    TypesService(InventoryContext context, PathContext ctx) {
+    ResourceTypesService(InventoryContext context, PathContext ctx) {
         super(context, ResourceType.class, ctx);
     }
 

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/ResourcesService.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/ResourcesService.java
@@ -40,7 +40,7 @@ import static org.hawkular.inventory.impl.tinkerpop.Constants.Type.resourceType;
  */
 final class ResourcesService
         extends AbstractSourcedGraphService<Resources.Single, Resources.Multiple, Resource, Resource.Blueprint>
-        implements Resources.ReadWrite, Resources.Read {
+        implements Resources.ReadWrite, Resources.Read, Resources.ReadRelate {
 
     public ResourcesService(InventoryContext context, PathContext ctx) {
         super(context, Resource.class, ctx);
@@ -108,5 +108,15 @@ final class ResourcesService
 
         context.getGraph().removeVertex(v);
         context.getGraph().commit();
+    }
+
+    @Override
+    public void add(String id) {
+        // TODO implelent
+    }
+
+    @Override
+    public void remove(String id) {
+        // TODO implelent
     }
 }

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TenantBrowser.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TenantBrowser.java
@@ -108,8 +108,8 @@ final class TenantBrowser extends AbstractBrowser<Tenant> {
                 pathToHereWithSelect(Filter.by(Related.by(contains), With.type(Environment.class))));
     }
 
-    public TypesService types() {
-        return new TypesService(context, pathToHereWithSelect(Filter.by(Related.by(contains),
+    public ResourceTypesService types() {
+        return new ResourceTypesService(context, pathToHereWithSelect(Filter.by(Related.by(contains),
                 With.type(ResourceType.class))));
     }
 

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TenantsService.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TenantsService.java
@@ -27,7 +27,7 @@ import org.hawkular.inventory.api.model.Tenant;
 * @since 1.0
 */
 final class TenantsService extends AbstractSourcedGraphService<Tenants.Single, Tenants.Multiple, Tenant, String>
-        implements Tenants.ReadWrite, Tenants.Read {
+        implements Tenants.ReadWrite, Tenants.Read, Tenants.ReadRelate {
 
     public TenantsService(InventoryContext context) {
         super(context, Tenant.class, new PathContext(FilterApplicator.fromPath().get(),
@@ -62,6 +62,18 @@ final class TenantsService extends AbstractSourcedGraphService<Tenants.Single, T
 
     @Override
     public void update(Tenant entity) {
+        //TODO implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void add(String id) {
+        //TODO implement
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void remove(String id) {
         //TODO implement
         throw new UnsupportedOperationException();
     }

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TypesService.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TypesService.java
@@ -33,7 +33,7 @@ import static org.hawkular.inventory.impl.tinkerpop.Constants.Type.tenant;
  */
 final class TypesService extends
         AbstractSourcedGraphService<ResourceTypes.Single, ResourceTypes.Multiple, ResourceType, ResourceType.Blueprint>
-        implements ResourceTypes.ReadWrite, ResourceTypes.Read {
+        implements ResourceTypes.ReadWrite, ResourceTypes.Read, ResourceTypes.ReadRelate {
 
     TypesService(InventoryContext context, PathContext ctx) {
         super(context, ResourceType.class, ctx);
@@ -78,5 +78,15 @@ final class TypesService extends
     public void delete(String id) {
         //TODO implement
 
+    }
+
+    @Override
+    public void add(String id) {
+        //TODO implement
+    }
+
+    @Override
+    public void remove(String id) {
+        //TODO implement
     }
 }

--- a/impl-tinkerpop/src/test/java/org/hawkular/inventory/impl/tinkerpop/test/BasicTest.java
+++ b/impl-tinkerpop/src/test/java/org/hawkular/inventory/impl/tinkerpop/test/BasicTest.java
@@ -260,7 +260,6 @@ public class BasicTest {
                 .accept(kids);
     }
 
-
     @Test
     public void testRelationshipServiceGet() throws Exception {
         // the edge IDs are set deterministically for dummy graph, but this may differ with graph implementation


### PR DESCRIPTION
First chunk. To be continued...
- [x] `get().entity()`
- [x] `named().entities()`
- [ ] `getAll(Filter...)`
- [x] possible consequent calls like `tenants()`, `environments()`, etc. respecting all the previous filters and introducing a new one on the based on the target type of the relationship
- [x] consider introducing a `RelationshipBrowser` (it would need some refactoring, because `Relationship` doesn't extend `Entity`).
- [ ] all the unit tests
