### PR TITLE
Adding auto-deploy of Swagger REST documentation

### DIFF
--- a/.travis.swagger.sh
+++ b/.travis.swagger.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Copyright 2015 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# generate the docs
+mvn clean compile -Pdocgen -DskipTests -Dcheckstyle.skip
+
+FILE_NAME="rest-inventory.adoc"
+FILE_PATH="rest-servlet/target/generated/$FILE_NAME"
+REPO="hawkular/hawkular.github.io"
+BRANCH="swagger"
+SHA=`curl -Ls https://api.github.com/repos/$REPO/contents/$FILE_NAME?ref=$BRANCH | grep '"sha"' | cut -d '"' -f4`
+CONTENT=`openssl enc -base64 -in $FILE_PATH | sed ':a;N;$!ba;s/\n//g'`
+
+# update the adoc file using GitHub api
+curl -Lis -X PUT -H "Authorization: token $DEPLOY_TOKEN" -d "{\"path\": \"$FILE_NAME\", \"message\": \"Travis CI (inventory): updating swagger documentation\", \"commiter\": {\"name\": \"Travis CI\", \"email\": \"foo@bar.com\"}, \"sha\": \"$SHA\", \"content\": \"$CONTENT\", \"branch\": \"$BRANCH\"}" https://api.github.com/repos/$REPO/contents/$FILE_NAME
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,7 @@ env:
   global:
   - secure: g/PGmXBWEd9PgmP9xfuUj60yGdvGR9x9cRzE3EDkX0ALkAdZZxHpI3qWdNpUl9mNrtjrxM/4/yi7oKDOpkwl+iCw2KAvlfjnn8sWTEwDIfK9+zyFAU0C6QEJnkToLFvkumO4NbbBBGxQ2KR4rxaIDRI6umf3F8roZybTD+SLXfg=
   - secure: FlQ6i3L1vf5Gf73FMmEY8a0ZJpuQVzTwLjYlABbi5iJd+VQdlke3+5nEhEFYHKiiK6duye6GIxtti65s/VHS6VHJb62p/Z1Fj6/FsKgoFbVmzYenGDXEfGQYHnvCUm4OY/kcHIgeI5RpG2n0BXHRK9PSYfGD4G50i7ev7d0BnKw=
+  # for pushing the swagger adoc documentation to the website repository
+  - secure: fRgTtGRZRh1DhRIXlOnuWV6cROHhVvtNL3DzVay1zDnX0y0SVH3Aau/kbsytIkG4DaKvRi1XnI4sRC4HtUReXCMQjvwO9sdmj+9F3y04vbhH8qNR8IUBFADKjLCjjnq7Qo8PBbuk6b8Sj1bFpYSgd2sJXcvvA9cP/xlTMu6XZSM=
 after_success:
-- test "${TRAVIS_BRANCH}" = "master" && test "${TRAVIS_PULL_REQUEST}" = "false" && mvn  -s .travis.maven.settings.xml deploy -DskipTests
+- test "${TRAVIS_BRANCH}" = "master" && test "${TRAVIS_PULL_REQUEST}" = "false" && mvn  -s .travis.maven.settings.xml deploy -DskipTests && ./.travis.swagger.sh

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.hawkular</groupId>
     <artifactId>hawkular-parent</artifactId>
-    <version>9</version>
+    <version>10</version>
   </parent>
 
   <modules>

--- a/rest-servlet/pom.xml
+++ b/rest-servlet/pom.xml
@@ -32,7 +32,6 @@
   <packaging>war</packaging>
 
   <properties>
-    <version.com.wordnik>1.3.12</version.com.wordnik>
   </properties>
 
   <dependencyManagement>
@@ -113,14 +112,12 @@
     <dependency>
       <groupId>com.wordnik</groupId>
       <artifactId>swagger-annotations</artifactId>
-      <version>${version.com.wordnik}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>com.wordnik</groupId>
       <artifactId>swagger-core_2.10</artifactId>
-      <version>${version.com.wordnik}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -152,7 +149,42 @@
       </plugin>
 
     </plugins>
-
   </build>
 
+  <profiles>
+    <profile>
+      <id>docgen</id>
+      <build>
+        <!-- Document generation from the Swagger annotations on the REST-API. -->
+        <plugins>
+          <plugin>
+            <groupId>com.github.kongchen</groupId>
+            <artifactId>swagger-maven-plugin</artifactId>
+            <configuration>
+              <apiSources>
+                <apiSource>
+                  <locations>org.hawkular.inventory.rest</locations>
+                  <apiVersion>0.1</apiVersion>
+                  <basePath>http://localhost:8080/hawkular/inventory</basePath>
+                  <outputTemplate>${basedir}/src/main/resources/rest-doc/asciidoc.mustache</outputTemplate>
+                  <swaggerDirectory>${project.build.directory}/generated/swagger-ui</swaggerDirectory>
+                  <swaggerInternalFilter>org.hawkular.inventory.rest.swagger.JaxRsFilter</swaggerInternalFilter>
+                  <swaggerApiReader>com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader</swaggerApiReader>
+                  <outputPath>${project.build.directory}/generated/rest-inventory.adoc</outputPath>
+                </apiSource>
+              </apiSources>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>compile</phase>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/swagger/JaxRsFilter.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/swagger/JaxRsFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.rest.swagger;
+
+import java.util.List;
+import java.util.Map;
+
+import com.wordnik.swagger.core.filter.SwaggerSpecFilter;
+import com.wordnik.swagger.model.ApiDescription;
+import com.wordnik.swagger.model.Operation;
+import com.wordnik.swagger.model.Parameter;
+
+/**
+ * Filter out AsyncResponse from swagger-json
+ *
+ * @author Michael Burman
+ */
+public class JaxRsFilter implements SwaggerSpecFilter {
+    @Override
+    public boolean isOperationAllowed(Operation operation, ApiDescription apiDescription, Map<String, List<String>>
+            map, Map<String, String> map1, Map<String, List<String>> map2) {
+        return true;
+    }
+
+    @Override
+    public boolean isParamAllowed(Parameter parameter, Operation operation, ApiDescription apiDescription,
+                                  Map<String, List<String>> map, Map<String, String> map1, Map<String, List<String>>
+            map2) {
+        if(parameter.dataType().equals("AsyncResponse")) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/rest-servlet/src/main/resources/rest-doc/asciidoc.mustache
+++ b/rest-servlet/src/main/resources/rest-doc/asciidoc.mustache
@@ -1,0 +1,83 @@
+{{!
+    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+}}
+== APIs
+{{#apiDocuments}}
+=== {{{description}}}
+
+{{#apis}}
+==== {{apiIndex}} `{{path}}`
+{{#operations}}
+
+{{summary}}
+
+{{{notes}}}
+
+----
+*{{httpMethod}}* `{{path}}`
+----
+
+{{#parameters}}
+===== {{paramType}} parameters
+
+[options="header"]
+|=======================
+|Parameter|Required|Description|Data Type
+{{#paras}}
+    |{{name}}|{{required}}|{{description}}|{{#linkType}}<<{{linkType}},{{type}}>>{{/linkType}}{{^linkType}}{{type}}{{/linkType}}
+{{/paras}}
+|=======================
+{{/parameters}}
+
+{{#responseClass}}
+===== Response
+[{{className}}](#{{classLinkName}}){{^genericClasses}}{{/genericClasses}}{{#genericClasses}}< [{{className}}](#<<{{classLinkName}}>>) >{{/genericClasses}}
+{{/responseClass}}
+
+===== Status codes
+[options="header"]
+|=======================
+| Status Code | Reason      | Response Model
+{{#errorResponses}}
+| {{code}}    | {{message}} | {{#linkType}}[{{type}}](#<<{{linkType}}>>){{/linkType}}{{^linkType}}{{#type}}{{{type}}}{{/type}}{{^type}}-{{/type}}{{/linkType}}
+{{/errorResponses}}
+|=======================
+
+{{/operations}}
+{{/apis}}
+{{/apiDocuments}}
+
+== Data Types
+{{#dataTypes}}
+
+[[{{name}}]]
+=== {{name}}
+[options="header"]
+|=======================
+| name | type | required | access | description | notes
+{{#items}}
+|{{name}}|{{#linkType}}{{linkType}}{{type}} {{/linkType}}{{^linkType}}{{type}}{{/linkType}}|{{#required}}required{{/required}}{{^required}}optional{{/required}}|{{#access}}{{{access}}}{{/access}}{{^access}}-{{/access}}|{{#description}}{{{description}}}{{/description}}{{^description}}-{{/description}}{{#allowableValue}} Allowable values:{{.}}{{/allowableValue}}|{{#notes}}{{{notes}}}{{/notes}}{{^notes}}-{{/notes}}
+{{/items}}
+|=======================
+
+{{/dataTypes}}
+
+{{#enumTypes}}
+    ## {{name}}
+    {{#allowableValues}}
+        {{.}}
+    {{/allowableValues}}
+{{/enumTypes}}


### PR DESCRIPTION
It's done by deploying it after each successful build to the website repo (`hawkular.github.io`), from where it is auto-deployed each time the website repo is being built.
