### PR TITLE
Fix filters to newly created entities to contain relations.

### DIFF
--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/EnvironmentsService.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/EnvironmentsService.java
@@ -19,12 +19,13 @@ package org.hawkular.inventory.impl.tinkerpop;
 import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.blueprints.Vertex;
 import org.hawkular.inventory.api.Environments;
-import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.filters.Filter;
+import org.hawkular.inventory.api.filters.Related;
 import org.hawkular.inventory.api.filters.With;
 import org.hawkular.inventory.api.model.Environment;
 import org.hawkular.inventory.api.model.Tenant;
 
+import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Type.tenant;
 
 /**
@@ -50,10 +51,11 @@ final class EnvironmentsService extends
         String tenantId = null;
         for (Vertex sourceTenant : source().hasType(tenant)) {
             tenantId = getUid(sourceTenant);
-            sourceTenant.addEdge(Relationships.WellKnown.contains.name(), newEntity);
+            sourceTenant.addEdge(contains.name(), newEntity);
         }
 
-        return Filter.by(With.type(Tenant.class), With.id(tenantId)).get();
+        return Filter.by(With.type(Tenant.class), With.id(tenantId), Related.by(contains),
+                With.type(Environment.class), With.id(getUid(newEntity))).get();
     }
 
     @Override

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FeedsService.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FeedsService.java
@@ -19,13 +19,14 @@ package org.hawkular.inventory.impl.tinkerpop;
 import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.blueprints.Vertex;
 import org.hawkular.inventory.api.Feeds;
-import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.filters.Filter;
+import org.hawkular.inventory.api.filters.Related;
 import org.hawkular.inventory.api.filters.With;
 import org.hawkular.inventory.api.model.Environment;
 import org.hawkular.inventory.api.model.Feed;
 import org.hawkular.inventory.api.model.Tenant;
 
+import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Type.environment;
 
 /**
@@ -43,13 +44,14 @@ final class FeedsService extends AbstractSourcedGraphService<Feeds.Single, Feeds
     protected Filter[] initNewEntity(Vertex newEntity, String blueprint) {
         Vertex env = null;
         for(Vertex sourceEnv : source().hasType(environment)) {
-            sourceEnv.addEdge(Relationships.WellKnown.contains.name(), newEntity);
+            sourceEnv.addEdge(contains.name(), newEntity);
             env = sourceEnv;
         }
 
         Vertex tenant = getTenantVertexOf(env);
-        return Filter.by(With.type(Tenant.class), With.id(getUid(tenant)), With.type(Environment.class),
-                With.id(getUid(env)), With.type(Feed.class), With.id(blueprint)).get();
+        return Filter.by(With.type(Tenant.class), With.id(getUid(tenant)), Related.by(contains),
+                With.type(Environment.class), With.id(getUid(env)), Related.by(contains),
+                With.type(Feed.class), With.id(getUid(newEntity))).get();
     }
 
     @Override

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricTypesService.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricTypesService.java
@@ -20,6 +20,7 @@ import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.blueprints.Vertex;
 import org.hawkular.inventory.api.MetricTypes;
 import org.hawkular.inventory.api.filters.Filter;
+import org.hawkular.inventory.api.filters.Related;
 import org.hawkular.inventory.api.filters.With;
 import org.hawkular.inventory.api.model.MetricType;
 import org.hawkular.inventory.api.model.Tenant;
@@ -54,8 +55,8 @@ final class MetricTypesService
 
         newEntity.setProperty(Constants.Property.unit.name(), blueprint.getUnit().getDisplayName());
 
-        return Filter.by(With.type(Tenant.class), With.id(getUid(tnt)), With.type(MetricType.class),
-                With.id(blueprint.getId())).get();
+        return Filter.by(With.type(Tenant.class), With.id(getUid(tnt)), Related.by(contains),
+                With.type(MetricType.class), With.id(getUid(newEntity))).get();
     }
 
     @Override

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricsService.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricsService.java
@@ -21,6 +21,7 @@ import com.tinkerpop.blueprints.Vertex;
 import org.hawkular.inventory.api.Metrics;
 import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.filters.Filter;
+import org.hawkular.inventory.api.filters.Related;
 import org.hawkular.inventory.api.filters.With;
 import org.hawkular.inventory.api.model.Environment;
 import org.hawkular.inventory.api.model.Metric;
@@ -72,8 +73,9 @@ final class MetricsService
 
         Vertex tenant = getTenantVertexOf(exampleEnv);
 
-        return Filter.by(With.type(Tenant.class), With.id(getUid(tenant)), With.type(Environment.class),
-                With.id(getUid(exampleEnv)), With.type(Metric.class), With.id(blueprint.getId())).get();
+        return Filter.by(With.type(Tenant.class), With.id(getUid(tenant)), Related.by(contains),
+                With.type(Environment.class), With.id(getUid(exampleEnv)), Related.by(contains),
+                With.type(Metric.class), With.id(getUid(newEntity))).get();
     }
 
     @Override

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/ResourcesService.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/ResourcesService.java
@@ -20,6 +20,7 @@ import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.blueprints.Vertex;
 import org.hawkular.inventory.api.Resources;
 import org.hawkular.inventory.api.filters.Filter;
+import org.hawkular.inventory.api.filters.Related;
 import org.hawkular.inventory.api.filters.With;
 import org.hawkular.inventory.api.model.Environment;
 import org.hawkular.inventory.api.model.Resource;
@@ -67,8 +68,9 @@ final class ResourcesService
 
         Vertex tenant = getTenantVertexOf(exampleEnv);
 
-        return Filter.by(With.type(Tenant.class), With.id(getUid(tenant)), With.type(Environment.class),
-                With.id(getUid(exampleEnv)), With.type(Resource.class), With.id(blueprint.getId())).get();
+        return Filter.by(With.type(Tenant.class), With.id(getUid(tenant)), Related.by(contains),
+                With.type(Environment.class), With.id(getUid(exampleEnv)), Related.by(contains),
+                With.type(Resource.class), With.id(getUid(newEntity))).get();
     }
 
     @Override

--- a/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TypesService.java
+++ b/impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TypesService.java
@@ -20,6 +20,7 @@ import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.blueprints.Vertex;
 import org.hawkular.inventory.api.ResourceTypes;
 import org.hawkular.inventory.api.filters.Filter;
+import org.hawkular.inventory.api.filters.Related;
 import org.hawkular.inventory.api.filters.With;
 import org.hawkular.inventory.api.model.ResourceType;
 import org.hawkular.inventory.api.model.Tenant;
@@ -49,8 +50,8 @@ final class TypesService extends
 
         newEntity.setProperty(Constants.Property.version.name(), blueprint.getVersion().toString());
 
-        return Filter.by(With.type(Tenant.class), With.id(getUid(exampleTnt)), With.type(ResourceType.class),
-                With.id(blueprint.getId())).get();
+        return Filter.by(With.type(Tenant.class), With.id(getUid(exampleTnt)), Related.by(contains),
+                With.type(ResourceType.class), With.id(getUid(newEntity))).get();
     }
 
     @Override

--- a/impl-tinkerpop/src/test/java/org/hawkular/inventory/impl/tinkerpop/test/BasicTest.java
+++ b/impl-tinkerpop/src/test/java/org/hawkular/inventory/impl/tinkerpop/test/BasicTest.java
@@ -76,44 +76,52 @@ public class BasicTest {
     }
 
     private void setupData() throws Exception {
-        inventory.tenants().create("com.acme.tenant");
-        inventory.tenants().get("com.acme.tenant").environments().create("production");
-        inventory.tenants().get("com.acme.tenant").resourceTypes()
-                .create(new ResourceType.Blueprint("URL", new Version("1.0")));
-        inventory.tenants().get("com.acme.tenant").metricTypes()
-                .create(new MetricType.Blueprint("ResponseTime", MetricUnit.MILLI_SECOND));
+        assert inventory.tenants().create("com.acme.tenant").entity().getId().equals("com.acme.tenant");
+        assert inventory.tenants().get("com.acme.tenant").environments().create("production").entity().getId()
+                .equals("production");
+        assert inventory.tenants().get("com.acme.tenant").resourceTypes()
+                .create(new ResourceType.Blueprint("URL", new Version("1.0"))).entity().getId().equals("URL");
+        assert inventory.tenants().get("com.acme.tenant").metricTypes()
+                .create(new MetricType.Blueprint("ResponseTime", MetricUnit.MILLI_SECOND)).entity().getId()
+                .equals("ResponseTime");
+
         inventory.tenants().get("com.acme.tenant").resourceTypes().get("URL").metricTypes().add("ResponseTime");
-        inventory.tenants().get("com.acme.tenant").environments().get("production").metrics()
+
+        assert inventory.tenants().get("com.acme.tenant").environments().get("production").metrics()
                 .create(new Metric.Blueprint(
                         new MetricType("com.acme.tenant", "ResponseTime", MetricUnit.MILLI_SECOND),
-                        "host1_ping_response"));
-        inventory.tenants().get("com.acme.tenant").environments().get("production").resources()
-                .create(new Resource.Blueprint("host1", new ResourceType("com.acme.tenant", "URL", "1.0")));
+                        "host1_ping_response")).entity().getId().equals("host1_ping_response");
+        assert inventory.tenants().get("com.acme.tenant").environments().get("production").resources()
+                .create(new Resource.Blueprint("host1", new ResourceType("com.acme.tenant", "URL", "1.0"))).entity()
+                .getId().equals("host1");
         inventory.tenants().get("com.acme.tenant").environments().get("production").resources()
                 .get("host1").metrics().add("host1_ping_response");
 
-        inventory.tenants().create("com.example.tenant");
-        inventory.tenants().get("com.example.tenant").environments().create("test");
-        inventory.tenants().get("com.example.tenant").resourceTypes()
-                .create(new ResourceType.Blueprint("Kachna", new Version("1.0")));
-        inventory.tenants().get("com.example.tenant").resourceTypes()
-                .create(new ResourceType.Blueprint("Playroom", new Version("1.0")));
-        inventory.tenants().get("com.example.tenant").metricTypes()
-                .create(new MetricType.Blueprint("Size", MetricUnit.BYTE));
+        assert inventory.tenants().create("com.example.tenant").entity().getId().equals("com.example.tenant");
+        assert inventory.tenants().get("com.example.tenant").environments().create("test").entity().getId()
+                .equals("test");
+        assert inventory.tenants().get("com.example.tenant").resourceTypes()
+                .create(new ResourceType.Blueprint("Kachna", new Version("1.0"))).entity().getId().equals("Kachna");
+        assert inventory.tenants().get("com.example.tenant").resourceTypes()
+                .create(new ResourceType.Blueprint("Playroom", new Version("1.0"))).entity().getId().equals("Playroom");
+        assert inventory.tenants().get("com.example.tenant").metricTypes()
+                .create(new MetricType.Blueprint("Size", MetricUnit.BYTE)).entity().getId().equals("Size");
         inventory.tenants().get("com.example.tenant").resourceTypes().get("Playroom").metricTypes().add("Size");
 
-        inventory.tenants().get("com.example.tenant").environments().get("test").metrics()
+        assert inventory.tenants().get("com.example.tenant").environments().get("test").metrics()
                 .create(new Metric.Blueprint(
                         new MetricType("com.example.tenant", "Size", MetricUnit.BYTE),
-                        "playroom1_size"));
-        inventory.tenants().get("com.example.tenant").environments().get("test").metrics()
+                        "playroom1_size")).entity().getId().equals("playroom1_size");
+        assert inventory.tenants().get("com.example.tenant").environments().get("test").metrics()
                 .create(new Metric.Blueprint(
                         new MetricType("com.example.tenant", "Size", MetricUnit.BYTE),
-                        "playroom2_size"));
-        inventory.tenants().get("com.example.tenant").environments().get("test").resources()
-                .create(new Resource.Blueprint("playroom1", new ResourceType("com.example.tenant", "Playroom", "1.0")));
-        inventory.tenants().get("com.example.tenant").environments().get("test").resources()
-                .create(new Resource.Blueprint("playroom2", new ResourceType("com.example.tenant", "Playroom", "1.0")));
+                        "playroom2_size")).entity().getId().equals("playroom2_size");
+        assert inventory.tenants().get("com.example.tenant").environments().get("test").resources()
+                .create(new Resource.Blueprint("playroom1", new ResourceType("com.example.tenant", "Playroom", "1.0")))
+                .entity().getId().equals("playroom1");
+        assert inventory.tenants().get("com.example.tenant").environments().get("test").resources()
+                .create(new Resource.Blueprint("playroom2", new ResourceType("com.example.tenant", "Playroom", "1.0")))
+                .entity().getId().equals("playroom2");
 
         inventory.tenants().get("com.example.tenant").environments().get("test").resources()
                 .get("playroom1").metrics().add("playroom1_size");


### PR DESCRIPTION
Without the fix, the entities cannot be resolved from the access interface returned from the `create` methods.
