### PR TITLE
Versioning

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <artifactId>hawkular-parent</artifactId>
     <groupId>org.hawkular</groupId>
-    <version>5</version>
+    <version>9</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.hawkular.inventory</groupId>
   <artifactId>inventory-api</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <name>inventory-api</name>
 
   <build>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,17 +20,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <parent>
-    <artifactId>hawkular-parent</artifactId>
-    <groupId>org.hawkular</groupId>
-    <version>9</version>
-  </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.hawkular.inventory</groupId>
+  <parent>
+    <groupId>org.hawkular.inventory</groupId>
+    <artifactId>inventory-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
   <artifactId>inventory-api</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
-  <name>inventory-api</name>
 
   <build>
     <finalName>hawkular-inventory-api</finalName>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.hawkular.inventory</groupId>
     <artifactId>inventory-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>inventory-api</artifactId>

--- a/impl-tinkerpop/pom.xml
+++ b/impl-tinkerpop/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.hawkular.inventory</groupId>
     <artifactId>inventory-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>inventory-impl-blueprints</artifactId>

--- a/impl-tinkerpop/pom.xml
+++ b/impl-tinkerpop/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>org.hawkular.inventory</groupId>
   <artifactId>inventory-impl-blueprints</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>hawkular-inventory-impl-blueprints</name>
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.hawkular</groupId>
     <artifactId>hawkular-parent</artifactId>
-    <version>5</version>
+    <version>9</version>
   </parent>
 
   <dependencies>

--- a/impl-tinkerpop/pom.xml
+++ b/impl-tinkerpop/pom.xml
@@ -22,24 +22,20 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.hawkular.inventory</groupId>
-  <artifactId>inventory-impl-blueprints</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
-  <packaging>jar</packaging>
-
-  <name>hawkular-inventory-impl-blueprints</name>
-
   <parent>
-    <groupId>org.hawkular</groupId>
-    <artifactId>hawkular-parent</artifactId>
-    <version>9</version>
+    <groupId>org.hawkular.inventory</groupId>
+    <artifactId>inventory-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
+
+  <artifactId>inventory-impl-blueprints</artifactId>
+  <packaging>jar</packaging>
 
   <dependencies>
     <dependency>
       <groupId>org.hawkular.inventory</groupId>
       <artifactId>inventory-api</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>org.hawkular.inventory</groupId>
   <artifactId>inventory-parent</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <inceptionYear>2015</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>org.hawkular.inventory</groupId>
   <artifactId>inventory-parent</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <inceptionYear>2015</inceptionYear>
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.hawkular</groupId>
     <artifactId>hawkular-parent</artifactId>
-    <version>6</version>
+    <version>9</version>
   </parent>
 
   <modules>

--- a/rest-servlet/pom.xml
+++ b/rest-servlet/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>org.hawkular.inventory</groupId>
   <artifactId>inventory-rest-api</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>war</packaging>
 
   <name>inventory-rest-api</name>
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.hawkular</groupId>
     <artifactId>hawkular-parent</artifactId>
-    <version>5</version>
+    <version>9</version>
   </parent>
 
   <dependencyManagement>

--- a/rest-servlet/pom.xml
+++ b/rest-servlet/pom.xml
@@ -22,18 +22,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.hawkular.inventory</groupId>
-  <artifactId>inventory-rest-api</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
-  <packaging>war</packaging>
-
-  <name>inventory-rest-api</name>
-
   <parent>
-    <groupId>org.hawkular</groupId>
-    <artifactId>hawkular-parent</artifactId>
-    <version>9</version>
+    <groupId>org.hawkular.inventory</groupId>
+    <artifactId>inventory-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
+
+  <artifactId>inventory-rest-api</artifactId>
+  <packaging>war</packaging>
 
   <dependencyManagement>
     <dependencies>
@@ -66,13 +62,13 @@
     <dependency>
       <groupId>org.hawkular.inventory</groupId>
       <artifactId>inventory-api</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.hawkular.inventory</groupId>
       <artifactId>inventory-impl-blueprints</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
 
 

--- a/rest-servlet/pom.xml
+++ b/rest-servlet/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.hawkular.inventory</groupId>
     <artifactId>inventory-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>inventory-rest-api</artifactId>

--- a/rest-test/pom.xml
+++ b/rest-test/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.hawkular.inventory</groupId>
     <artifactId>inventory-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>inventory-rest-test</artifactId>

--- a/rest-test/pom.xml
+++ b/rest-test/pom.xml
@@ -20,24 +20,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <parent>
-    <groupId>org.hawkular</groupId>
-    <artifactId>hawkular-parent</artifactId>
-    <version>9</version>
-  </parent>
-
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.hawkular.inventory</groupId>
+    <artifactId>inventory-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
 
-  <groupId>org.hawkular.inventory</groupId>
   <artifactId>inventory-rest-test</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
 
   <dependencies>
     <dependency>
       <groupId>org.hawkular.inventory</groupId>
       <artifactId>inventory-api</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>

--- a/rest-test/pom.xml
+++ b/rest-test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular</groupId>
     <artifactId>hawkular-parent</artifactId>
-    <version>5</version>
+    <version>9</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -31,7 +31,7 @@
 
   <groupId>org.hawkular.inventory</groupId>
   <artifactId>inventory-rest-test</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
This PR is doing to `future` basically the same as Mazz' commit e850d1d0fea787 to `master`.

..also increasing hawkular-parent version to 9 and using `${project.version}` for internal dependencies (instead of repeating the `1.0.0-SNAPSHOT`). 

If we would like to diverge some inventory sub-module's version from the "global" inventory version, we can do that by overriding its `<version>` element (inherited from the `inventory-parent`) and changing the `${project.version}` in a module's pom that uses this module to a different version.

**NOTE**: also migrating to `0.x.y` semantic version schema (every change under `0.x.y` could be potentially breaking)
