### PR TITLE
[HWKINVENT-21] Observable Inventory

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,6 +30,25 @@
 
   <artifactId>inventory-api</artifactId>
 
+  <dependencies>
+    <dependency>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava</artifactId>
+      <version>1.0.8</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+  </dependencies>
+
   <build>
     <finalName>hawkular-inventory-api</finalName>
   </build>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -29,6 +29,7 @@
   </parent>
 
   <artifactId>inventory-api</artifactId>
+  <name>Hawkular Inventory API</name>
 
   <dependencies>
     <dependency>
@@ -41,11 +42,13 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.10.19</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/api/src/main/java/org/hawkular/inventory/api/AssociationInterface.java
+++ b/api/src/main/java/org/hawkular/inventory/api/AssociationInterface.java
@@ -60,8 +60,10 @@ interface AssociationInterface {
      * @see #associate(String) for explanation of how the current entity and the relation is determined.
      *
      * @param id the id of the entity to remove from the relation with the current entity.
+     *
+     * @return the relationship that was deleted as a result of the disassociation
      */
-    void disassociate(String id) throws EntityNotFoundException;
+    Relationship disassociate(String id) throws EntityNotFoundException;
 
     /**
      * Finds the relationship with the entity with the provided id.

--- a/api/src/main/java/org/hawkular/inventory/api/AssociationInterface.java
+++ b/api/src/main/java/org/hawkular/inventory/api/AssociationInterface.java
@@ -17,18 +17,20 @@
 
 package org.hawkular.inventory.api;
 
+import org.hawkular.inventory.api.model.Relationship;
+
 /**
  * An interface providing methods to add a pre-existing entity into relation with the single entity in the current
  * position on the inventory traversal.
  *
  * <p>Note that this interface should never be inherited by the actual {@code Single} interface together with the
- * {@link WriteInterface}. Having both {@code create} and {@code add} or {@code remove} and {@code delete} methods
- * would be semantically incorrect (in addition to being confusing to the API consumer).
+ * {@link WriteInterface}. Having both {@code create} and {@code associate} or {@code disassociate} and {@code delete}
+ * methods would be semantically incorrect (in addition to being confusing to the API consumer).
  *
  * @author Lukas Krejci
  * @since 1.0
  */
-interface RelateInterface {
+interface AssociationInterface {
 
     /**
      * Adds a pre-existing entity into the relation with the current entity.
@@ -37,16 +39,17 @@ interface RelateInterface {
      * being related to it. Consider this example:
      *
      * <pre><code>
-     * inventory.tenants().get(tenantId).environments().get(envId).resources().get(rId).metrics().add(metricId);
+     * inventory.tenants().get(tenantId).environments().get(envId).resources().get(rId).metrics().associate(metricId);
      * </code></pre>
      *
-     * <p>In here the {@code add} method will add a new metric (identified by the {@code metricId}) to the resource
-     * identified by the {@code rId}.
+     * <p>In here the {@code associate} method will add a new metric (identified by the {@code metricId}) to the
+     * resource identified by the {@code rId}.
      *
      * @param id the id of a pre-existing entity to be related to the entity on the current position in the inventory
-     *           traversal.s
+     *           traversal.
+     * @return the relationship that was created as the consequence of the association.
      */
-    void add(String id);
+    Relationship associate(String id) throws EntityNotFoundException, RelationAlreadyExistsException;
 
     /**
      * Removes an entity from the relation with the current entity.
@@ -54,9 +57,22 @@ interface RelateInterface {
      * The current entity and the type of the entity to remove from the relation is determined by the current position
      * in the inventory traversal.
      *
-     * @see #add(String) for explanation of how the current entity and the relation is determined.
+     * @see #associate(String) for explanation of how the current entity and the relation is determined.
      *
      * @param id the id of the entity to remove from the relation with the current entity.
      */
-    void remove(String id);
+    void disassociate(String id) throws EntityNotFoundException;
+
+    /**
+     * Finds the relationship with the entity with the provided id.
+     *
+     * @see #associate(String) for the discussion of how the entity and the relationship is determined
+     *
+     * @param id the id of the entity to find the relation with
+     *
+     * @return the relationship found
+     *
+     * @throws RelationNotFoundException
+     */
+    Relationship associationWith(String id) throws RelationNotFoundException;
 }

--- a/api/src/main/java/org/hawkular/inventory/api/Environments.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Environments.java
@@ -74,6 +74,4 @@ public final class Environments {
     public interface ReadWrite extends ReadWriteInterface<Environment, String, Single, Multiple> {
         void copy(String sourceEnvironmentId, String targetEnvironmentId);
     }
-
-    public interface ReadRelate extends ReadInterface<Single, Multiple>, RelateInterface {}
 }

--- a/api/src/main/java/org/hawkular/inventory/api/Environments.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Environments.java
@@ -50,7 +50,7 @@ public final class Environments {
     /**
      * Interface for accessing a single environment in a writable manner.
      */
-    public interface Single extends SingleRelatableEntityBrowser<Environment>,
+    public interface Single extends ResolvableToSingleWithRelationships<Environment>,
             BrowserBase<Feeds.ReadAndRegister, Resources.ReadWrite, Metrics.ReadWrite> {}
 
     /**
@@ -60,7 +60,7 @@ public final class Environments {
      * modification methods, you first need to resolve the traversal to a single entity (using the
      * {@link ReadInterface#get(String)} method).
      */
-    public interface Multiple extends MultipleRelatableEntityBrowser<Environment>,
+    public interface Multiple extends ResolvableToManyWithRelationships<Environment>,
             BrowserBase<Feeds.Read, Resources.Read, Metrics.Read> {}
 
     /**

--- a/api/src/main/java/org/hawkular/inventory/api/Feeds.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Feeds.java
@@ -32,9 +32,9 @@ public final class Feeds {
         Resources.Read resources();
     }
 
-    public interface Single extends SingleRelatableEntityBrowser<Feed>, BrowserBase {}
+    public interface Single extends ResolvableToSingleWithRelationships<Feed>, BrowserBase {}
 
-    public interface Multiple extends MultipleRelatableEntityBrowser<Feed>, BrowserBase {}
+    public interface Multiple extends ResolvableToManyWithRelationships<Feed>, BrowserBase {}
 
     public interface Read extends ReadInterface<Single, Multiple> {}
 

--- a/api/src/main/java/org/hawkular/inventory/api/Feeds.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Feeds.java
@@ -41,6 +41,4 @@ public final class Feeds {
     public interface ReadAndRegister extends ReadInterface<Single, Multiple> {
         Single register(String proposedId);
     }
-
-    public interface ReadRelate extends ReadInterface<Single, Multiple>, RelateInterface {}
 }

--- a/api/src/main/java/org/hawkular/inventory/api/MetricTypes.java
+++ b/api/src/main/java/org/hawkular/inventory/api/MetricTypes.java
@@ -69,5 +69,5 @@ public final class MetricTypes {
      * Provides read-only access to metric types with the additional ability to relate the metric types to the current
      * position in the inventory traversal.
      */
-    public interface ReadRelate extends Read, RelateInterface {}
+    public interface ReadAssociate extends Read, AssociationInterface {}
 }

--- a/api/src/main/java/org/hawkular/inventory/api/MetricTypes.java
+++ b/api/src/main/java/org/hawkular/inventory/api/MetricTypes.java
@@ -41,7 +41,7 @@ public final class MetricTypes {
     /**
      * Interface for accessing a single metric type in a writable manner.
      */
-    public interface Single extends SingleRelatableEntityBrowser<MetricType>, BrowserBase {
+    public interface Single extends ResolvableToSingleWithRelationships<MetricType>, BrowserBase {
     }
 
     /**
@@ -51,7 +51,7 @@ public final class MetricTypes {
      * modification methods, you first need to resolve the traversal to a single entity (using the
      * {@link ReadInterface#get(String)} method).
      */
-    public interface Multiple extends MultipleRelatableEntityBrowser<MetricType>, BrowserBase {
+    public interface Multiple extends ResolvableToManyWithRelationships<MetricType>, BrowserBase {
     }
 
     /**

--- a/api/src/main/java/org/hawkular/inventory/api/Metrics.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Metrics.java
@@ -33,7 +33,7 @@ public final class Metrics {
     /**
      * Interface for accessing a single metric in a writable manner.
      */
-    public interface Single extends SingleRelatableEntityBrowser<Metric> {}
+    public interface Single extends ResolvableToSingleWithRelationships<Metric> {}
 
     /**
      * Interface for traversing over a set of metrics.
@@ -42,7 +42,7 @@ public final class Metrics {
      * modification methods, you first need to resolve the traversal to a single entity (using the
      * {@link ReadInterface#get(String)} method).
      */
-    public interface Multiple extends MultipleRelatableEntityBrowser<Metric> {}
+    public interface Multiple extends ResolvableToManyWithRelationships<Metric> {}
 
     /**
      * Provides read-only access to metrics.

--- a/api/src/main/java/org/hawkular/inventory/api/Metrics.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Metrics.java
@@ -58,5 +58,5 @@ public final class Metrics {
      * Provides read-only access to metrics with the additional ability to relate the metrics to the current
      * position in the inventory traversal.
      */
-    public interface ReadRelate extends ReadInterface<Single, Multiple>, RelateInterface {}
+    public interface ReadAssociate extends ReadInterface<Single, Multiple>, AssociationInterface {}
 }

--- a/api/src/main/java/org/hawkular/inventory/api/ReadInterface.java
+++ b/api/src/main/java/org/hawkular/inventory/api/ReadInterface.java
@@ -27,7 +27,7 @@ import org.hawkular.inventory.api.filters.Filter;
  * @author Lukas Krejci
  * @since 1.0
  */
-interface ReadInterface<Single, Multiple> {
+public interface ReadInterface<Single, Multiple> {
 
     /**
      * Tries to find a single entity in the current position in the inventory traversal.

--- a/api/src/main/java/org/hawkular/inventory/api/Relatable.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Relatable.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api;
+
+/**
+ * The contract for resolvable interfaces ({@link ResolvableToMany} and {@link ResolvableToMany}) that also support
+ * relationships.
+ *
+ * @param <Access> the access interface to the relationships (this should be one of
+ * {@link org.hawkular.inventory.api.Relationships.Read} or {@link org.hawkular.inventory.api.Relationships.ReadWrite}).
+ *
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+public interface Relatable<Access> {
+    /**
+     * @return the (r/w) access interface to all (outgoing) relationships of the entities on the current position in
+     * the inventory traversal.
+     */
+    Access relationships();
+
+    /**
+     * @param direction the direction of the relation (aka edge) This is needed because relationships are not
+     *                  bidirectional.
+     * @return the (r/w) access interface to all relationships of the entities on the current position in
+     * the inventory traversal.
+     */
+    Access relationships(Relationships.Direction direction);
+}

--- a/api/src/main/java/org/hawkular/inventory/api/ResolvableToManyWithRelationships.java
+++ b/api/src/main/java/org/hawkular/inventory/api/ResolvableToManyWithRelationships.java
@@ -26,19 +26,5 @@ package org.hawkular.inventory.api;
  * @author Jirka Kremser
  * @since 1.0
  */
-interface MultipleRelatableEntityBrowser<Entity> extends ResolvableToMany<Entity> {
-
-    /**
-     * @return the (read) access interface to all (outgoing) relationships of the entities on the current position in
-     * the inventory traversal.
-     */
-    Relationships.Read relationships();
-
-    /**
-     * @param direction the direction of the relation (aka edge) This is needed because relationships are not
-     *                  bidirectional.
-     * @return the (read) access interface to all relationships of the entities on the current position in
-     * the inventory traversal.
-     */
-    Relationships.Read relationships(Relationships.Direction direction);
+interface ResolvableToManyWithRelationships<Entity> extends ResolvableToMany<Entity>, Relatable<Relationships.Read> {
 }

--- a/api/src/main/java/org/hawkular/inventory/api/ResolvableToSingleWithRelationships.java
+++ b/api/src/main/java/org/hawkular/inventory/api/ResolvableToSingleWithRelationships.java
@@ -26,19 +26,6 @@ package org.hawkular.inventory.api;
  * @author Jirka Kremser
  * @since 1.0
  */
-interface SingleRelatableEntityBrowser<Entity> extends ResolvableToSingle<Entity> {
-
-    /**
-     * @return the (r/w) access interface to all (outgoing) relationships of the entities on the current position in
-     * the inventory traversal.
-     */
-    Relationships.ReadWrite relationships();
-
-    /**
-     * @param direction the direction of the relation (aka edge) This is needed because relationships are not
-     *                  bidirectional.
-     * @return the (r/w) access interface to all relationships of the entities on the current position in
-     * the inventory traversal.
-     */
-    Relationships.ReadWrite relationships(Relationships.Direction direction);
+interface ResolvableToSingleWithRelationships<Entity> extends ResolvableToSingle<Entity>,
+        Relatable<Relationships.ReadWrite> {
 }

--- a/api/src/main/java/org/hawkular/inventory/api/ResourceTypes.java
+++ b/api/src/main/java/org/hawkular/inventory/api/ResourceTypes.java
@@ -46,7 +46,7 @@ public final class ResourceTypes {
      * Interface for accessing a single resource type in a writable manner.
      */
     public interface Single extends ResolvableToSingleWithRelationships<ResourceType>,
-            BrowserBase<Resources.Read, MetricTypes.ReadRelate> {}
+            BrowserBase<Resources.Read, MetricTypes.ReadAssociate> {}
 
     /**
      * Interface for traversing over a set of resource types.

--- a/api/src/main/java/org/hawkular/inventory/api/ResourceTypes.java
+++ b/api/src/main/java/org/hawkular/inventory/api/ResourceTypes.java
@@ -67,5 +67,4 @@ public final class ResourceTypes {
      * Provides read-write access to resource types.
      */
     public interface ReadWrite extends ReadWriteInterface<ResourceType, ResourceType.Blueprint, Single, Multiple> {}
-    public interface ReadRelate extends ReadInterface<Single, Multiple>, RelateInterface {}
 }

--- a/api/src/main/java/org/hawkular/inventory/api/ResourceTypes.java
+++ b/api/src/main/java/org/hawkular/inventory/api/ResourceTypes.java
@@ -45,7 +45,7 @@ public final class ResourceTypes {
     /**
      * Interface for accessing a single resource type in a writable manner.
      */
-    public interface Single extends SingleRelatableEntityBrowser<ResourceType>,
+    public interface Single extends ResolvableToSingleWithRelationships<ResourceType>,
             BrowserBase<Resources.Read, MetricTypes.ReadRelate> {}
 
     /**
@@ -55,7 +55,7 @@ public final class ResourceTypes {
      * modification methods, you first need to resolve the traversal to a single entity (using the
      * {@link ReadInterface#get(String)} method).
      */
-    public interface Multiple extends MultipleRelatableEntityBrowser<ResourceType>,
+    public interface Multiple extends ResolvableToManyWithRelationships<ResourceType>,
             BrowserBase<Resources.Read, MetricTypes.Read> {}
 
     /**

--- a/api/src/main/java/org/hawkular/inventory/api/Resources.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Resources.java
@@ -59,9 +59,4 @@ public final class Resources {
      * Provides read-write access to resources.
      */
     public interface ReadWrite extends ReadWriteInterface<Resource, Resource.Blueprint, Single, Multiple> {}
-
-    /**
-     * Provides read access to relationships of resource.
-     */
-    public interface ReadRelate extends ReadInterface<Single, Multiple>, RelateInterface {}
 }

--- a/api/src/main/java/org/hawkular/inventory/api/Resources.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Resources.java
@@ -39,7 +39,7 @@ public final class Resources {
     /**
      * Interface for accessing a single resource in a writable manner.
      */
-    public interface Single extends ResolvableToSingleWithRelationships<Resource>, BrowserBase<Metrics.ReadRelate> {}
+    public interface Single extends ResolvableToSingleWithRelationships<Resource>, BrowserBase<Metrics.ReadAssociate> {}
 
     /**
      * Interface for traversing over a set of resources.

--- a/api/src/main/java/org/hawkular/inventory/api/Resources.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Resources.java
@@ -39,7 +39,7 @@ public final class Resources {
     /**
      * Interface for accessing a single resource in a writable manner.
      */
-    public interface Single extends SingleRelatableEntityBrowser<Resource>, BrowserBase<Metrics.ReadRelate> {}
+    public interface Single extends ResolvableToSingleWithRelationships<Resource>, BrowserBase<Metrics.ReadRelate> {}
 
     /**
      * Interface for traversing over a set of resources.
@@ -48,7 +48,7 @@ public final class Resources {
      * modification methods, you first need to resolve the traversal to a single entity (using the
      * {@link ReadInterface#get(String)} method).
      */
-    public interface Multiple extends MultipleRelatableEntityBrowser<Resource>, BrowserBase<Metrics.Read> {}
+    public interface Multiple extends ResolvableToManyWithRelationships<Resource>, BrowserBase<Metrics.Read> {}
 
     /**
      * Provides read-only access to resources.

--- a/api/src/main/java/org/hawkular/inventory/api/Tenants.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Tenants.java
@@ -72,6 +72,4 @@ public final class Tenants {
      * Provides methods for read-write access to tenants.
      */
     public interface ReadWrite extends ReadWriteInterface<Tenant, String, Single, Multiple> {}
-
-    public interface ReadRelate extends ReadInterface<Single, Multiple>, RelateInterface {}
 }

--- a/api/src/main/java/org/hawkular/inventory/api/Tenants.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Tenants.java
@@ -50,7 +50,7 @@ public final class Tenants {
     /**
      * Interface for accessing a single tenant in a writable manner.
      */
-    public interface Single extends SingleRelatableEntityBrowser<Tenant>,
+    public interface Single extends ResolvableToSingleWithRelationships<Tenant>,
             BrowserBase<ResourceTypes.ReadWrite, MetricTypes.ReadWrite, Environments.ReadWrite> {}
 
     /**
@@ -60,7 +60,7 @@ public final class Tenants {
      * modification methods, you first need to resolve the traversal to a single entity (using the
      * {@link ReadInterface#get(String)} method).
      */
-    public interface Multiple extends MultipleRelatableEntityBrowser<Tenant>,
+    public interface Multiple extends ResolvableToManyWithRelationships<Tenant>,
             BrowserBase<ResourceTypes.Read, MetricTypes.Read, Environments.Read> {}
 
     /**

--- a/api/src/main/java/org/hawkular/inventory/api/WriteInterface.java
+++ b/api/src/main/java/org/hawkular/inventory/api/WriteInterface.java
@@ -26,7 +26,7 @@ package org.hawkular.inventory.api;
  * @author Lukas Krejci
  * @since 1.0
  */
-interface WriteInterface<Entity, Blueprint, Single> {
+public interface WriteInterface<Entity, Blueprint, Single> {
 
     /**
      * Creates a new entity at the current position in the inventory traversal.

--- a/api/src/main/java/org/hawkular/inventory/api/observable/Action.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/Action.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.observable;
+
+import org.hawkular.inventory.api.model.Environment;
+import org.hawkular.inventory.api.model.Feed;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+@SuppressWarnings("unchecked")
+public final class Action<T> {
+    private static final Action<?> CREATE = new Action<>();
+    private static final Action<?> UPDATE = new Action<>();
+    private static final Action<?> DELETE = new Action<>();
+    private static final Action<EnvironmentCopy> COPY = new Action<>();
+    private static final Action<Feed> REGISTER = new Action<>();
+
+    private Action() {
+
+    }
+
+    public static <T> Action<T> create() {
+        return (Action<T>) CREATE;
+    }
+
+    public static <T> Action<T> update() {
+        return (Action<T>) UPDATE;
+    }
+
+    public static <T> Action<T> delete() {
+        return (Action<T>) DELETE;
+    }
+
+    public static Action<EnvironmentCopy> copy() {
+        return COPY;
+    }
+
+    public static Action<Feed> register() {
+        return REGISTER;
+    }
+
+    public static final class EnvironmentCopy {
+        private final Environment source;
+        private final Environment target;
+
+        public EnvironmentCopy(Environment source, Environment target) {
+            this.source = source;
+            this.target = target;
+        }
+
+        public Environment getSource() {
+            return source;
+        }
+
+        public Environment getTarget() {
+            return target;
+        }
+    }
+}

--- a/api/src/main/java/org/hawkular/inventory/api/observable/Action.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/Action.java
@@ -35,6 +35,8 @@ public final class Action<C, E> {
 
     }
 
+    //theses should really be Action<E, E> but I get a stack overflow in javac 8_u40 if I do that...
+    //didn't isolate the cause of this yet.. :(
     public static <C, E> Action<C, E> created() {
         return (Action<C, E>) CREATE;
     }

--- a/api/src/main/java/org/hawkular/inventory/api/observable/Action.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/Action.java
@@ -24,34 +24,34 @@ import org.hawkular.inventory.api.model.Feed;
  * @since 0.0.1
  */
 @SuppressWarnings("unchecked")
-public final class Action<T> {
-    private static final Action<?> CREATE = new Action<>();
-    private static final Action<?> UPDATE = new Action<>();
-    private static final Action<?> DELETE = new Action<>();
-    private static final Action<EnvironmentCopy> COPY = new Action<>();
-    private static final Action<Feed> REGISTER = new Action<>();
+public final class Action<C, E> {
+    private static final Action<?, ?> CREATE = new Action<>();
+    private static final Action<?, ?> UPDATE = new Action<>();
+    private static final Action<?, ?> DELETE = new Action<>();
+    private static final Action<EnvironmentCopy, Environment> COPY = new Action<>();
+    private static final Action<Feed, Feed> REGISTER = new Action<>();
 
     private Action() {
 
     }
 
-    public static <T> Action<T> create() {
-        return (Action<T>) CREATE;
+    public static <C, E> Action<C, E> created() {
+        return (Action<C, E>) CREATE;
     }
 
-    public static <T> Action<T> update() {
-        return (Action<T>) UPDATE;
+    public static <C, E> Action<C, E> updated() {
+        return (Action<C, E>) UPDATE;
     }
 
-    public static <T> Action<T> delete() {
-        return (Action<T>) DELETE;
+    public static <C, E> Action<C, E> deleted() {
+        return (Action<C, E>) DELETE;
     }
 
-    public static Action<EnvironmentCopy> copy() {
+    public static Action<EnvironmentCopy, Environment> copied() {
         return COPY;
     }
 
-    public static Action<Feed> register() {
+    public static Action<Feed, Feed> registered() {
         return REGISTER;
     }
 

--- a/api/src/main/java/org/hawkular/inventory/api/observable/Interest.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/Interest.java
@@ -19,32 +19,21 @@ package org.hawkular.inventory.api.observable;
 /**
  * Expresses what the user is interested in observing.
  *
+ * @param <C> the type of the action context that will be passed to the observers
  * @param <E> the type of the entity.
  *
  * @author Lukas Krejci
  * @since 0.0.1
  */
-public final class Interest<E> {
-    private final Action<E> action;
+public final class Interest<C, E> {
+    private final Action<C, E> action;
     private final Class<E> entityType;
 
-    public static <T> Builder<T> inCreate() {
-        return in(Action.create());
+    public static <T> Builder<T> in(Class<T> entity) {
+        return new Builder<>(entity);
     }
 
-    public static <T> Builder<T> inUpdate() {
-        return in(Action.update());
-    }
-
-    public static <T> Builder<T> inDelete() {
-        return in(Action.delete());
-    }
-
-    public static <T> Builder<T> in(Action<T> action) {
-        return new Builder<>(action);
-    }
-
-    public Interest(Action<E> action, Class<E> entityType) {
+    public Interest(Action<C, E> action, Class<E> entityType) {
         this.action = action;
         this.entityType = entityType;
     }
@@ -56,7 +45,7 @@ public final class Interest<E> {
      * @param object the object to check
      * @return true if the object is of interest to this, false otherwise
      */
-    public boolean matches(Action<?> action, Object object) {
+    public boolean matches(Action<?, ?> action, Object object) {
         return this.action == action && object != null && entityType.isAssignableFrom(object.getClass());
     }
 
@@ -65,7 +54,7 @@ public final class Interest<E> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        Interest<?> interest = (Interest<?>) o;
+        Interest<?, ?> interest = (Interest<?, ?>) o;
 
         if (action != interest.action) return false;
         return entityType.equals(interest.entityType);
@@ -84,26 +73,15 @@ public final class Interest<E> {
         return "Interest[" + "action=" + action + ", entityType=" + entityType + ']';
     }
 
-    public static final class Builder<T> {
-        private final Action<T> action;
-        private Class<?> entityType;
+    public static final class Builder<E> {
+        private final Class<E> entityType;
 
-        private Builder(Action<T> action) {
-            this.action = action;
-        }
-
-        public <E> Builder<E> of(Class<E> entityType) {
+        private Builder(Class<E> entityType) {
             this.entityType = entityType;
-            return cast(this);
         }
 
-        public Interest<T> build() {
-            return new Interest<>(action, cast(entityType));
-        }
-
-        @SuppressWarnings("unchecked")
-        private <U> U cast(Object o) {
-            return (U) o;
+        public <C> Interest<C, E> being(Action<C, E> action) {
+            return new Interest<>(action, entityType);
         }
     }
 }

--- a/api/src/main/java/org/hawkular/inventory/api/observable/Interest.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/Interest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.observable;
+
+/**
+ * Expresses what the user is interested in observing.
+ *
+ * @param <E> the type of the entity.
+ *
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+public final class Interest<E> {
+    private final Action action;
+    private final Class<E> entityType;
+
+    public static Builder<?> inCreate() {
+        return in(Action.CREATE);
+    }
+
+    public static Builder<?> inUpdate() {
+        return in(Action.UPDATE);
+    }
+
+    public static Builder<?> inDelete() {
+        return in(Action.DELETE);
+    }
+
+    public static Builder<?> in(Action action) {
+        return new Builder(action);
+    }
+
+    public Interest(Action action, Class<E> entityType) {
+        this.action = action;
+        this.entityType = entityType;
+    }
+
+    /**
+     * Checks whether given object is of interest to this interest instance.
+     *
+     * @param action the action to be performed on the object
+     * @param object the object to check
+     * @return true if the object is of interest to this, false otherwise
+     */
+    public boolean matches(Action action, Object object) {
+        return this.action == action && object != null && entityType.isAssignableFrom(object.getClass());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Interest<?> interest = (Interest<?>) o;
+
+        if (action != interest.action) return false;
+        return entityType.equals(interest.entityType);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = action.hashCode();
+        result = 31 * result + entityType.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Interest[" + "action=" + action + ", entityType=" + entityType + ']';
+    }
+
+    public enum Action {
+        CREATE, UPDATE, DELETE
+    }
+
+    public static final class Builder<T> {
+        private final Action action;
+        private Class<?> entityType;
+
+        private Builder(Action action) {
+            this.action = action;
+        }
+
+        public <E> Builder<E> of(Class<E> entityType) {
+            this.entityType = entityType;
+            return cast(this);
+        }
+
+        public Interest<T> build() {
+            return new Interest<>(action, cast(entityType));
+        }
+
+        @SuppressWarnings("unchecked")
+        private <U> U cast(Object o) {
+            return (U) o;
+        }
+    }
+}

--- a/api/src/main/java/org/hawkular/inventory/api/observable/Interest.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/Interest.java
@@ -25,26 +25,26 @@ package org.hawkular.inventory.api.observable;
  * @since 0.0.1
  */
 public final class Interest<E> {
-    private final Action action;
+    private final Action<E> action;
     private final Class<E> entityType;
 
-    public static Builder<?> inCreate() {
-        return in(Action.CREATE);
+    public static <T> Builder<T> inCreate() {
+        return in(Action.create());
     }
 
-    public static Builder<?> inUpdate() {
-        return in(Action.UPDATE);
+    public static <T> Builder<T> inUpdate() {
+        return in(Action.update());
     }
 
-    public static Builder<?> inDelete() {
-        return in(Action.DELETE);
+    public static <T> Builder<T> inDelete() {
+        return in(Action.delete());
     }
 
-    public static Builder<?> in(Action action) {
-        return new Builder(action);
+    public static <T> Builder<T> in(Action<T> action) {
+        return new Builder<>(action);
     }
 
-    public Interest(Action action, Class<E> entityType) {
+    public Interest(Action<E> action, Class<E> entityType) {
         this.action = action;
         this.entityType = entityType;
     }
@@ -56,7 +56,7 @@ public final class Interest<E> {
      * @param object the object to check
      * @return true if the object is of interest to this, false otherwise
      */
-    public boolean matches(Action action, Object object) {
+    public boolean matches(Action<?> action, Object object) {
         return this.action == action && object != null && entityType.isAssignableFrom(object.getClass());
     }
 
@@ -84,15 +84,11 @@ public final class Interest<E> {
         return "Interest[" + "action=" + action + ", entityType=" + entityType + ']';
     }
 
-    public enum Action {
-        CREATE, UPDATE, DELETE
-    }
-
     public static final class Builder<T> {
-        private final Action action;
+        private final Action<T> action;
         private Class<?> entityType;
 
-        private Builder(Action action) {
+        private Builder(Action<T> action) {
             this.action = action;
         }
 

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableBase.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableBase.java
@@ -66,7 +66,7 @@ public class ObservableBase<T> {
         }
     }
 
-    public static abstract class Read<Single extends ResolvableToSingle<?>,
+    public abstract static class Read<Single extends ResolvableToSingle<?>,
             Multiple extends ResolvableToMany<?>, Iface extends ReadInterface<Single, Multiple>>
             extends ObservableBase<Iface> {
 
@@ -87,7 +87,7 @@ public class ObservableBase<T> {
         }
     }
 
-    public static abstract class ReadWrite<Entity, Blueprint,
+    public abstract static class ReadWrite<Entity, Blueprint,
             Single extends ResolvableToSingle<Entity> & Relatable<Relationships.ReadWrite>,
             Multiple extends ResolvableToMany<Entity>,
             Iface extends ReadInterface<Single, Multiple> & WriteInterface<Entity, Blueprint, Single>>
@@ -112,12 +112,12 @@ public class ObservableBase<T> {
         public Single create(Blueprint b) {
             Single s = wrapped.create(b);
 
-            notify(s.entity(), Action.<Entity>create());
+            notify(s.entity(), Action.create());
 
             //there is a possible race here if someone creates a relationship on the entity between the time it
             //is created above and here. Such relationships would be observed twice...
             s.relationships(Relationships.Direction.both).getAll().entities()
-                    .forEach((r) -> notify(r, Action.<Relationship>create()));
+                    .forEach((r) -> notify(r, Action.create()));
 
             return wrap(singleCtor(), s);
         }
@@ -134,9 +134,9 @@ public class ObservableBase<T> {
         }
     }
 
-    public static abstract class Single<E, T extends ResolvableToSingle<E>> extends ObservableBase<T> {
+    public abstract static class SingleBase<E, T extends ResolvableToSingle<E>> extends ObservableBase<T> {
 
-        Single(T wrapped, ObservableContext context) {
+        SingleBase(T wrapped, ObservableContext context) {
             super(wrapped, context);
         }
 
@@ -145,9 +145,9 @@ public class ObservableBase<T> {
         }
     }
 
-    public static abstract class Multiple<E, T extends ResolvableToMany<E>> extends ObservableBase<T> {
+    public abstract static class MultipleBase<E, T extends ResolvableToMany<E>> extends ObservableBase<T> {
 
-        Multiple(T wrapped, ObservableContext context) {
+        MultipleBase(T wrapped, ObservableContext context) {
             super(wrapped, context);
         }
 
@@ -156,8 +156,8 @@ public class ObservableBase<T> {
         }
     }
 
-    public static abstract class RelatableSingle<E,
-            T extends Relatable<Relationships.ReadWrite> & ResolvableToSingle<E>> extends Single<E, T> {
+    public abstract static class RelatableSingle<E,
+            T extends Relatable<Relationships.ReadWrite> & ResolvableToSingle<E>> extends SingleBase<E, T> {
 
         RelatableSingle(T wrapped, ObservableContext context) {
             super(wrapped, context);
@@ -172,8 +172,8 @@ public class ObservableBase<T> {
         }
     }
 
-    public static abstract class RelatableMultiple<E,
-            T extends Relatable<Relationships.Read> & ResolvableToMany<E>> extends Multiple<E, T> {
+    public abstract static class RelatableMultiple<E,
+            T extends Relatable<Relationships.Read> & ResolvableToMany<E>> extends MultipleBase<E, T> {
 
         RelatableMultiple(T wrapped, ObservableContext context) {
             super(wrapped, context);

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableBase.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableBase.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.observable;
+
+import org.hawkular.inventory.api.ReadInterface;
+import org.hawkular.inventory.api.ResolvableToMany;
+import org.hawkular.inventory.api.ResolvableToSingle;
+import org.hawkular.inventory.api.WriteInterface;
+import org.hawkular.inventory.api.filters.Filter;
+import rx.subjects.Subject;
+
+import java.util.Iterator;
+import java.util.function.BiFunction;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+public class ObservableBase<T> {
+
+    protected final ObservableContext context;
+    protected final T wrapped;
+
+    ObservableBase(T wrapped, ObservableContext context) {
+        this.context = context;
+        this.wrapped = wrapped;
+    }
+
+    protected <V, I> I wrap(BiFunction<V, ObservableContext, I> constructor, V value) {
+        return constructor.apply(value, context);
+    }
+
+    protected <V extends ResolvableToSingle<?>, I> I wrapAndNotify(BiFunction<V, ObservableContext, I> constructor,
+        V value, Interest.Action action) {
+
+        Object e = value.entity();
+
+        notify(e, action);
+
+        return constructor.apply(value, context);
+    }
+
+    protected <E> void notify(E entity, Interest.Action action) {
+        Iterator<Subject<Object, Object>> subjects = context.matchingSubjects(action, entity);
+        while (subjects.hasNext()) {
+            Subject<Object, Object> s = subjects.next();
+            s.onNext(entity);
+        }
+    }
+
+    public static abstract class Read<Single extends ResolvableToSingle<?>,
+            Multiple extends ResolvableToMany<?>, Iface extends ReadInterface<Single, Multiple>>
+            extends ObservableBase<Iface> {
+
+        Read(Iface wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        protected abstract BiFunction<Single, ObservableContext, ? extends Single> singleCtor();
+
+        protected abstract BiFunction<Multiple, ObservableContext, ? extends Multiple> multipleCtor();
+
+        public Single get(String id) {
+            return wrap(singleCtor(), wrapped.get(id));
+        }
+
+        public Multiple getAll(Filter... filters) {
+            return wrap(multipleCtor(), wrapped.getAll(filters));
+        }
+    }
+
+    public static abstract class ReadWrite<Entity, Blueprint, Single extends ResolvableToSingle<Entity>,
+            Multiple extends ResolvableToMany<Entity>,
+            Iface extends ReadInterface<Single, Multiple> & WriteInterface<Entity, Blueprint, Single>>
+            extends ObservableBase<Iface> {
+
+        ReadWrite(Iface wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        protected abstract BiFunction<Single, ObservableContext, ? extends Single> singleCtor();
+
+        protected abstract BiFunction<Multiple, ObservableContext, ? extends Multiple> multipleCtor();
+
+        public Single get(String id) {
+            return wrap(singleCtor(), wrapped.get(id));
+        }
+
+        public Multiple getAll(Filter... filters) {
+            return wrap(multipleCtor(), wrapped.getAll(filters));
+        }
+
+        public Single create(Blueprint b) {
+            return wrapAndNotify(singleCtor(), wrapped.create(b), Interest.Action.CREATE);
+        }
+
+        public void update(Entity e) {
+            wrapped.update(e);
+            notify(e, Interest.Action.UPDATE);
+        }
+
+        public void delete(String id) {
+            Entity e = get(id).entity();
+            wrapped.delete(id);
+            notify(e, Interest.Action.DELETE);
+        }
+    }
+}

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableContext.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableContext.java
@@ -17,7 +17,6 @@
 package org.hawkular.inventory.api.observable;
 
 import rx.Observable;
-import rx.Subscriber;
 import rx.functions.Action0;
 import rx.subjects.PublishSubject;
 import rx.subjects.Subject;
@@ -49,7 +48,7 @@ final class ObservableContext {
     }
 
     @SuppressWarnings("unchecked")
-    public <T> Iterator<Subject<T, T>> matchingSubjects(Interest.Action action, T object) {
+    public <T> Iterator<Subject<T, T>> matchingSubjects(Action<T> action, T object) {
         return observables.entrySet().stream().filter((e) -> e.getKey().matches(action, object))
                 .map((e) -> (Subject<T, T>) e.getValue()).iterator();
     }

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableContext.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableContext.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.observable;
+
+import rx.subjects.PublishSubject;
+import rx.subjects.Subject;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+final class ObservableContext {
+    private final Map<Interest<?>, Subject<?, ?>> observables = new ConcurrentHashMap<>();
+
+    public <T> Subject<T, T> getSubject(Interest<T> interest) {
+        @SuppressWarnings("unchecked")
+        Subject<T, T> ret = (Subject<T, T>) observables.get(interest);
+
+        if (ret == null) {
+            ret = PublishSubject.create();
+            observables.put(interest, ret);
+        }
+
+        return ret;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> Iterator<Subject<T, T>> matchingSubjects(Interest.Action action, T object) {
+        return observables.entrySet().stream().filter((e) -> e.getKey().matches(action, object))
+                .map((e) -> (Subject<T, T>) e.getValue()).iterator();
+    }
+}

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableEnvironments.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableEnvironments.java
@@ -72,8 +72,8 @@ public final class ObservableEnvironments {
             wrapped.copy(sourceEnvironmentId, targetEnvironmentId);
             Environment s = get(sourceEnvironmentId).entity();
             Environment t = get(targetEnvironmentId).entity();
-            notify(t, Action.create());
-            notify(new Action.EnvironmentCopy(s, t), Action.copy());
+            notify(t, Action.created());
+            notify(s, new Action.EnvironmentCopy(s, t), Action.copied());
         }
     }
 

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableEnvironments.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableEnvironments.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.observable;
+
+import org.hawkular.inventory.api.Environments;
+import org.hawkular.inventory.api.model.Environment;
+
+import java.util.function.BiFunction;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+public final class ObservableEnvironments {
+    private ObservableEnvironments() {
+
+    }
+
+    public static final class Read
+            extends ObservableBase.Read<Environments.Single, Environments.Multiple, Environments.Read>
+            implements Environments.Read {
+
+        Read(Environments.Read wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        protected BiFunction<Environments.Single, ObservableContext, ? extends Environments.Single> singleCtor() {
+            return ObservableEnvironments.Single::new;
+        }
+
+        @Override
+        protected BiFunction<Environments.Multiple, ObservableContext, ? extends Environments.Multiple> multipleCtor() {
+            return ObservableEnvironments.Multiple::new;
+        }
+    }
+
+    public static final class ReadWrite
+            extends ObservableBase.ReadWrite<Environment, String, Environments.Single, Environments.Multiple,
+                Environments.ReadWrite> implements Environments.ReadWrite {
+
+        ReadWrite(Environments.ReadWrite wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        protected BiFunction<Environments.Single, ObservableContext, ? extends Environments.Single> singleCtor() {
+            return ObservableEnvironments.Single::new;
+        }
+
+        @Override
+        protected BiFunction<Environments.Multiple, ObservableContext, ? extends Environments.Multiple> multipleCtor() {
+            return ObservableEnvironments.Multiple::new;
+        }
+
+        @Override
+        public void copy(String sourceEnvironmentId, String targetEnvironmentId) {
+            wrapped.copy(sourceEnvironmentId, targetEnvironmentId);
+            Environment s = get(sourceEnvironmentId).entity();
+            Environment t = get(targetEnvironmentId).entity();
+            notify(t, Action.create());
+            notify(new Action.EnvironmentCopy(s, t), Action.copy());
+        }
+    }
+
+    public static final class Single extends ObservableBase.RelatableSingle<Environment, Environments.Single>
+            implements Environments.Single {
+
+        Single(Environments.Single wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        public ObservableFeeds.ReadAndRegister feeds() {
+            return wrap(ObservableFeeds.ReadAndRegister::new, wrapped.feeds());
+        }
+
+        @Override
+        public ObservableResources.ReadWrite resources() {
+            return wrap(ObservableResources.ReadWrite::new, wrapped.resources());
+        }
+
+        @Override
+        public ObservableMetrics.ReadWrite metrics() {
+            return wrap(ObservableMetrics.ReadWrite::new, wrapped.metrics());
+        }
+    }
+
+    public static final class Multiple extends ObservableBase.RelatableMultiple<Environment, Environments.Multiple>
+            implements Environments.Multiple {
+
+        Multiple(Environments.Multiple wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        public ObservableFeeds.Read feeds() {
+            return wrap(ObservableFeeds.Read::new, wrapped.feeds());
+        }
+
+        @Override
+        public ObservableResources.Read resources() {
+            return wrap(ObservableResources.Read::new, wrapped.resources());
+        }
+
+        @Override
+        public ObservableMetrics.Read metrics() {
+            return wrap(ObservableMetrics.Read::new, wrapped.metrics());
+        }
+    }
+}

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableFeeds.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableFeeds.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.observable;
+
+import org.hawkular.inventory.api.EntityNotFoundException;
+import org.hawkular.inventory.api.Feeds;
+import org.hawkular.inventory.api.RelationNotFoundException;
+import org.hawkular.inventory.api.filters.Filter;
+import org.hawkular.inventory.api.model.Feed;
+
+import java.util.function.BiFunction;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+public final class ObservableFeeds {
+
+    private ObservableFeeds() {
+
+    }
+
+    public static final class Read extends ObservableBase.Read<Feeds.Single, Feeds.Multiple, Feeds.Read>
+            implements Feeds.Read {
+
+        Read(Feeds.Read wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        protected BiFunction<Feeds.Single, ObservableContext, ? extends Feeds.Single> singleCtor() {
+            return ObservableFeeds.Single::new;
+        }
+
+        @Override
+        protected BiFunction<Feeds.Multiple, ObservableContext, ? extends Feeds.Multiple> multipleCtor() {
+            return ObservableFeeds.Multiple::new;
+        }
+    }
+
+    public static final class ReadAndRegister extends ObservableBase<Feeds.ReadAndRegister>
+            implements Feeds.ReadAndRegister {
+
+        ReadAndRegister(Feeds.ReadAndRegister wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        public Feeds.Single register(String proposedId) {
+            return wrap(ObservableFeeds.Single::new, wrapped.register(proposedId));
+        }
+
+        @Override
+        public Feeds.Single get(String id) throws EntityNotFoundException, RelationNotFoundException {
+            return wrap(ObservableFeeds.Single::new, wrapped.get(id));
+        }
+
+        @Override
+        public Feeds.Multiple getAll(Filter... filters) {
+            return wrap(ObservableFeeds.Multiple::new, wrapped.getAll(filters));
+        }
+    }
+
+    public static final class Single extends ObservableBase.RelatableSingle<Feed, Feeds.Single>
+            implements Feeds.Single {
+
+        Single(Feeds.Single wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        public ObservableResources.Read resources() {
+            return wrap(ObservableResources.Read::new, wrapped.resources());
+        }
+    }
+
+    public static final class Multiple extends ObservableBase.RelatableMultiple<Feed, Feeds.Multiple>
+            implements Feeds.Multiple {
+
+        Multiple(Feeds.Multiple wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        public ObservableResources.Read resources() {
+            return wrap(ObservableResources.Read::new, wrapped.resources());
+        }
+    }
+}

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableInventory.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableInventory.java
@@ -51,6 +51,6 @@ public final class ObservableInventory implements Inventory {
     }
 
     public <E> Observable<E> observable(Interest<E> interest) {
-        return context.getSubject(interest);
+        return context.getObservableFor(interest);
     }
 }

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableInventory.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableInventory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.observable;
+
+import org.hawkular.inventory.api.Configuration;
+import org.hawkular.inventory.api.Inventory;
+import rx.Observable;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+public final class ObservableInventory implements Inventory {
+
+    private final Inventory inventory;
+
+    private final ObservableContext context;
+
+    public ObservableInventory(Inventory inventory) {
+        this.inventory = inventory;
+        this.context = new ObservableContext();
+    }
+
+    @Override
+    public void initialize(Configuration configuration) {
+        inventory.initialize(configuration);
+    }
+
+    @Override
+    public ObservableTenants.ReadWrite tenants() {
+        return new ObservableTenants.ReadWrite(inventory.tenants(), context);
+    }
+
+    @Override
+    public void close() throws Exception {
+        inventory.close();
+    }
+
+    public <E> Observable<E> observable(Interest<E> interest) {
+        return context.getSubject(interest);
+    }
+}

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableInventory.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableInventory.java
@@ -53,4 +53,8 @@ public final class ObservableInventory implements Inventory {
     public <E> Observable<E> observable(Interest<E> interest) {
         return context.getObservableFor(interest);
     }
+
+    public boolean hasObservers(Interest<?> interest) {
+        return context.isObserved(interest);
+    }
 }

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableInventory.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableInventory.java
@@ -50,11 +50,11 @@ public final class ObservableInventory implements Inventory {
         inventory.close();
     }
 
-    public <E> Observable<E> observable(Interest<E> interest) {
+    public <C, E> Observable<C> observable(Interest<C, E> interest) {
         return context.getObservableFor(interest);
     }
 
-    public boolean hasObservers(Interest<?> interest) {
+    public boolean hasObservers(Interest<?, ?> interest) {
         return context.isObserved(interest);
     }
 }

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetricTypes.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetricTypes.java
@@ -91,14 +91,14 @@ public final class ObservableMetricTypes {
         @Override
         public Relationship associate(String id) {
             Relationship ret = wrapped.associate(id);
-            notify(ret, Action.create());
+            notify(ret, Action.created());
             return ret;
         }
 
         @Override
         public Relationship disassociate(String id) {
             Relationship ret = wrapped.associate(id);
-            notify(ret, Action.delete());
+            notify(ret, Action.deleted());
             return ret;
         }
 

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetricTypes.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetricTypes.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.observable;
+
+import org.hawkular.inventory.api.MetricTypes;
+import org.hawkular.inventory.api.model.MetricType;
+
+import java.util.function.BiFunction;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+public final class ObservableMetricTypes {
+    private ObservableMetricTypes() {
+
+    }
+
+    public static final class Read
+            extends ObservableBase.Read<MetricTypes.Single, MetricTypes.Multiple, MetricTypes.Read>
+            implements MetricTypes.Read {
+
+        Read(MetricTypes.Read wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        protected BiFunction<MetricTypes.Single, ObservableContext, ? extends MetricTypes.Single> singleCtor() {
+           return ObservableMetricTypes.Single::new;
+        }
+
+        @Override
+        protected BiFunction<MetricTypes.Multiple, ObservableContext, ? extends MetricTypes.Multiple> multipleCtor() {
+            return ObservableMetricTypes.Multiple::new;
+        }
+    }
+
+    public static final class ReadWrite
+        extends ObservableBase.ReadWrite<MetricType, MetricType.Blueprint, MetricTypes.Single, MetricTypes.Multiple,
+            MetricTypes.ReadWrite> implements MetricTypes.ReadWrite {
+
+        ReadWrite(MetricTypes.ReadWrite wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        protected BiFunction<MetricTypes.Single, ObservableContext, ? extends MetricTypes.Single> singleCtor() {
+            return ObservableMetricTypes.Single::new;
+        }
+
+        @Override
+        protected BiFunction<MetricTypes.Multiple, ObservableContext, ? extends MetricTypes.Multiple> multipleCtor() {
+            return ObservableMetricTypes.Multiple::new;
+        }
+    }
+
+    public static final class ReadRelate
+        extends ObservableBase.Read<MetricTypes.Single, MetricTypes.Multiple, MetricTypes.ReadRelate>
+        implements MetricTypes.ReadRelate {
+
+        ReadRelate(MetricTypes.ReadRelate wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        protected BiFunction<MetricTypes.Single, ObservableContext, ? extends MetricTypes.Single> singleCtor() {
+            return ObservableMetricTypes.Single::new;
+        }
+
+        @Override
+        protected BiFunction<MetricTypes.Multiple, ObservableContext, ? extends MetricTypes.Multiple> multipleCtor() {
+            return ObservableMetricTypes.Multiple::new;
+        }
+
+        @Override
+        public void add(String id) {
+            wrapped.add(id);
+        }
+
+        @Override
+        public void remove(String id) {
+            wrapped.remove(id);
+        }
+    }
+
+    public static final class Single extends ObservableBase.RelatableSingle<MetricType, MetricTypes.Single>
+            implements MetricTypes.Single {
+
+        Single(MetricTypes.Single wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        public ObservableMetrics.Read metrics() {
+            return wrap(ObservableMetrics.Read::new, wrapped.metrics());
+        }
+    }
+
+    public static final class Multiple extends ObservableBase.RelatableMultiple<MetricType, MetricTypes.Multiple>
+            implements MetricTypes.Multiple {
+
+        Multiple(MetricTypes.Multiple wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        public ObservableMetrics.Read metrics() {
+            return wrap(ObservableMetrics.Read::new, wrapped.metrics());
+        }
+    }
+}

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetricTypes.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetricTypes.java
@@ -91,14 +91,14 @@ public final class ObservableMetricTypes {
         @Override
         public Relationship associate(String id) {
             Relationship ret = wrapped.associate(id);
-            notify(ret, Action.<Relationship>create());
+            notify(ret, Action.create());
             return ret;
         }
 
         @Override
         public Relationship disassociate(String id) {
             Relationship ret = wrapped.associate(id);
-            notify(ret, Action.<Relationship>delete());
+            notify(ret, Action.delete());
             return ret;
         }
 

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetricTypes.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetricTypes.java
@@ -90,12 +90,16 @@ public final class ObservableMetricTypes {
 
         @Override
         public Relationship associate(String id) {
-            return wrapped.associate(id);
+            Relationship ret = wrapped.associate(id);
+            notify(ret, Action.<Relationship>create());
+            return ret;
         }
 
         @Override
-        public void disassociate(String id) {
-            wrapped.disassociate(id);
+        public Relationship disassociate(String id) {
+            Relationship ret = wrapped.associate(id);
+            notify(ret, Action.<Relationship>delete());
+            return ret;
         }
 
         @Override

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetricTypes.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetricTypes.java
@@ -17,7 +17,9 @@
 package org.hawkular.inventory.api.observable;
 
 import org.hawkular.inventory.api.MetricTypes;
+import org.hawkular.inventory.api.RelationNotFoundException;
 import org.hawkular.inventory.api.model.MetricType;
+import org.hawkular.inventory.api.model.Relationship;
 
 import java.util.function.BiFunction;
 
@@ -68,11 +70,11 @@ public final class ObservableMetricTypes {
         }
     }
 
-    public static final class ReadRelate
-        extends ObservableBase.Read<MetricTypes.Single, MetricTypes.Multiple, MetricTypes.ReadRelate>
-        implements MetricTypes.ReadRelate {
+    public static final class ReadAssociate
+        extends ObservableBase.Read<MetricTypes.Single, MetricTypes.Multiple, MetricTypes.ReadAssociate>
+        implements MetricTypes.ReadAssociate {
 
-        ReadRelate(MetricTypes.ReadRelate wrapped, ObservableContext context) {
+        ReadAssociate(MetricTypes.ReadAssociate wrapped, ObservableContext context) {
             super(wrapped, context);
         }
 
@@ -87,13 +89,18 @@ public final class ObservableMetricTypes {
         }
 
         @Override
-        public void add(String id) {
-            wrapped.add(id);
+        public Relationship associate(String id) {
+            return wrapped.associate(id);
         }
 
         @Override
-        public void remove(String id) {
-            wrapped.remove(id);
+        public void disassociate(String id) {
+            wrapped.disassociate(id);
+        }
+
+        @Override
+        public Relationship associationWith(String id) throws RelationNotFoundException {
+            return wrapped.associationWith(id);
         }
     }
 

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetrics.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetrics.java
@@ -71,14 +71,14 @@ public final class ObservableMetrics {
         @Override
         public Relationship associate(String id) {
             Relationship ret = wrapped.associate(id);
-            notify(ret, Action.<Relationship>create());
+            notify(ret, Action.created());
             return ret;
         }
 
         @Override
         public Relationship disassociate(String id) {
             Relationship ret = wrapped.disassociate(id);
-            notify(ret, Action.<Relationship>delete());
+            notify(ret, Action.deleted());
             return ret;
         }
 

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetrics.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetrics.java
@@ -70,12 +70,16 @@ public final class ObservableMetrics {
 
         @Override
         public Relationship associate(String id) {
-            return wrapped.associate(id);
+            Relationship ret = wrapped.associate(id);
+            notify(ret, Action.<Relationship>create());
+            return ret;
         }
 
         @Override
-        public void disassociate(String id) {
-            wrapped.disassociate(id);
+        public Relationship disassociate(String id) {
+            Relationship ret = wrapped.disassociate(id);
+            notify(ret, Action.<Relationship>delete());
+            return ret;
         }
 
         @Override

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetrics.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetrics.java
@@ -17,7 +17,9 @@
 package org.hawkular.inventory.api.observable;
 
 import org.hawkular.inventory.api.Metrics;
+import org.hawkular.inventory.api.RelationNotFoundException;
 import org.hawkular.inventory.api.model.Metric;
+import org.hawkular.inventory.api.model.Relationship;
 
 import java.util.function.BiFunction;
 
@@ -48,11 +50,11 @@ public final class ObservableMetrics {
         }
     }
 
-    public static final class ReadRelate
-            extends ObservableBase.Read<Metrics.Single, Metrics.Multiple, Metrics.ReadRelate>
-            implements Metrics.ReadRelate {
+    public static final class ReadAssociate
+            extends ObservableBase.Read<Metrics.Single, Metrics.Multiple, Metrics.ReadAssociate>
+            implements Metrics.ReadAssociate {
 
-        ReadRelate(Metrics.ReadRelate wrapped, ObservableContext context) {
+        ReadAssociate(Metrics.ReadAssociate wrapped, ObservableContext context) {
             super(wrapped, context);
         }
 
@@ -67,13 +69,18 @@ public final class ObservableMetrics {
         }
 
         @Override
-        public void add(String id) {
-            wrapped.add(id);
+        public Relationship associate(String id) {
+            return wrapped.associate(id);
         }
 
         @Override
-        public void remove(String id) {
-            wrapped.remove(id);
+        public void disassociate(String id) {
+            wrapped.disassociate(id);
+        }
+
+        @Override
+        public Relationship associationWith(String id) throws RelationNotFoundException {
+            return wrapped.associationWith(id);
         }
     }
 

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetrics.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableMetrics.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.observable;
+
+import org.hawkular.inventory.api.Metrics;
+import org.hawkular.inventory.api.model.Metric;
+
+import java.util.function.BiFunction;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+public final class ObservableMetrics {
+    private ObservableMetrics() {
+
+    }
+
+    public static final class Read extends ObservableBase.Read<Metrics.Single, Metrics.Multiple, Metrics.Read>
+        implements Metrics.Read {
+
+        Read(Metrics.Read wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        protected BiFunction<Metrics.Single, ObservableContext, ? extends Metrics.Single> singleCtor() {
+            return ObservableMetrics.Single::new;
+        }
+
+        @Override
+        protected BiFunction<Metrics.Multiple, ObservableContext, ? extends Metrics.Multiple> multipleCtor() {
+            return ObservableMetrics.Multiple::new;
+        }
+    }
+
+    public static final class ReadRelate
+            extends ObservableBase.Read<Metrics.Single, Metrics.Multiple, Metrics.ReadRelate>
+            implements Metrics.ReadRelate {
+
+        ReadRelate(Metrics.ReadRelate wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        protected BiFunction<Metrics.Single, ObservableContext, ? extends Metrics.Single> singleCtor() {
+            return ObservableMetrics.Single::new;
+        }
+
+        @Override
+        protected BiFunction<Metrics.Multiple, ObservableContext, ? extends Metrics.Multiple> multipleCtor() {
+            return ObservableMetrics.Multiple::new;
+        }
+
+        @Override
+        public void add(String id) {
+            wrapped.add(id);
+        }
+
+        @Override
+        public void remove(String id) {
+            wrapped.remove(id);
+        }
+    }
+
+    public static final class ReadWrite
+        extends ObservableBase.ReadWrite<Metric, Metric.Blueprint, Metrics.Single, Metrics.Multiple, Metrics.ReadWrite>
+        implements Metrics.ReadWrite {
+
+        ReadWrite(Metrics.ReadWrite wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        protected BiFunction<Metrics.Single, ObservableContext, ? extends Metrics.Single> singleCtor() {
+            return ObservableMetrics.Single::new;
+        }
+
+        @Override
+        protected BiFunction<Metrics.Multiple, ObservableContext, ? extends Metrics.Multiple> multipleCtor() {
+            return ObservableMetrics.Multiple::new;
+        }
+    }
+
+    public static final class Single extends ObservableBase.RelatableSingle<Metric, Metrics.Single>
+            implements Metrics.Single {
+
+        Single(Metrics.Single wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+    }
+
+    public static final class Multiple extends ObservableBase.RelatableMultiple<Metric, Metrics.Multiple>
+            implements Metrics.Multiple {
+
+        Multiple(Metrics.Multiple wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+    }
+}

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableRelationships.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableRelationships.java
@@ -47,27 +47,27 @@ public final class ObservableRelationships {
 
         @Override
         public Relationships.Multiple named(String name) {
-            return wrap(Multiple::new, wrapped.named(name));
+            return wrap(ObservableRelationships.Multiple::new, wrapped.named(name));
         }
 
         @Override
         public Relationships.Multiple named(Relationships.WellKnown name) {
-            return wrap(Multiple::new, wrapped.named(name));
+            return wrap(ObservableRelationships.Multiple::new, wrapped.named(name));
         }
 
         @Override
         public Relationships.Single get(String id) throws EntityNotFoundException, RelationNotFoundException {
-            return wrap(Single::new, wrapped.get(id));
+            return wrap(ObservableRelationships.Single::new, wrapped.get(id));
         }
 
         @Override
         public Relationships.Multiple getAll(RelationFilter... filters) {
-            return wrap(Multiple::new, wrapped.getAll(filters));
+            return wrap(ObservableRelationships.Multiple::new, wrapped.getAll(filters));
         }
 
         @Override
         public Relationships.Single linkWith(String name, Entity targetOrSource) throws IllegalArgumentException {
-            return wrapAndNotify(Single::new, wrapped.linkWith(name, targetOrSource), Interest.Action.CREATE);
+            return wrapAndNotify(ObservableRelationships.Single::new, wrapped.linkWith(name, targetOrSource), Action.create());
         }
 
         @Override
@@ -78,30 +78,54 @@ public final class ObservableRelationships {
         @Override
         public void update(Relationship relationship) throws RelationNotFoundException {
             wrapped.update(relationship);
-            notify(relationship, Interest.Action.UPDATE);
+            notify(relationship, Action.update());
         }
 
         @Override
         public void delete(String id) throws RelationNotFoundException {
             Relationship r = get(id).entity();
             wrapped.delete(id);
-            notify(r, Interest.Action.DELETE);
+            notify(r, Action.delete());
         }
     }
 
-    public static final class Single extends ObservableBase<Relationships.Single> implements Relationships.Single {
+    public static final class Read extends ObservableBase<Relationships.Read>
+            implements Relationships.Read {
 
-        Single(Relationships.Single wrapped, ObservableContext context) {
+        Read(Relationships.Read wrapped, ObservableContext context) {
             super(wrapped, context);
         }
 
         @Override
-        public Relationship entity() {
-            return wrapped.entity();
+        public Relationships.Multiple named(String name) {
+            return wrap(ObservableRelationships.Multiple::new, wrapped.named(name));
+        }
+
+        @Override
+        public Relationships.Multiple named(Relationships.WellKnown name) {
+            return wrap(ObservableRelationships.Multiple::new, wrapped.named(name));
+        }
+
+        @Override
+        public Relationships.Single get(String id) throws EntityNotFoundException, RelationNotFoundException {
+            return wrap(ObservableRelationships.Single::new, wrapped.get(id));
+        }
+
+        @Override
+        public Relationships.Multiple getAll(RelationFilter... filters) {
+            return wrap(ObservableRelationships.Multiple::new, wrapped.getAll(filters));
         }
     }
 
-    public static final class Multiple extends ObservableBase<Relationships.Multiple>
+    public static final class Single extends ObservableBase.Single<Relationship, Relationships.Single> 
+            implements Relationships.Single {
+
+        Single(Relationships.Single wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+    }
+
+    public static final class Multiple extends ObservableBase.Multiple<Relationship, Relationships.Multiple>
             implements Relationships.Multiple {
 
         Multiple(Relationships.Multiple wrapped, ObservableContext context) {
@@ -109,50 +133,38 @@ public final class ObservableRelationships {
         }
 
         @Override
-        public Tenants.Read tenants() {
-            //TODO implement
-            return null;
+        public ObservableTenants.Read tenants() {
+            return wrap(ObservableTenants.Read::new, wrapped.tenants());
         }
 
         @Override
-        public Environments.Read environments() {
-            //TODO implement
-            return null;
+        public ObservableEnvironments.Read environments() {
+            return wrap(ObservableEnvironments.Read::new, wrapped.environments());
         }
 
         @Override
-        public Feeds.Read feeds() {
-            //TODO implement
-            return null;
+        public ObservableFeeds.Read feeds() {
+            return wrap(ObservableFeeds.Read::new, wrapped.feeds());
         }
 
         @Override
-        public MetricTypes.Read metricTypes() {
-            //TODO implement
-            return null;
+        public ObservableMetricTypes.Read metricTypes() {
+            return wrap(ObservableMetricTypes.Read::new, wrapped.metricTypes());
         }
 
         @Override
-        public Metrics.Read metrics() {
-            //TODO implement
-            return null;
+        public ObservableMetrics.Read metrics() {
+            return wrap(ObservableMetrics.Read::new, wrapped.metrics());
         }
 
         @Override
-        public Resources.Read resources() {
-            //TODO implement
-            return null;
+        public ObservableResources.Read resources() {
+            return wrap(ObservableResources.Read::new, wrapped.resources());
         }
 
         @Override
-        public ResourceTypes.Read resourceTypes() {
-            //TODO implement
-            return null;
-        }
-
-        @Override
-        public Set<Relationship> entities() {
-            return wrapped.entities();
+        public ObservableResourceTypes.Read resourceTypes() {
+            return wrap(ObservableResourceTypes.Read::new, wrapped.resourceTypes());
         }
     }
 }

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableRelationships.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableRelationships.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.observable;
+
+import org.hawkular.inventory.api.EntityNotFoundException;
+import org.hawkular.inventory.api.Environments;
+import org.hawkular.inventory.api.Feeds;
+import org.hawkular.inventory.api.MetricTypes;
+import org.hawkular.inventory.api.Metrics;
+import org.hawkular.inventory.api.RelationNotFoundException;
+import org.hawkular.inventory.api.Relationships;
+import org.hawkular.inventory.api.ResourceTypes;
+import org.hawkular.inventory.api.Resources;
+import org.hawkular.inventory.api.Tenants;
+import org.hawkular.inventory.api.filters.RelationFilter;
+import org.hawkular.inventory.api.model.Entity;
+import org.hawkular.inventory.api.model.Relationship;
+
+import java.util.Set;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+public final class ObservableRelationships {
+
+    public static final class ReadWrite extends ObservableBase<Relationships.ReadWrite>
+            implements Relationships.ReadWrite {
+
+        ReadWrite(Relationships.ReadWrite wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        public Relationships.Multiple named(String name) {
+            return wrap(Multiple::new, wrapped.named(name));
+        }
+
+        @Override
+        public Relationships.Multiple named(Relationships.WellKnown name) {
+            return wrap(Multiple::new, wrapped.named(name));
+        }
+
+        @Override
+        public Relationships.Single get(String id) throws EntityNotFoundException, RelationNotFoundException {
+            return wrap(Single::new, wrapped.get(id));
+        }
+
+        @Override
+        public Relationships.Multiple getAll(RelationFilter... filters) {
+            return wrap(Multiple::new, wrapped.getAll(filters));
+        }
+
+        @Override
+        public Relationships.Single linkWith(String name, Entity targetOrSource) throws IllegalArgumentException {
+            return wrapAndNotify(Single::new, wrapped.linkWith(name, targetOrSource), Interest.Action.CREATE);
+        }
+
+        @Override
+        public Relationships.Single linkWith(Relationships.WellKnown name, Entity targetOrSource) throws IllegalArgumentException {
+            return linkWith(name.name(), targetOrSource);
+        }
+
+        @Override
+        public void update(Relationship relationship) throws RelationNotFoundException {
+            wrapped.update(relationship);
+            notify(relationship, Interest.Action.UPDATE);
+        }
+
+        @Override
+        public void delete(String id) throws RelationNotFoundException {
+            Relationship r = get(id).entity();
+            wrapped.delete(id);
+            notify(r, Interest.Action.DELETE);
+        }
+    }
+
+    public static final class Single extends ObservableBase<Relationships.Single> implements Relationships.Single {
+
+        Single(Relationships.Single wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        public Relationship entity() {
+            return wrapped.entity();
+        }
+    }
+
+    public static final class Multiple extends ObservableBase<Relationships.Multiple>
+            implements Relationships.Multiple {
+
+        Multiple(Relationships.Multiple wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        public Tenants.Read tenants() {
+            //TODO implement
+            return null;
+        }
+
+        @Override
+        public Environments.Read environments() {
+            //TODO implement
+            return null;
+        }
+
+        @Override
+        public Feeds.Read feeds() {
+            //TODO implement
+            return null;
+        }
+
+        @Override
+        public MetricTypes.Read metricTypes() {
+            //TODO implement
+            return null;
+        }
+
+        @Override
+        public Metrics.Read metrics() {
+            //TODO implement
+            return null;
+        }
+
+        @Override
+        public Resources.Read resources() {
+            //TODO implement
+            return null;
+        }
+
+        @Override
+        public ResourceTypes.Read resourceTypes() {
+            //TODO implement
+            return null;
+        }
+
+        @Override
+        public Set<Relationship> entities() {
+            return wrapped.entities();
+        }
+    }
+}

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableRelationships.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableRelationships.java
@@ -19,6 +19,7 @@ package org.hawkular.inventory.api.observable;
 import org.hawkular.inventory.api.EntityNotFoundException;
 import org.hawkular.inventory.api.RelationNotFoundException;
 import org.hawkular.inventory.api.Relationships;
+import org.hawkular.inventory.api.ResolvableToSingle;
 import org.hawkular.inventory.api.filters.RelationFilter;
 import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.model.Relationship;
@@ -59,7 +60,7 @@ public final class ObservableRelationships {
         @Override
         public Relationships.Single linkWith(String name, Entity targetOrSource) throws IllegalArgumentException {
             return wrapAndNotify(ObservableRelationships.Single::new, wrapped.linkWith(name, targetOrSource),
-                    Action.create());
+                    ResolvableToSingle::entity, Action.created());
         }
 
         @Override
@@ -71,14 +72,14 @@ public final class ObservableRelationships {
         @Override
         public void update(Relationship relationship) throws RelationNotFoundException {
             wrapped.update(relationship);
-            notify(relationship, Action.update());
+            notify(relationship, relationship, Action.updated());
         }
 
         @Override
         public void delete(String id) throws RelationNotFoundException {
             Relationship r = get(id).entity();
             wrapped.delete(id);
-            notify(r, Action.delete());
+            notify(r, Action.deleted());
         }
     }
 

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableRelationships.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableRelationships.java
@@ -17,20 +17,11 @@
 package org.hawkular.inventory.api.observable;
 
 import org.hawkular.inventory.api.EntityNotFoundException;
-import org.hawkular.inventory.api.Environments;
-import org.hawkular.inventory.api.Feeds;
-import org.hawkular.inventory.api.MetricTypes;
-import org.hawkular.inventory.api.Metrics;
 import org.hawkular.inventory.api.RelationNotFoundException;
 import org.hawkular.inventory.api.Relationships;
-import org.hawkular.inventory.api.ResourceTypes;
-import org.hawkular.inventory.api.Resources;
-import org.hawkular.inventory.api.Tenants;
 import org.hawkular.inventory.api.filters.RelationFilter;
 import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.model.Relationship;
-
-import java.util.Set;
 
 /**
  * @author Lukas Krejci
@@ -67,11 +58,13 @@ public final class ObservableRelationships {
 
         @Override
         public Relationships.Single linkWith(String name, Entity targetOrSource) throws IllegalArgumentException {
-            return wrapAndNotify(ObservableRelationships.Single::new, wrapped.linkWith(name, targetOrSource), Action.create());
+            return wrapAndNotify(ObservableRelationships.Single::new, wrapped.linkWith(name, targetOrSource),
+                    Action.create());
         }
 
         @Override
-        public Relationships.Single linkWith(Relationships.WellKnown name, Entity targetOrSource) throws IllegalArgumentException {
+        public Relationships.Single linkWith(Relationships.WellKnown name, Entity targetOrSource)
+                throws IllegalArgumentException {
             return linkWith(name.name(), targetOrSource);
         }
 
@@ -117,7 +110,7 @@ public final class ObservableRelationships {
         }
     }
 
-    public static final class Single extends ObservableBase.Single<Relationship, Relationships.Single> 
+    public static final class Single extends ObservableBase.SingleBase<Relationship, Relationships.Single>
             implements Relationships.Single {
 
         Single(Relationships.Single wrapped, ObservableContext context) {
@@ -125,7 +118,7 @@ public final class ObservableRelationships {
         }
     }
 
-    public static final class Multiple extends ObservableBase.Multiple<Relationship, Relationships.Multiple>
+    public static final class Multiple extends ObservableBase.MultipleBase<Relationship, Relationships.Multiple>
             implements Relationships.Multiple {
 
         Multiple(Relationships.Multiple wrapped, ObservableContext context) {

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableResourceTypes.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableResourceTypes.java
@@ -16,17 +16,9 @@
  */
 package org.hawkular.inventory.api.observable;
 
-import org.hawkular.inventory.api.EntityAlreadyExistsException;
-import org.hawkular.inventory.api.EntityNotFoundException;
-import org.hawkular.inventory.api.MetricTypes;
-import org.hawkular.inventory.api.RelationNotFoundException;
-import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.ResourceTypes;
-import org.hawkular.inventory.api.Resources;
-import org.hawkular.inventory.api.filters.Filter;
 import org.hawkular.inventory.api.model.ResourceType;
 
-import java.util.Set;
 import java.util.function.BiFunction;
 
 /**
@@ -93,8 +85,8 @@ public final class ObservableResourceTypes {
         }
 
         @Override
-        public ObservableMetricTypes.ReadRelate metricTypes() {
-            return wrap(ObservableMetricTypes.ReadRelate::new, wrapped.metricTypes());
+        public ObservableMetricTypes.ReadAssociate metricTypes() {
+            return wrap(ObservableMetricTypes.ReadAssociate::new, wrapped.metricTypes());
         }
     }
 

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableResourceTypes.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableResourceTypes.java
@@ -33,7 +33,7 @@ import java.util.function.BiFunction;
  * @author Lukas Krejci
  * @since 0.0.1
  */
-public class ObservableResourceTypes {
+public final class ObservableResourceTypes {
 
     private ObservableResourceTypes() {
 
@@ -50,12 +50,12 @@ public class ObservableResourceTypes {
 
         @Override
         protected BiFunction<ResourceTypes.Single, ObservableContext, ? extends ResourceTypes.Single> singleCtor() {
-            return Single::new;
+            return ObservableResourceTypes.Single::new;
         }
 
         @Override
         protected BiFunction<ResourceTypes.Multiple, ObservableContext, ? extends ResourceTypes.Multiple> multipleCtor() {
-            return Multiple::new;
+            return ObservableResourceTypes.Multiple::new;
         }
     }
 
@@ -71,84 +71,48 @@ public class ObservableResourceTypes {
 
         @Override
         protected BiFunction<ResourceTypes.Single, ObservableContext, ? extends ResourceTypes.Single> singleCtor() {
-            return Single::new;
+            return ObservableResourceTypes.Single::new;
         }
 
         @Override
         protected BiFunction<ResourceTypes.Multiple, ObservableContext, ? extends ResourceTypes.Multiple> multipleCtor() {
-            return Multiple::new;
+            return ObservableResourceTypes.Multiple::new;
         }
     }
 
-    public static final class Single extends ObservableBase<ResourceTypes.Single> implements ResourceTypes.Single {
+    public static final class Single extends ObservableBase.RelatableSingle<ResourceType, ResourceTypes.Single> 
+            implements ResourceTypes.Single {
 
         Single(ResourceTypes.Single wrapped, ObservableContext context) {
             super(wrapped, context);
         }
 
         @Override
-        public Resources.Read resources() {
-            //TODO implement
-            return null;
+        public ObservableResources.Read resources() {
+            return wrap(ObservableResources.Read::new, wrapped.resources());
         }
 
         @Override
-        public MetricTypes.ReadRelate metricTypes() {
-            //TODO implement
-            return null;
-        }
-
-        @Override
-        public Relationships.ReadWrite relationships() {
-            //TODO implement
-            return null;
-        }
-
-        @Override
-        public Relationships.ReadWrite relationships(Relationships.Direction direction) {
-            //TODO implement
-            return null;
-        }
-
-        @Override
-        public ResourceType entity() {
-            return wrapped.entity();
+        public ObservableMetricTypes.ReadRelate metricTypes() {
+            return wrap(ObservableMetricTypes.ReadRelate::new, wrapped.metricTypes());
         }
     }
 
-    public static final class Multiple extends ObservableBase<ResourceTypes.Multiple> implements ResourceTypes.Multiple {
+    public static final class Multiple extends ObservableBase.RelatableMultiple<ResourceType, ResourceTypes.Multiple>
+            implements ResourceTypes.Multiple {
 
         Multiple(ResourceTypes.Multiple wrapped, ObservableContext context) {
             super(wrapped, context);
         }
 
         @Override
-        public Resources.Read resources() {
-            //TODO implement
-            return null;
+        public ObservableResources.Read resources() {
+            return wrap(ObservableResources.Read::new, wrapped.resources());
         }
 
         @Override
-        public MetricTypes.Read metricTypes() {
-            //TODO implement
-            return null;
-        }
-
-        @Override
-        public Relationships.Read relationships() {
-            //TODO implement
-            return null;
-        }
-
-        @Override
-        public Relationships.Read relationships(Relationships.Direction direction) {
-            //TODO implement
-            return null;
-        }
-
-        @Override
-        public Set<ResourceType> entities() {
-            return wrapped.entities();
+        public ObservableMetricTypes.Read metricTypes() {
+            return wrap(ObservableMetricTypes.Read::new, wrapped.metricTypes());
         }
     }
 }

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableResourceTypes.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableResourceTypes.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.observable;
+
+import org.hawkular.inventory.api.EntityAlreadyExistsException;
+import org.hawkular.inventory.api.EntityNotFoundException;
+import org.hawkular.inventory.api.MetricTypes;
+import org.hawkular.inventory.api.RelationNotFoundException;
+import org.hawkular.inventory.api.Relationships;
+import org.hawkular.inventory.api.ResourceTypes;
+import org.hawkular.inventory.api.Resources;
+import org.hawkular.inventory.api.filters.Filter;
+import org.hawkular.inventory.api.model.ResourceType;
+
+import java.util.Set;
+import java.util.function.BiFunction;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+public class ObservableResourceTypes {
+
+    private ObservableResourceTypes() {
+
+    }
+
+    public static final class Read
+            extends ObservableBase.Read<ResourceTypes.Single, ResourceTypes.Multiple, ResourceTypes.Read>
+            implements ResourceTypes.Read {
+
+
+        Read(ResourceTypes.Read wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        protected BiFunction<ResourceTypes.Single, ObservableContext, ? extends ResourceTypes.Single> singleCtor() {
+            return Single::new;
+        }
+
+        @Override
+        protected BiFunction<ResourceTypes.Multiple, ObservableContext, ? extends ResourceTypes.Multiple> multipleCtor() {
+            return Multiple::new;
+        }
+    }
+
+    public static final class ReadWrite
+            extends ObservableBase.ReadWrite<ResourceType, ResourceType.Blueprint, ResourceTypes.Single,
+                ResourceTypes.Multiple, ResourceTypes.ReadWrite>
+            implements ResourceTypes.ReadWrite {
+
+
+        ReadWrite(ResourceTypes.ReadWrite wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        protected BiFunction<ResourceTypes.Single, ObservableContext, ? extends ResourceTypes.Single> singleCtor() {
+            return Single::new;
+        }
+
+        @Override
+        protected BiFunction<ResourceTypes.Multiple, ObservableContext, ? extends ResourceTypes.Multiple> multipleCtor() {
+            return Multiple::new;
+        }
+    }
+
+    public static final class Single extends ObservableBase<ResourceTypes.Single> implements ResourceTypes.Single {
+
+        Single(ResourceTypes.Single wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        public Resources.Read resources() {
+            //TODO implement
+            return null;
+        }
+
+        @Override
+        public MetricTypes.ReadRelate metricTypes() {
+            //TODO implement
+            return null;
+        }
+
+        @Override
+        public Relationships.ReadWrite relationships() {
+            //TODO implement
+            return null;
+        }
+
+        @Override
+        public Relationships.ReadWrite relationships(Relationships.Direction direction) {
+            //TODO implement
+            return null;
+        }
+
+        @Override
+        public ResourceType entity() {
+            return wrapped.entity();
+        }
+    }
+
+    public static final class Multiple extends ObservableBase<ResourceTypes.Multiple> implements ResourceTypes.Multiple {
+
+        Multiple(ResourceTypes.Multiple wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        public Resources.Read resources() {
+            //TODO implement
+            return null;
+        }
+
+        @Override
+        public MetricTypes.Read metricTypes() {
+            //TODO implement
+            return null;
+        }
+
+        @Override
+        public Relationships.Read relationships() {
+            //TODO implement
+            return null;
+        }
+
+        @Override
+        public Relationships.Read relationships(Relationships.Direction direction) {
+            //TODO implement
+            return null;
+        }
+
+        @Override
+        public Set<ResourceType> entities() {
+            return wrapped.entities();
+        }
+    }
+}

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableResourceTypes.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableResourceTypes.java
@@ -46,7 +46,9 @@ public final class ObservableResourceTypes {
         }
 
         @Override
-        protected BiFunction<ResourceTypes.Multiple, ObservableContext, ? extends ResourceTypes.Multiple> multipleCtor() {
+        protected BiFunction<ResourceTypes.Multiple, ObservableContext, ? extends ResourceTypes.Multiple>
+            multipleCtor() {
+
             return ObservableResourceTypes.Multiple::new;
         }
     }
@@ -67,12 +69,14 @@ public final class ObservableResourceTypes {
         }
 
         @Override
-        protected BiFunction<ResourceTypes.Multiple, ObservableContext, ? extends ResourceTypes.Multiple> multipleCtor() {
+        protected BiFunction<ResourceTypes.Multiple, ObservableContext, ? extends ResourceTypes.Multiple>
+            multipleCtor() {
+
             return ObservableResourceTypes.Multiple::new;
         }
     }
 
-    public static final class Single extends ObservableBase.RelatableSingle<ResourceType, ResourceTypes.Single> 
+    public static final class Single extends ObservableBase.RelatableSingle<ResourceType, ResourceTypes.Single>
             implements ResourceTypes.Single {
 
         Single(ResourceTypes.Single wrapped, ObservableContext context) {

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableResources.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableResources.java
@@ -74,8 +74,8 @@ public final class ObservableResources {
         }
 
         @Override
-        public ObservableMetrics.ReadRelate metrics() {
-            return wrap(ObservableMetrics.ReadRelate::new, wrapped.metrics());
+        public ObservableMetrics.ReadAssociate metrics() {
+            return wrap(ObservableMetrics.ReadAssociate::new, wrapped.metrics());
         }
     }
 

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableResources.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableResources.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.observable;
+
+import org.hawkular.inventory.api.Resources;
+import org.hawkular.inventory.api.model.Resource;
+
+import java.util.function.BiFunction;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+public final class ObservableResources {
+    private ObservableResources() {
+
+    }
+
+    public static final class Read extends ObservableBase.Read<Resources.Single, Resources.Multiple, Resources.Read>
+        implements Resources.Read {
+
+        Read(Resources.Read wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        protected BiFunction<Resources.Single, ObservableContext, ? extends Resources.Single> singleCtor() {
+            return ObservableResources.Single::new;
+        }
+
+        @Override
+        protected BiFunction<Resources.Multiple, ObservableContext, ? extends Resources.Multiple> multipleCtor() {
+            return ObservableResources.Multiple::new;
+        }
+    }
+
+    public static final class ReadWrite extends ObservableBase.ReadWrite<Resource, Resource.Blueprint, Resources.Single,
+            Resources.Multiple, Resources.ReadWrite> implements Resources.ReadWrite {
+
+        ReadWrite(Resources.ReadWrite wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        protected BiFunction<Resources.Single, ObservableContext, ? extends Resources.Single> singleCtor() {
+            return ObservableResources.Single::new;
+        }
+
+        @Override
+        protected BiFunction<Resources.Multiple, ObservableContext, ? extends Resources.Multiple> multipleCtor() {
+            return ObservableResources.Multiple::new;
+        }
+    }
+
+    public static final class Single extends ObservableBase.RelatableSingle<Resource, Resources.Single>
+        implements Resources.Single {
+
+        Single(Resources.Single wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        public ObservableMetrics.ReadRelate metrics() {
+            return wrap(ObservableMetrics.ReadRelate::new, wrapped.metrics());
+        }
+    }
+
+    public static final class Multiple extends ObservableBase.RelatableMultiple<Resource, Resources.Multiple>
+        implements Resources.Multiple {
+
+        Multiple(Resources.Multiple wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        public ObservableMetrics.Read metrics() {
+            return wrap(ObservableMetrics.Read::new, wrapped.metrics());
+        }
+    }
+}

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableTenants.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableTenants.java
@@ -45,12 +45,12 @@ public final class ObservableTenants {
 
         @Override
         protected BiFunction<Tenants.Single, ObservableContext, ? extends Tenants.Single> singleCtor() {
-            return Single::new;
+            return ObservableTenants.Single::new;
         }
 
         @Override
         protected BiFunction<Tenants.Multiple, ObservableContext, ? extends Tenants.Multiple> multipleCtor() {
-            return Multiple::new;
+            return ObservableTenants.Multiple::new;
         }
     }
 
@@ -64,96 +64,58 @@ public final class ObservableTenants {
 
         @Override
         protected BiFunction<Tenants.Single, ObservableContext, ? extends Tenants.Single> singleCtor() {
-            return Single::new;
+            return ObservableTenants.Single::new;
         }
 
         @Override
         protected BiFunction<Tenants.Multiple, ObservableContext, ? extends Tenants.Multiple> multipleCtor() {
-            return Multiple::new;
+            return ObservableTenants.Multiple::new;
         }
     }
 
-    public static final class Single extends ObservableBase<Tenants.Single> implements Tenants.Single {
+    public static final class Single extends ObservableBase.RelatableSingle<Tenant, Tenants.Single> 
+            implements Tenants.Single {
 
         Single(Tenants.Single wrapped, ObservableContext context) {
             super(wrapped, context);
         }
 
         @Override
-        public ResourceTypes.ReadWrite resourceTypes() {
-            // return new ObservableResourceTypes.ReadWrite(wrapped.resourceTypes(), context);
-            return null;
+        public ObservableResourceTypes.ReadWrite resourceTypes() {
+            return wrap(ObservableResourceTypes.ReadWrite::new, wrapped.resourceTypes());
         }
 
         @Override
-        public MetricTypes.ReadWrite metricTypes() {
-            // return new ObservableMetricTypes.ReadWrite(wrapped.metricTypes(), context);
-            return null;
+        public ObservableMetricTypes.ReadWrite metricTypes() {
+            return wrap(ObservableMetricTypes.ReadWrite::new, wrapped.metricTypes());
         }
 
         @Override
-        public Environments.ReadWrite environments() {
-            // return new ObservableEnvironments.ReadWrite(wrapped.environments(), context);
-            return null;
-        }
-
-        @Override
-        public Relationships.ReadWrite relationships() {
-            // return new ObservableRelationships.ReadWrite(wrapped.relationships(), context);
-            return null;
-        }
-
-        @Override
-        public Relationships.ReadWrite relationships(Relationships.Direction direction) {
-            // return new ObservableRelationships.ReadWrite(wrapped.relationships(direction), context);
-            return null;
-        }
-
-        @Override
-        public Tenant entity() {
-            return wrapped.entity();
+        public ObservableEnvironments.ReadWrite environments() {
+            return wrap(ObservableEnvironments.ReadWrite::new, wrapped.environments());
         }
     }
 
-    public static final class Multiple extends ObservableBase<Tenants.Multiple> implements Tenants.Multiple {
+    public static final class Multiple extends ObservableBase.RelatableMultiple<Tenant, Tenants.Multiple>
+            implements Tenants.Multiple {
 
         Multiple(Tenants.Multiple wrapped, ObservableContext context) {
             super(wrapped, context);
         }
 
         @Override
-        public ResourceTypes.Read resourceTypes() {
-            // return new ObservableResourceTypes.Read(wrapped.resourceTypes(), context);
-            return null;
+        public ObservableResourceTypes.Read resourceTypes() {
+            return wrap(ObservableResourceTypes.Read::new, wrapped.resourceTypes());
         }
 
         @Override
-        public MetricTypes.Read metricTypes() {
-            // return new ObservableMetricTypes.Read(wrapped.metricTypes(), context);
-            return null;
+        public ObservableMetricTypes.Read metricTypes() {
+            return wrap(ObservableMetricTypes.Read::new, wrapped.metricTypes());
         }
 
         @Override
-        public Environments.Read environments() {
-            // return new ObservableEnvironments.Read(wrapped.environments(), context);
-            return null;
-        }
-
-        @Override
-        public Relationships.Read relationships() {
-            // return new ObservableRelationships.Read(wrapped.relationships(), context);
-            return null;
-        }
-
-        @Override
-        public Relationships.Read relationships(Relationships.Direction direction) {
-            // return new ObservableRelationships.Read(wrapped.relationships(direction), context);
-            return null;
-        }
-
-        @Override
-        public Set<Tenant> entities() {
-            return wrapped.entities();
+        public ObservableEnvironments.Read environments() {
+            return wrap(ObservableEnvironments.Read::new, wrapped.environments());
         }
     }
 }

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableTenants.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableTenants.java
@@ -16,14 +16,9 @@
  */
 package org.hawkular.inventory.api.observable;
 
-import org.hawkular.inventory.api.Environments;
-import org.hawkular.inventory.api.MetricTypes;
-import org.hawkular.inventory.api.Relationships;
-import org.hawkular.inventory.api.ResourceTypes;
 import org.hawkular.inventory.api.Tenants;
 import org.hawkular.inventory.api.model.Tenant;
 
-import java.util.Set;
 import java.util.function.BiFunction;
 
 /**
@@ -73,7 +68,7 @@ public final class ObservableTenants {
         }
     }
 
-    public static final class Single extends ObservableBase.RelatableSingle<Tenant, Tenants.Single> 
+    public static final class Single extends ObservableBase.RelatableSingle<Tenant, Tenants.Single>
             implements Tenants.Single {
 
         Single(Tenants.Single wrapped, ObservableContext context) {

--- a/api/src/main/java/org/hawkular/inventory/api/observable/ObservableTenants.java
+++ b/api/src/main/java/org/hawkular/inventory/api/observable/ObservableTenants.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.observable;
+
+import org.hawkular.inventory.api.Environments;
+import org.hawkular.inventory.api.MetricTypes;
+import org.hawkular.inventory.api.Relationships;
+import org.hawkular.inventory.api.ResourceTypes;
+import org.hawkular.inventory.api.Tenants;
+import org.hawkular.inventory.api.model.Tenant;
+
+import java.util.Set;
+import java.util.function.BiFunction;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+public final class ObservableTenants {
+
+    private ObservableTenants() {
+
+    }
+
+    public static final class Read extends ObservableBase.Read<Tenants.Single, Tenants.Multiple, Tenants.Read>
+            implements Tenants.Read {
+
+        Read(Tenants.Read wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        protected BiFunction<Tenants.Single, ObservableContext, ? extends Tenants.Single> singleCtor() {
+            return Single::new;
+        }
+
+        @Override
+        protected BiFunction<Tenants.Multiple, ObservableContext, ? extends Tenants.Multiple> multipleCtor() {
+            return Multiple::new;
+        }
+    }
+
+    public static final class ReadWrite
+            extends ObservableBase.ReadWrite<Tenant, String, Tenants.Single, Tenants.Multiple, Tenants.ReadWrite>
+            implements Tenants.ReadWrite {
+
+        public ReadWrite(Tenants.ReadWrite wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        protected BiFunction<Tenants.Single, ObservableContext, ? extends Tenants.Single> singleCtor() {
+            return Single::new;
+        }
+
+        @Override
+        protected BiFunction<Tenants.Multiple, ObservableContext, ? extends Tenants.Multiple> multipleCtor() {
+            return Multiple::new;
+        }
+    }
+
+    public static final class Single extends ObservableBase<Tenants.Single> implements Tenants.Single {
+
+        Single(Tenants.Single wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        public ResourceTypes.ReadWrite resourceTypes() {
+            // return new ObservableResourceTypes.ReadWrite(wrapped.resourceTypes(), context);
+            return null;
+        }
+
+        @Override
+        public MetricTypes.ReadWrite metricTypes() {
+            // return new ObservableMetricTypes.ReadWrite(wrapped.metricTypes(), context);
+            return null;
+        }
+
+        @Override
+        public Environments.ReadWrite environments() {
+            // return new ObservableEnvironments.ReadWrite(wrapped.environments(), context);
+            return null;
+        }
+
+        @Override
+        public Relationships.ReadWrite relationships() {
+            // return new ObservableRelationships.ReadWrite(wrapped.relationships(), context);
+            return null;
+        }
+
+        @Override
+        public Relationships.ReadWrite relationships(Relationships.Direction direction) {
+            // return new ObservableRelationships.ReadWrite(wrapped.relationships(direction), context);
+            return null;
+        }
+
+        @Override
+        public Tenant entity() {
+            return wrapped.entity();
+        }
+    }
+
+    public static final class Multiple extends ObservableBase<Tenants.Multiple> implements Tenants.Multiple {
+
+        Multiple(Tenants.Multiple wrapped, ObservableContext context) {
+            super(wrapped, context);
+        }
+
+        @Override
+        public ResourceTypes.Read resourceTypes() {
+            // return new ObservableResourceTypes.Read(wrapped.resourceTypes(), context);
+            return null;
+        }
+
+        @Override
+        public MetricTypes.Read metricTypes() {
+            // return new ObservableMetricTypes.Read(wrapped.metricTypes(), context);
+            return null;
+        }
+
+        @Override
+        public Environments.Read environments() {
+            // return new ObservableEnvironments.Read(wrapped.environments(), context);
+            return null;
+        }
+
+        @Override
+        public Relationships.Read relationships() {
+            // return new ObservableRelationships.Read(wrapped.relationships(), context);
+            return null;
+        }
+
+        @Override
+        public Relationships.Read relationships(Relationships.Direction direction) {
+            // return new ObservableRelationships.Read(wrapped.relationships(direction), context);
+            return null;
+        }
+
+        @Override
+        public Set<Tenant> entities() {
+            return wrapped.entities();
+        }
+    }
+}

--- a/api/src/test/java/org/hawkular/inventory/api/test/InventoryMock.java
+++ b/api/src/test/java/org/hawkular/inventory/api/test/InventoryMock.java
@@ -51,13 +51,13 @@ public class InventoryMock {
 
     public static Metrics.Multiple metricsMultiple;
     public static Metrics.Read metricsRead;
-    public static Metrics.ReadRelate metricsReadRelate;
+    public static Metrics.ReadAssociate metricsReadAssociate;
     public static Metrics.ReadWrite metricsReadWrite;
     public static Metrics.Single metricsSingle;
 
     public static MetricTypes.Multiple metricTypesMultiple;
     public static MetricTypes.Read metricTypesRead;
-    public static MetricTypes.ReadRelate metricTypesReadRelate;
+    public static MetricTypes.ReadAssociate metricTypesReadAssociate;
     public static MetricTypes.ReadWrite metricTypesReadWrite;
     public static MetricTypes.Single metricTypesSingle;
 
@@ -97,13 +97,13 @@ public class InventoryMock {
 
         metricsMultiple = Mockito.mock(Metrics.Multiple.class);
         metricsRead = Mockito.mock(Metrics.Read.class);
-        metricsReadRelate = Mockito.mock(Metrics.ReadRelate.class);
+        metricsReadAssociate = Mockito.mock(Metrics.ReadAssociate.class);
         metricsReadWrite = Mockito.mock(Metrics.ReadWrite.class);
         metricsSingle = Mockito.mock(Metrics.Single.class);
 
         metricTypesMultiple = Mockito.mock(MetricTypes.Multiple.class);
         metricTypesRead = Mockito.mock(MetricTypes.Read.class);
-        metricTypesReadRelate = Mockito.mock(MetricTypes.ReadRelate.class);
+        metricTypesReadAssociate = Mockito.mock(MetricTypes.ReadAssociate.class);
         metricTypesReadWrite = Mockito.mock(MetricTypes.ReadWrite.class);
         metricTypesSingle = Mockito.mock(MetricTypes.Single.class);
 
@@ -160,8 +160,8 @@ public class InventoryMock {
         when(metricsMultiple.relationships(any())).thenReturn(relationshipsRead);
         when(metricsRead.get(any())).thenReturn(metricsSingle);
         when(metricsRead.getAll(anyVararg())).thenReturn(metricsMultiple);
-        when(metricsReadRelate.get(any())).thenReturn(metricsSingle);
-        when(metricsReadRelate.getAll(anyVararg())).thenReturn(metricsMultiple);
+        when(metricsReadAssociate.get(any())).thenReturn(metricsSingle);
+        when(metricsReadAssociate.getAll(anyVararg())).thenReturn(metricsMultiple);
         when(metricsReadWrite.get(any())).thenReturn(metricsSingle);
         when(metricsReadWrite.getAll(anyVararg())).thenReturn(metricsMultiple);
         when(metricsSingle.relationships()).thenReturn(relationshipsReadWrite);
@@ -172,8 +172,8 @@ public class InventoryMock {
         when(metricTypesMultiple.relationships(any())).thenReturn(relationshipsRead);
         when(metricTypesRead.get(any())).thenReturn(metricTypesSingle);
         when(metricTypesRead.getAll(anyVararg())).thenReturn(metricTypesMultiple);
-        when(metricTypesReadRelate.get(any())).thenReturn(metricTypesSingle);
-        when(metricTypesReadRelate.getAll(anyVararg())).thenReturn(metricTypesMultiple);
+        when(metricTypesReadAssociate.get(any())).thenReturn(metricTypesSingle);
+        when(metricTypesReadAssociate.getAll(anyVararg())).thenReturn(metricTypesMultiple);
         when(metricTypesReadWrite.get(any())).thenReturn(metricTypesSingle);
         when(metricTypesReadWrite.getAll(anyVararg())).thenReturn(metricTypesMultiple);
         when(metricTypesSingle.metrics()).thenReturn(metricsRead);
@@ -201,7 +201,7 @@ public class InventoryMock {
         when(resourcesRead.getAll(anyVararg())).thenReturn(resourcesMultiple);
         when(resourcesReadWrite.get(any())).thenReturn(resourcesSingle);
         when(resourcesReadWrite.getAll(anyVararg())).thenReturn(resourcesMultiple);
-        when(resourcesSingle.metrics()).thenReturn(metricsReadRelate);
+        when(resourcesSingle.metrics()).thenReturn(metricsReadAssociate);
         when(resourcesSingle.relationships()).thenReturn(relationshipsReadWrite);
         when(resourcesSingle.relationships(any())).thenReturn(relationshipsReadWrite);
 
@@ -212,7 +212,7 @@ public class InventoryMock {
         when(resourceTypesRead.getAll(anyVararg())).thenReturn(resourceTypesMultiple);
         when(resourceTypesReadWrite.get(any())).thenReturn(resourceTypesSingle);
         when(resourceTypesReadWrite.getAll(anyVararg())).thenReturn(resourceTypesMultiple);
-        when(resourceTypesSingle.metricTypes()).thenReturn(metricTypesReadRelate);
+        when(resourceTypesSingle.metricTypes()).thenReturn(metricTypesReadAssociate);
         when(resourceTypesSingle.relationships()).thenReturn(relationshipsReadWrite);
         when(resourceTypesSingle.relationships(any())).thenReturn(relationshipsReadWrite);
 

--- a/api/src/test/java/org/hawkular/inventory/api/test/InventoryMock.java
+++ b/api/src/test/java/org/hawkular/inventory/api/test/InventoryMock.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.test;
+
+import org.hawkular.inventory.api.Environments;
+import org.hawkular.inventory.api.Feeds;
+import org.hawkular.inventory.api.Inventory;
+import org.hawkular.inventory.api.MetricTypes;
+import org.hawkular.inventory.api.Metrics;
+import org.hawkular.inventory.api.Relationships;
+import org.hawkular.inventory.api.ResourceTypes;
+import org.hawkular.inventory.api.Resources;
+import org.hawkular.inventory.api.Tenants;
+import org.mockito.Mockito;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+public class InventoryMock {
+    public static Inventory inventory;
+
+    public static Environments.Multiple environmentsMultiple;
+    public static Environments.Read environmentsRead;
+    public static Environments.ReadWrite environmentsReadWrite;
+    public static Environments.Single environmentsSingle;
+
+    public static Feeds.Multiple feedsMultiple;
+    public static Feeds.Read feedsRead;
+    public static Feeds.ReadAndRegister feedsReadAndRegister;
+    public static Feeds.Single feedsSingle;
+
+    public static Metrics.Multiple metricsMultiple;
+    public static Metrics.Read metricsRead;
+    public static Metrics.ReadRelate metricsReadRelate;
+    public static Metrics.ReadWrite metricsReadWrite;
+    public static Metrics.Single metricsSingle;
+
+    public static MetricTypes.Multiple metricTypesMultiple;
+    public static MetricTypes.Read metricTypesRead;
+    public static MetricTypes.ReadRelate metricTypesReadRelate;
+    public static MetricTypes.ReadWrite metricTypesReadWrite;
+    public static MetricTypes.Single metricTypesSingle;
+
+    public static Relationships.Multiple relationshipsMultiple;
+    public static Relationships.Read relationshipsRead;
+    public static Relationships.ReadWrite relationshipsReadWrite;
+    public static Relationships.Single relationshipsSingle;
+
+    public static Resources.Multiple resourcesMultiple;
+    public static Resources.Read resourcesRead;
+    public static Resources.ReadWrite resourcesReadWrite;
+    public static Resources.Single resourcesSingle;
+
+    public static ResourceTypes.Multiple resourceTypesMultiple;
+    public static ResourceTypes.Read resourceTypesRead;
+    public static ResourceTypes.ReadWrite resourceTypesReadWrite;
+    public static ResourceTypes.Single resourceTypesSingle;
+
+    public static Tenants.Multiple tenantsMultiple;
+    public static Tenants.Read tenantsRead;
+    public static Tenants.ReadWrite tenantsReadWrite;
+    public static Tenants.Single tenantsSingle;
+
+
+    public static void rewire() {
+        inventory = Mockito.mock(Inventory.class);
+
+        environmentsMultiple = Mockito.mock(Environments.Multiple.class);
+        environmentsRead = Mockito.mock(Environments.Read.class);
+        environmentsReadWrite = Mockito.mock(Environments.ReadWrite.class);
+        environmentsSingle = Mockito.mock(Environments.Single.class);
+
+        feedsMultiple = Mockito.mock(Feeds.Multiple.class);
+        feedsRead = Mockito.mock(Feeds.Read.class);
+        feedsReadAndRegister = Mockito.mock(Feeds.ReadAndRegister.class);
+        feedsSingle = Mockito.mock(Feeds.Single.class);
+
+        metricsMultiple = Mockito.mock(Metrics.Multiple.class);
+        metricsRead = Mockito.mock(Metrics.Read.class);
+        metricsReadRelate = Mockito.mock(Metrics.ReadRelate.class);
+        metricsReadWrite = Mockito.mock(Metrics.ReadWrite.class);
+        metricsSingle = Mockito.mock(Metrics.Single.class);
+
+        metricTypesMultiple = Mockito.mock(MetricTypes.Multiple.class);
+        metricTypesRead = Mockito.mock(MetricTypes.Read.class);
+        metricTypesReadRelate = Mockito.mock(MetricTypes.ReadRelate.class);
+        metricTypesReadWrite = Mockito.mock(MetricTypes.ReadWrite.class);
+        metricTypesSingle = Mockito.mock(MetricTypes.Single.class);
+
+        relationshipsMultiple = Mockito.mock(Relationships.Multiple.class);
+        relationshipsRead = Mockito.mock(Relationships.Read.class);
+        relationshipsReadWrite = Mockito.mock(Relationships.ReadWrite.class);
+        relationshipsSingle = Mockito.mock(Relationships.Single.class);
+
+        resourcesMultiple = Mockito.mock(Resources.Multiple.class);
+        resourcesRead = Mockito.mock(Resources.Read.class);
+        resourcesReadWrite = Mockito.mock(Resources.ReadWrite.class);
+        resourcesSingle = Mockito.mock(Resources.Single.class);
+
+        resourceTypesMultiple = Mockito.mock(ResourceTypes.Multiple.class);
+        resourceTypesRead = Mockito.mock(ResourceTypes.Read.class);
+        resourceTypesReadWrite = Mockito.mock(ResourceTypes.ReadWrite.class);
+        resourceTypesSingle = Mockito.mock(ResourceTypes.Single.class);
+
+        tenantsMultiple = Mockito.mock(Tenants.Multiple.class);
+        tenantsRead = Mockito.mock(Tenants.Read.class);
+        tenantsReadWrite = Mockito.mock(Tenants.ReadWrite.class);
+        tenantsSingle = Mockito.mock(Tenants.Single.class);
+
+        when(inventory.tenants()).thenReturn(tenantsReadWrite);
+
+        when(environmentsMultiple.feeds()).thenReturn(feedsRead);
+        when(environmentsMultiple.metrics()).thenReturn(metricsRead);
+        when(environmentsMultiple.relationships()).thenReturn(relationshipsRead);
+        when(environmentsMultiple.relationships(any())).thenReturn(relationshipsRead);
+        when(environmentsMultiple.resources()).thenReturn(resourcesRead);
+        when(environmentsRead.get(any())).thenReturn(environmentsSingle);
+        when(environmentsRead.getAll(anyVararg())).thenReturn(environmentsMultiple);
+        when(environmentsReadWrite.get(any())).thenReturn(environmentsSingle);
+        when(environmentsReadWrite.getAll(anyVararg())).thenReturn(environmentsMultiple);
+        when(environmentsSingle.feeds()).thenReturn(feedsReadAndRegister);
+        when(environmentsSingle.metrics()).thenReturn(metricsReadWrite);
+        when(environmentsSingle.relationships()).thenReturn(relationshipsReadWrite);
+        when(environmentsSingle.relationships(any())).thenReturn(relationshipsReadWrite);
+        when(environmentsSingle.resources()).thenReturn(resourcesReadWrite);
+
+        when(feedsMultiple.relationships()).thenReturn(relationshipsRead);
+        when(feedsMultiple.relationships(anyVararg())).thenReturn(relationshipsRead);
+        when(feedsMultiple.resources()).thenReturn(resourcesRead);
+        when(feedsRead.get(any())).thenReturn(feedsSingle);
+        when(feedsRead.getAll(anyVararg())).thenReturn(feedsMultiple);
+        when(feedsReadAndRegister.get(any())).thenReturn(feedsSingle);
+        when(feedsReadAndRegister.getAll(anyVararg())).thenReturn(feedsMultiple);
+        when(feedsReadAndRegister.register(any())).thenReturn(feedsSingle);
+        when(feedsSingle.relationships()).thenReturn(relationshipsReadWrite);
+        when(feedsSingle.relationships(any())).thenReturn(relationshipsReadWrite);
+        when(feedsSingle.resources()).thenReturn(resourcesRead);
+
+        when(metricsMultiple.relationships()).thenReturn(relationshipsRead);
+        when(metricsMultiple.relationships(any())).thenReturn(relationshipsRead);
+        when(metricsRead.get(any())).thenReturn(metricsSingle);
+        when(metricsRead.getAll(anyVararg())).thenReturn(metricsMultiple);
+        when(metricsReadRelate.get(any())).thenReturn(metricsSingle);
+        when(metricsReadRelate.getAll(anyVararg())).thenReturn(metricsMultiple);
+        when(metricsReadWrite.get(any())).thenReturn(metricsSingle);
+        when(metricsReadWrite.getAll(anyVararg())).thenReturn(metricsMultiple);
+        when(metricsSingle.relationships()).thenReturn(relationshipsReadWrite);
+        when(metricsSingle.relationships(any())).thenReturn(relationshipsReadWrite);
+
+        when(metricTypesMultiple.metrics()).thenReturn(metricsRead);
+        when(metricTypesMultiple.relationships()).thenReturn(relationshipsRead);
+        when(metricTypesMultiple.relationships(any())).thenReturn(relationshipsRead);
+        when(metricTypesRead.get(any())).thenReturn(metricTypesSingle);
+        when(metricTypesRead.getAll(anyVararg())).thenReturn(metricTypesMultiple);
+        when(metricTypesReadRelate.get(any())).thenReturn(metricTypesSingle);
+        when(metricTypesReadRelate.getAll(anyVararg())).thenReturn(metricTypesMultiple);
+        when(metricTypesReadWrite.get(any())).thenReturn(metricTypesSingle);
+        when(metricTypesReadWrite.getAll(anyVararg())).thenReturn(metricTypesMultiple);
+        when(metricTypesSingle.metrics()).thenReturn(metricsRead);
+        when(metricTypesSingle.relationships()).thenReturn(relationshipsReadWrite);
+        when(metricTypesSingle.relationships(any())).thenReturn(relationshipsReadWrite);
+
+        when(relationshipsMultiple.environments()).thenReturn(environmentsRead);
+        when(relationshipsMultiple.feeds()).thenReturn(feedsRead);
+        when(relationshipsMultiple.metrics()).thenReturn(metricsRead);
+        when(relationshipsMultiple.metricTypes()).thenReturn(metricTypesRead);
+        when(relationshipsMultiple.resources()).thenReturn(resourcesRead);
+        when(relationshipsMultiple.resourceTypes()).thenReturn(resourceTypesRead);
+        when(relationshipsMultiple.tenants()).thenReturn(tenantsRead);
+        when(relationshipsRead.get(any())).thenReturn(relationshipsSingle);
+        when(relationshipsRead.getAll(anyVararg())).thenReturn(relationshipsMultiple);
+        when(relationshipsRead.named(anyString())).thenReturn(relationshipsMultiple);
+        when(relationshipsRead.named(Mockito.<Relationships.WellKnown>any())).thenReturn(relationshipsMultiple);
+        when(relationshipsReadWrite.named(anyString())).thenReturn(relationshipsMultiple);
+        when(relationshipsReadWrite.named(Mockito.<Relationships.WellKnown>any())).thenReturn(relationshipsMultiple);
+
+        when(resourcesMultiple.metrics()).thenReturn(metricsRead);
+        when(resourcesMultiple.relationships()).thenReturn(relationshipsRead);
+        when(resourcesMultiple.relationships(any())).thenReturn(relationshipsRead);
+        when(resourcesRead.get(any())).thenReturn(resourcesSingle);
+        when(resourcesRead.getAll(anyVararg())).thenReturn(resourcesMultiple);
+        when(resourcesReadWrite.get(any())).thenReturn(resourcesSingle);
+        when(resourcesReadWrite.getAll(anyVararg())).thenReturn(resourcesMultiple);
+        when(resourcesSingle.metrics()).thenReturn(metricsReadRelate);
+        when(resourcesSingle.relationships()).thenReturn(relationshipsReadWrite);
+        when(resourcesSingle.relationships(any())).thenReturn(relationshipsReadWrite);
+
+        when(resourceTypesMultiple.metricTypes()).thenReturn(metricTypesRead);
+        when(resourceTypesMultiple.relationships()).thenReturn(relationshipsRead);
+        when(resourceTypesMultiple.relationships(any())).thenReturn(relationshipsRead);
+        when(resourceTypesRead.get(any())).thenReturn(resourceTypesSingle);
+        when(resourceTypesRead.getAll(anyVararg())).thenReturn(resourceTypesMultiple);
+        when(resourceTypesReadWrite.get(any())).thenReturn(resourceTypesSingle);
+        when(resourceTypesReadWrite.getAll(anyVararg())).thenReturn(resourceTypesMultiple);
+        when(resourceTypesSingle.metricTypes()).thenReturn(metricTypesReadRelate);
+        when(resourceTypesSingle.relationships()).thenReturn(relationshipsReadWrite);
+        when(resourceTypesSingle.relationships(any())).thenReturn(relationshipsReadWrite);
+
+        when(tenantsReadWrite.get(anyString())).thenReturn(tenantsSingle);
+        when(tenantsReadWrite.getAll(anyVararg())).thenReturn(tenantsMultiple);
+        when(tenantsRead.get(anyString())).thenReturn(tenantsSingle);
+        when(tenantsRead.getAll(anyVararg())).thenReturn(tenantsMultiple);
+        when(tenantsSingle.environments()).thenReturn(environmentsReadWrite);
+        when(tenantsSingle.metricTypes()).thenReturn(metricTypesReadWrite);
+        when(tenantsSingle.relationships()).thenReturn(relationshipsReadWrite);
+        when(tenantsSingle.relationships(any())).thenReturn(relationshipsReadWrite);
+        when(tenantsSingle.resourceTypes()).thenReturn(resourceTypesReadWrite);
+        when(tenantsMultiple.environments()).thenReturn(environmentsRead);
+        when(tenantsMultiple.metricTypes()).thenReturn(metricTypesRead);
+        when(tenantsMultiple.relationships()).thenReturn(relationshipsRead);
+        when(tenantsMultiple.relationships(any())).thenReturn(relationshipsRead);
+        when(tenantsMultiple.resourceTypes()).thenReturn(resourceTypesRead);
+    }
+}

--- a/api/src/test/java/org/hawkular/inventory/api/test/InventoryMock.java
+++ b/api/src/test/java/org/hawkular/inventory/api/test/InventoryMock.java
@@ -193,6 +193,8 @@ public class InventoryMock {
         when(relationshipsRead.named(Mockito.<Relationships.WellKnown>any())).thenReturn(relationshipsMultiple);
         when(relationshipsReadWrite.named(anyString())).thenReturn(relationshipsMultiple);
         when(relationshipsReadWrite.named(Mockito.<Relationships.WellKnown>any())).thenReturn(relationshipsMultiple);
+        when(relationshipsReadWrite.get(any())).thenReturn(relationshipsSingle);
+        when(relationshipsReadWrite.getAll(anyVararg())).thenReturn(relationshipsMultiple);
 
         when(resourcesMultiple.metrics()).thenReturn(metricsRead);
         when(resourcesMultiple.relationships()).thenReturn(relationshipsRead);

--- a/api/src/test/java/org/hawkular/inventory/api/test/ObservableInventoryTest.java
+++ b/api/src/test/java/org/hawkular/inventory/api/test/ObservableInventoryTest.java
@@ -55,7 +55,7 @@ public class ObservableInventoryTest {
         when(InventoryMock.tenantsSingle.entity()).thenReturn(prototype);
         when(InventoryMock.relationshipsMultiple.entities()).thenReturn(Collections.emptySet());
 
-        runTest(() -> {
+        runTest(Tenant.class, () -> {
             observableInventory.tenants().create("kachny");
             observableInventory.tenants().update(prototype);
             observableInventory.tenants().delete(prototype.getId());
@@ -71,7 +71,7 @@ public class ObservableInventoryTest {
         when(InventoryMock.relationshipsMultiple.entities())
                 .thenReturn(Collections.singleton(new Relationship("r", "contains", new Tenant("t"), prototype)));
 
-        runTest(() -> {
+        runTest(Environment.class, () -> {
             observableInventory.tenants().get("t").environments().create("e");
             observableInventory.tenants().get("t").environments().update(prototype);
             observableInventory.tenants().get("t").environments().delete(prototype.getId());
@@ -80,22 +80,22 @@ public class ObservableInventoryTest {
         observableInventory.observable(Interest.in(Action.copy()).of(Environment.class).build());
     }
 
-    private void runTest(Runnable payload) {
-        List<Tenant> createdTenants = new ArrayList<>();
-        List<Tenant> updatedTenants = new ArrayList<>();
-        List<Tenant> deletedTenants = new ArrayList<>();
+    private <T> void runTest(Class<T> entityClass, Runnable payload) {
+        List<T> createdTenants = new ArrayList<>();
+        List<T> updatedTenants = new ArrayList<>();
+        List<T> deletedTenants = new ArrayList<>();
 
-        Subscription s1 = observableInventory.observable(Interest.inCreate().of(Tenant.class).build())
+        Subscription s1 = observableInventory.observable(Interest.inCreate().of(entityClass).build())
                 .subscribe(createdTenants::add);
 
-        Subscription s2 = observableInventory.observable(Interest.inUpdate().of(Tenant.class).build())
+        Subscription s2 = observableInventory.observable(Interest.inUpdate().of(entityClass).build())
                 .subscribe(updatedTenants::add);
 
-        Subscription s3 = observableInventory.observable(Interest.inDelete().of(Tenant.class).build())
+        Subscription s3 = observableInventory.observable(Interest.inDelete().of(entityClass).build())
                 .subscribe(deletedTenants::add);
 
         //dummy observer just to check that unsubscription works
-        observableInventory.observable(Interest.inCreate().of(Tenant.class).build())
+        observableInventory.observable(Interest.inCreate().of(entityClass).build())
                 .subscribe((t) -> {});
 
         payload.run();
@@ -108,8 +108,8 @@ public class ObservableInventoryTest {
         s2.unsubscribe();
         s3.unsubscribe();
 
-        Assert.assertTrue(observableInventory.hasObservers(Interest.inCreate().of(Tenant.class).build()));
-        Assert.assertFalse(observableInventory.hasObservers(Interest.inUpdate().of(Tenant.class).build()));
-        Assert.assertFalse(observableInventory.hasObservers(Interest.inDelete().of(Tenant.class).build()));
+        Assert.assertTrue(observableInventory.hasObservers(Interest.inCreate().of(entityClass).build()));
+        Assert.assertFalse(observableInventory.hasObservers(Interest.inUpdate().of(entityClass).build()));
+        Assert.assertFalse(observableInventory.hasObservers(Interest.inDelete().of(entityClass).build()));
     }
 }

--- a/api/src/test/java/org/hawkular/inventory/api/test/ObservableInventoryTest.java
+++ b/api/src/test/java/org/hawkular/inventory/api/test/ObservableInventoryTest.java
@@ -16,15 +16,19 @@
  */
 package org.hawkular.inventory.api.test;
 
-import org.junit.Assert;
+import org.hawkular.inventory.api.model.Environment;
+import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.Tenant;
+import org.hawkular.inventory.api.observable.Action;
 import org.hawkular.inventory.api.observable.Interest;
 import org.hawkular.inventory.api.observable.ObservableInventory;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import rx.Subscription;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
@@ -42,18 +46,46 @@ public class ObservableInventoryTest {
         InventoryMock.rewire();
         observableInventory = new ObservableInventory(InventoryMock.inventory);
     }
+
     @Test
     public void testTenants() throws Exception {
         Tenant prototype = new Tenant("kachny");
 
         when(InventoryMock.tenantsReadWrite.create("kachny")).thenReturn(InventoryMock.tenantsSingle);
         when(InventoryMock.tenantsSingle.entity()).thenReturn(prototype);
+        when(InventoryMock.relationshipsMultiple.entities()).thenReturn(Collections.emptySet());
 
+        runTest(() -> {
+            observableInventory.tenants().create("kachny");
+            observableInventory.tenants().update(prototype);
+            observableInventory.tenants().delete(prototype.getId());
+        });
+    }
+
+    @Test
+    public void testEnvironments() throws Exception {
+        Environment prototype = new Environment("t", "e");
+
+        when(InventoryMock.environmentsReadWrite.create("e")).thenReturn(InventoryMock.environmentsSingle);
+        when(InventoryMock.environmentsSingle.entity()).thenReturn(prototype);
+        when(InventoryMock.relationshipsMultiple.entities())
+                .thenReturn(Collections.singleton(new Relationship("r", "contains", new Tenant("t"), prototype)));
+
+        runTest(() -> {
+            observableInventory.tenants().get("t").environments().create("e");
+            observableInventory.tenants().get("t").environments().update(prototype);
+            observableInventory.tenants().get("t").environments().delete(prototype.getId());
+        });
+
+        observableInventory.observable(Interest.in(Action.copy()).of(Environment.class).build());
+    }
+
+    private void runTest(Runnable payload) {
         List<Tenant> createdTenants = new ArrayList<>();
         List<Tenant> updatedTenants = new ArrayList<>();
         List<Tenant> deletedTenants = new ArrayList<>();
 
-        Subscription s1 =observableInventory.observable(Interest.inCreate().of(Tenant.class).build())
+        Subscription s1 = observableInventory.observable(Interest.inCreate().of(Tenant.class).build())
                 .subscribe(createdTenants::add);
 
         Subscription s2 = observableInventory.observable(Interest.inUpdate().of(Tenant.class).build())
@@ -62,21 +94,22 @@ public class ObservableInventoryTest {
         Subscription s3 = observableInventory.observable(Interest.inDelete().of(Tenant.class).build())
                 .subscribe(deletedTenants::add);
 
-        observableInventory.tenants().create("kachny");
-        observableInventory.tenants().update(prototype);
-        observableInventory.tenants().delete(prototype.getId());
+        //dummy observer just to check that unsubscription works
+        observableInventory.observable(Interest.inCreate().of(Tenant.class).build())
+                .subscribe((t) -> {});
+
+        payload.run();
 
         Assert.assertEquals(1, createdTenants.size());
-        Assert.assertEquals(prototype, createdTenants.get(0));
         Assert.assertEquals(1, updatedTenants.size());
-        Assert.assertEquals(prototype, updatedTenants.get(0));
         Assert.assertEquals(1, deletedTenants.size());
-        Assert.assertEquals(prototype, deletedTenants.get(0));
 
-        //this is just for debugging that the interest map in the ObservableContext gets indeed cleared. There's no
-        //direct testing possible as that object is an internal impl. detail of ObservableInventory.
         s1.unsubscribe();
         s2.unsubscribe();
         s3.unsubscribe();
+
+        Assert.assertTrue(observableInventory.hasObservers(Interest.inCreate().of(Tenant.class).build()));
+        Assert.assertFalse(observableInventory.hasObservers(Interest.inUpdate().of(Tenant.class).build()));
+        Assert.assertFalse(observableInventory.hasObservers(Interest.inDelete().of(Tenant.class).build()));
     }
 }

--- a/api/src/test/java/org/hawkular/inventory/api/test/ObservableInventoryTest.java
+++ b/api/src/test/java/org/hawkular/inventory/api/test/ObservableInventoryTest.java
@@ -22,7 +22,7 @@ import org.hawkular.inventory.api.observable.Interest;
 import org.hawkular.inventory.api.observable.ObservableInventory;
 import org.junit.Before;
 import org.junit.Test;
-import rx.Observable;
+import rx.Subscription;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,13 +53,13 @@ public class ObservableInventoryTest {
         List<Tenant> updatedTenants = new ArrayList<>();
         List<Tenant> deletedTenants = new ArrayList<>();
 
-        observableInventory.observable(Interest.inCreate().of(Tenant.class).build())
+        Subscription s1 =observableInventory.observable(Interest.inCreate().of(Tenant.class).build())
                 .subscribe(createdTenants::add);
 
-        observableInventory.observable(Interest.inUpdate().of(Tenant.class).build())
+        Subscription s2 = observableInventory.observable(Interest.inUpdate().of(Tenant.class).build())
                 .subscribe(updatedTenants::add);
 
-        observableInventory.observable(Interest.inDelete().of(Tenant.class).build())
+        Subscription s3 = observableInventory.observable(Interest.inDelete().of(Tenant.class).build())
                 .subscribe(deletedTenants::add);
 
         observableInventory.tenants().create("kachny");
@@ -72,5 +72,11 @@ public class ObservableInventoryTest {
         Assert.assertEquals(prototype, updatedTenants.get(0));
         Assert.assertEquals(1, deletedTenants.size());
         Assert.assertEquals(prototype, deletedTenants.get(0));
+
+        //this is just for debugging that the interest map in the ObservableContext gets indeed cleared. There's no
+        //direct testing possible as that object is an internal impl. detail of ObservableInventory.
+        s1.unsubscribe();
+        s2.unsubscribe();
+        s3.unsubscribe();
     }
 }

--- a/api/src/test/java/org/hawkular/inventory/api/test/ObservableInventoryTest.java
+++ b/api/src/test/java/org/hawkular/inventory/api/test/ObservableInventoryTest.java
@@ -17,15 +17,20 @@
 package org.hawkular.inventory.api.test;
 
 import org.hawkular.inventory.api.model.Environment;
+import org.hawkular.inventory.api.model.Metric;
+import org.hawkular.inventory.api.model.MetricType;
+import org.hawkular.inventory.api.model.MetricUnit;
 import org.hawkular.inventory.api.model.Relationship;
+import org.hawkular.inventory.api.model.Resource;
+import org.hawkular.inventory.api.model.ResourceType;
 import org.hawkular.inventory.api.model.Tenant;
+import org.hawkular.inventory.api.model.Version;
 import org.hawkular.inventory.api.observable.Action;
 import org.hawkular.inventory.api.observable.Interest;
 import org.hawkular.inventory.api.observable.ObservableInventory;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import rx.Observable;
 import rx.Subscription;
 
 import java.util.ArrayList;
@@ -36,6 +41,7 @@ import static org.hawkular.inventory.api.observable.Action.copied;
 import static org.hawkular.inventory.api.observable.Action.created;
 import static org.hawkular.inventory.api.observable.Action.deleted;
 import static org.hawkular.inventory.api.observable.Action.updated;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
 /**
@@ -60,7 +66,7 @@ public class ObservableInventoryTest {
         when(InventoryMock.tenantsSingle.entity()).thenReturn(prototype);
         when(InventoryMock.relationshipsMultiple.entities()).thenReturn(Collections.emptySet());
 
-        runTest(Tenant.class, () -> {
+        runTest(Tenant.class, false, () -> {
             observableInventory.tenants().create("kachny");
             observableInventory.tenants().update(prototype);
             observableInventory.tenants().delete(prototype.getId());
@@ -76,19 +82,120 @@ public class ObservableInventoryTest {
         when(InventoryMock.relationshipsMultiple.entities())
                 .thenReturn(Collections.singleton(new Relationship("r", "contains", new Tenant("t"), prototype)));
 
-        runTest(Environment.class, () -> {
+        runTest(Environment.class, true, () -> {
             observableInventory.tenants().get("t").environments().create("e");
             observableInventory.tenants().get("t").environments().update(prototype);
             observableInventory.tenants().get("t").environments().delete(prototype.getId());
         });
 
-        observableInventory.observable(Interest.in(Environment.class).being(copied()));
+        List<Action.EnvironmentCopy> copied = new ArrayList<>();
+
+        observableInventory.observable(Interest.in(Environment.class).being(copied())).subscribe(copied::add);
+
+        observableInventory.tenants().get("t").environments().copy("1", "2");
+
+        Assert.assertEquals(1, copied.size());
     }
 
-    private <T> void runTest(Class<T> entityClass, Runnable payload) {
+    @Test
+    public void testResourceTypes() throws Exception {
+        ResourceType prototype = new ResourceType("t", "rt", "1.0.0");
+
+        when(InventoryMock.resourceTypesReadWrite.create(any())).thenReturn(InventoryMock.resourceTypesSingle);
+        when(InventoryMock.resourceTypesSingle.entity()).thenReturn(prototype);
+        when(InventoryMock.relationshipsMultiple.entities())
+                .thenReturn(Collections.singleton(new Relationship("r", "contains", new Tenant("t"), prototype)));
+
+        runTest(ResourceType.class, true, () -> {
+            observableInventory.tenants().get("t").resourceTypes()
+                    .create(new ResourceType.Blueprint("rt", new Version("1.0")));
+            observableInventory.tenants().get("t").resourceTypes().update(prototype);
+            observableInventory.tenants().get("t").resourceTypes().delete(prototype.getId());
+        });
+
+        when(InventoryMock.metricTypesReadAssociate.associate("mt"))
+                .thenReturn(new Relationship("rt", "owns", prototype, new MetricType("t", "mt")));
+
+        List<Relationship> createdRelatonships = new ArrayList<>();
+
+        observableInventory.observable(Interest.in(Relationship.class).<Relationship>being(created()))
+                .subscribe(createdRelatonships::add);
+
+        observableInventory.tenants().get("t").resourceTypes().get("rt").metricTypes().associate("mt");
+
+        Assert.assertEquals(1, createdRelatonships.size());
+    }
+
+    @Test
+    public void testMetricTypes() throws Exception {
+        MetricType prototype = new MetricType("t", "rt", MetricUnit.BYTE);
+
+        when(InventoryMock.metricTypesReadWrite.create(any())).thenReturn(InventoryMock.metricTypesSingle);
+        when(InventoryMock.metricTypesSingle.entity()).thenReturn(prototype);
+        when(InventoryMock.relationshipsMultiple.entities())
+                .thenReturn(Collections.singleton(new Relationship("r", "contains", new Tenant("t"), prototype)));
+
+        runTest(MetricType.class, true, () -> {
+            observableInventory.tenants().get("t").metricTypes()
+                    .create(new MetricType.Blueprint("rt", MetricUnit.BYTE));
+            observableInventory.tenants().get("t").metricTypes().update(prototype);
+            observableInventory.tenants().get("t").metricTypes().delete(prototype.getId());
+        });
+    }
+
+    @Test
+    public void testMetrics() throws Exception {
+        Metric prototype = new Metric("t", "e", "m", new MetricType("t", "mt"));
+
+        when(InventoryMock.metricsReadWrite.create(any())).thenReturn(InventoryMock.metricsSingle);
+        when(InventoryMock.metricsSingle.entity()).thenReturn(prototype);
+        when(InventoryMock.relationshipsMultiple.entities())
+                .thenReturn(Collections.singleton(new Relationship("r", "contains", new Environment("t", "e"),
+                        prototype)));
+
+        runTest(Metric.class, true, () -> {
+            observableInventory.tenants().get("t").environments().get("e").metrics()
+                    .create(new Metric.Blueprint(new MetricType("t", "mt"), "m"));
+            observableInventory.tenants().get("t").environments().get("e").metrics().update(prototype);
+            observableInventory.tenants().get("t").environments().get("e").metrics().delete(prototype.getId());
+        });
+    }
+
+    @Test
+    public void testResources() throws Exception {
+        Resource prototype = new Resource("t", "e", "r", new ResourceType("t", "rt", "1.0"));
+
+        when(InventoryMock.resourcesReadWrite.create(any())).thenReturn(InventoryMock.resourcesSingle);
+        when(InventoryMock.resourcesSingle.entity()).thenReturn(prototype);
+        when(InventoryMock.relationshipsMultiple.entities())
+                .thenReturn(Collections.singleton(new Relationship("r", "contains", new Environment("t", "e"), prototype)));
+
+        runTest(Resource.class, true, () -> {
+            observableInventory.tenants().get("t").environments().get("e").resources()
+                    .create(new Resource.Blueprint("r", new ResourceType("t", "rt", "1.0")));
+            observableInventory.tenants().get("t").environments().get("e").resources().update(prototype);
+            observableInventory.tenants().get("t").environments().get("e").resources().delete(prototype.getId());
+        });
+
+        when(InventoryMock.metricsReadAssociate.associate("m"))
+                .thenReturn(new Relationship("asdf", "owns", prototype,
+                        new Metric("t", "e", "mt", new MetricType("t", "mt"))));
+
+        List<Relationship> createdRelatonships = new ArrayList<>();
+
+        observableInventory.observable(Interest.in(Relationship.class).<Relationship>being(created()))
+                .subscribe(createdRelatonships::add);
+
+        observableInventory.tenants().get("t").environments().get("e").resources().get("rt").metrics().associate("m");
+
+        Assert.assertEquals(1, createdRelatonships.size());
+    }
+
+    private <T> void runTest(Class<T> entityClass, boolean watchRelationships, Runnable payload) {
         List<T> createdTenants = new ArrayList<>();
         List<T> updatedTenants = new ArrayList<>();
         List<T> deletedTenants = new ArrayList<>();
+        List<Relationship> createdRelationships = new ArrayList<>();
 
         Subscription s1 = observableInventory.observable(Interest.in(entityClass).<T>being(created()))
                 .subscribe(createdTenants::add);
@@ -99,6 +206,9 @@ public class ObservableInventoryTest {
         Subscription s3 = observableInventory.observable(Interest.in(entityClass).<T>being(deleted()))
                 .subscribe(deletedTenants::add);
 
+        observableInventory.observable(Interest.in(Relationship.class).<Relationship>being(created()))
+                .subscribe(createdRelationships::add);
+
         //dummy observer just to check that unsubscription works
         observableInventory.observable(Interest.in(entityClass).<T>being(created())).subscribe((t) -> {});
 
@@ -107,6 +217,9 @@ public class ObservableInventoryTest {
         Assert.assertEquals(1, createdTenants.size());
         Assert.assertEquals(1, updatedTenants.size());
         Assert.assertEquals(1, deletedTenants.size());
+        if (watchRelationships) {
+            Assert.assertEquals(1, createdRelationships.size());
+        }
 
         s1.unsubscribe();
         s2.unsubscribe();

--- a/api/src/test/java/org/hawkular/inventory/api/test/ObservableInventoryTest.java
+++ b/api/src/test/java/org/hawkular/inventory/api/test/ObservableInventoryTest.java
@@ -168,7 +168,8 @@ public class ObservableInventoryTest {
         when(InventoryMock.resourcesReadWrite.create(any())).thenReturn(InventoryMock.resourcesSingle);
         when(InventoryMock.resourcesSingle.entity()).thenReturn(prototype);
         when(InventoryMock.relationshipsMultiple.entities())
-                .thenReturn(Collections.singleton(new Relationship("r", "contains", new Environment("t", "e"), prototype)));
+                .thenReturn(Collections.singleton(new Relationship("r", "contains", new Environment("t", "e"),
+                        prototype)));
 
         runTest(Resource.class, true, () -> {
             observableInventory.tenants().get("t").environments().get("e").resources()

--- a/api/src/test/java/org/hawkular/inventory/api/test/ObservableInventoryTest.java
+++ b/api/src/test/java/org/hawkular/inventory/api/test/ObservableInventoryTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.test;
+
+import org.junit.Assert;
+import org.hawkular.inventory.api.model.Tenant;
+import org.hawkular.inventory.api.observable.Interest;
+import org.hawkular.inventory.api.observable.ObservableInventory;
+import org.junit.Before;
+import org.junit.Test;
+import rx.Observable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+public class ObservableInventoryTest {
+
+    private ObservableInventory observableInventory;
+
+    @Before
+    public void init() {
+        InventoryMock.rewire();
+        observableInventory = new ObservableInventory(InventoryMock.inventory);
+    }
+    @Test
+    public void testTenants() throws Exception {
+        Tenant prototype = new Tenant("kachny");
+
+        when(InventoryMock.tenantsReadWrite.create("kachny")).thenReturn(InventoryMock.tenantsSingle);
+        when(InventoryMock.tenantsSingle.entity()).thenReturn(prototype);
+
+        List<Tenant> createdTenants = new ArrayList<>();
+        List<Tenant> updatedTenants = new ArrayList<>();
+        List<Tenant> deletedTenants = new ArrayList<>();
+
+        observableInventory.observable(Interest.inCreate().of(Tenant.class).build())
+                .subscribe(createdTenants::add);
+
+        observableInventory.observable(Interest.inUpdate().of(Tenant.class).build())
+                .subscribe(updatedTenants::add);
+
+        observableInventory.observable(Interest.inDelete().of(Tenant.class).build())
+                .subscribe(deletedTenants::add);
+
+        observableInventory.tenants().create("kachny");
+        observableInventory.tenants().update(prototype);
+        observableInventory.tenants().delete(prototype.getId());
+
+        Assert.assertEquals(1, createdTenants.size());
+        Assert.assertEquals(prototype, createdTenants.get(0));
+        Assert.assertEquals(1, updatedTenants.size());
+        Assert.assertEquals(prototype, updatedTenants.get(0));
+        Assert.assertEquals(1, deletedTenants.size());
+        Assert.assertEquals(prototype, deletedTenants.get(0));
+    }
+}

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/AbstractBrowser.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/AbstractBrowser.java
@@ -53,12 +53,13 @@ abstract class AbstractBrowser<E extends Entity> extends AbstractSourcedGraphSer
 
         return ret;
     }
-    public RelationshipService relationships() {
+
+    public RelationshipService<E> relationships() {
         return relationships(Relationships.Direction.outgoing);
     }
 
-    public RelationshipService relationships(Relationships.Direction direction) {
-        return new RelationshipService(context, new PathContext(path, Filter.all()), entityClass, direction);
+    public RelationshipService<E> relationships(Relationships.Direction direction) {
+        return new RelationshipService<>(context, new PathContext(path, Filter.all()), entityClass, direction);
     }
 
     @Override

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/AbstractSourcedGraphService.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/AbstractSourcedGraphService.java
@@ -30,7 +30,6 @@ import org.hawkular.inventory.api.filters.With;
 import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.model.Relationship;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/AbstractSourcedGraphService.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/AbstractSourcedGraphService.java
@@ -21,10 +21,14 @@ import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Vertex;
 import org.hawkular.inventory.api.EntityNotFoundException;
+import org.hawkular.inventory.api.RelationAlreadyExistsException;
+import org.hawkular.inventory.api.RelationNotFoundException;
 import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.filters.Filter;
+import org.hawkular.inventory.api.filters.Related;
 import org.hawkular.inventory.api.filters.With;
 import org.hawkular.inventory.api.model.Entity;
+import org.hawkular.inventory.api.model.Relationship;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -186,16 +190,47 @@ abstract class AbstractSourcedGraphService<Single, Multiple, E extends Entity, B
 
     }
 
-    protected void addRelationship(Constants.Type typeInSource, Relationships.WellKnown rel, Iterable<Vertex> others) {
+    protected Relationship addAssociation(Constants.Type typeInSource, Relationships.WellKnown rel,
+                                          Iterable<Vertex> others) {
+        //noinspection LoopStatementThatDoesntLoop
         for (Vertex v : source().hasType(typeInSource)) {
+            //noinspection LoopStatementThatDoesntLoop
             for (Vertex o : others) {
-                v.addEdge(rel.name(), o);
+                for (Edge e : v.getEdges(Direction.OUT, rel.name())) {
+                    if (e.getVertex(Direction.IN).equals(o)) {
+                        throw new RelationAlreadyExistsException(rel.name(), FilterApplicator.filters(path));
+                    }
+                }
+
+                Edge e = v.addEdge(rel.name(), o);
+
+                return new Relationship(getUid(e), e.getLabel(), convert(e.getVertex(Direction.OUT)),
+                        convert(e.getVertex(Direction.IN)));
             }
+
+            throw new EntityNotFoundException(entityClass,
+                    FilterApplicator.filters(FilterApplicator.from(path).andPath(Related.by(rel)).get()));
         }
+
+        throw new EntityNotFoundException(typeInSource.getEntityType(), FilterApplicator.filters(path));
     }
 
-    protected void removeRelationship(Constants.Type typeInSource, Relationships.WellKnown rel,
-                                      String targetUid) {
+    protected Relationship findAssociation(String targetId, String label) {
+        Vertex source = source().next();
+
+        for(Edge e : source.getEdges(Direction.OUT, label)) {
+            Vertex target = e.getVertex(Direction.IN);
+            if (getUid(target).equals(targetId)) {
+                return new Relationship(getUid(e), label, convert(source), convert(target));
+            }
+        }
+
+        throw new RelationNotFoundException(label, FilterApplicator.filters(path));
+
+    }
+
+    protected void removeAssociation(Constants.Type typeInSource, Relationships.WellKnown rel,
+                                     String targetUid) {
 
         Constants.Type myType = Constants.Type.of(entityClass);
 

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/Constants.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/Constants.java
@@ -48,12 +48,15 @@ final class Constants {
      * The type of entities known to Hawkular.
      */
     enum Type {
-        tenant, environment, feed, resourceType(version), metricType(unit), resource, metric;
+        tenant(Tenant.class), environment(Environment.class), feed(Feed.class),
+        resourceType(ResourceType.class, version), metricType(MetricType.class, unit), resource(Resource.class),
+        metric(Metric.class);
 
         private final String[] mappedProperties;
+        private final Class<? extends Entity> entityType;
 
-
-        private Type(Property... mappedProperties) {
+        private Type(Class<? extends Entity> entityType, Property... mappedProperties) {
+            this.entityType = entityType;
             this.mappedProperties = new String[mappedProperties.length + 2];
             Arrays.setAll(this.mappedProperties, i -> i == 0 ? Property.type.name() :
                     (i == 1 ? Property.uid.name() : mappedProperties[i - 2].name()));
@@ -116,6 +119,10 @@ final class Constants {
             } else {
                 throw new IllegalArgumentException("Unsupported entity class " + ec);
             }
+        }
+
+        public Class<? extends Entity> getEntityType() {
+            return entityType;
         }
 
         public String[] getMappedProperties() {

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/EnvironmentsService.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/EnvironmentsService.java
@@ -33,7 +33,7 @@ import static org.hawkular.inventory.impl.tinkerpop.Constants.Type.tenant;
  */
 final class EnvironmentsService extends
         AbstractSourcedGraphService<Environments.Single, Environments.Multiple, Environment, String>
-        implements Environments.ReadWrite, Environments.Read, Environments.ReadRelate {
+        implements Environments.ReadWrite, Environments.Read {
 
     public EnvironmentsService(InventoryContext context, PathContext ctx) {
         super(context, Environment.class, ctx);
@@ -70,15 +70,5 @@ final class EnvironmentsService extends
     @Override
     protected String getProposedId(String b) {
         return b;
-    }
-
-    @Override
-    public void add(String id) {
-        //TODO implement
-    }
-
-    @Override
-    public void remove(String id) {
-        //TODO implement
     }
 }

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/FeedBrowser.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/FeedBrowser.java
@@ -17,6 +17,7 @@
 package org.hawkular.inventory.impl.tinkerpop;
 
 import org.hawkular.inventory.api.Feeds;
+import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.Resources;
 import org.hawkular.inventory.api.filters.Filter;
 import org.hawkular.inventory.api.filters.Related;
@@ -24,19 +25,74 @@ import org.hawkular.inventory.api.filters.With;
 import org.hawkular.inventory.api.model.Feed;
 import org.hawkular.inventory.api.model.Resource;
 
+import java.util.Set;
+
 import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
 
 /**
  * @author Lukas Krejci
  * @since 1.0
  */
-final class FeedBrowser extends AbstractBrowser<Feed> implements Feeds.Single, Feeds.Multiple {
+final class FeedBrowser extends AbstractBrowser<Feed> {
+
+    public static Feeds.Single single(InventoryContext context, FilterApplicator... path) {
+        FeedBrowser b = new FeedBrowser(context, path);
+
+        return new Feeds.Single() {
+
+            @Override
+            public Feed entity() {
+                return b.entity();
+            }
+
+            @Override
+            public Relationships.ReadWrite relationships() {
+                return b.relationships();
+            }
+
+            @Override
+            public Relationships.ReadWrite relationships(Relationships.Direction direction) {
+                return b.relationships(direction);
+            }
+
+            @Override
+            public Resources.Read resources() {
+                return b.resources();
+            }
+        };
+    }
+
+    public static Feeds.Multiple multiple(InventoryContext context, FilterApplicator... path) {
+        FeedBrowser b = new FeedBrowser(context, path);
+
+        return new Feeds.Multiple() {
+
+            @Override
+            public Set<Feed> entities() {
+                return b.entities();
+            }
+
+            @Override
+            public Relationships.Read relationships() {
+                return b.relationships();
+            }
+
+            @Override
+            public Relationships.Read relationships(Relationships.Direction direction) {
+                return b.relationships(direction);
+            }
+
+            @Override
+            public Resources.Read resources() {
+                return b.resources();
+            }
+        };
+    }
 
     FeedBrowser(InventoryContext context, FilterApplicator... path) {
         super(context, Feed.class, path);
     }
 
-    @Override
     public Resources.Read resources() {
         return new ResourcesService(context, pathToHereWithSelect(Filter.by(Related.by(contains),
                 With.type(Resource.class))));

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/FeedsService.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/FeedsService.java
@@ -33,7 +33,7 @@ import static org.hawkular.inventory.impl.tinkerpop.Constants.Type.environment;
  * @since 1.0
  */
 final class FeedsService extends AbstractSourcedGraphService<Feeds.Single, Feeds.Multiple, Feed, String>
-        implements Feeds.ReadAndRegister, Feeds.Read, Feeds.ReadRelate {
+        implements Feeds.ReadAndRegister, Feeds.Read {
 
     FeedsService(InventoryContext context, PathContext ctx) {
         super(context, Feed.class, ctx);
@@ -81,15 +81,5 @@ final class FeedsService extends AbstractSourcedGraphService<Feeds.Single, Feeds
     @Override
     public Feeds.Single register(String proposedId) {
         return super.create(proposedId);
-    }
-
-    @Override
-    public void add(String id) {
-        //TODO implement
-    }
-
-    @Override
-    public void remove(String id) {
-        //TODO implement
     }
 }

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/FeedsService.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/FeedsService.java
@@ -54,13 +54,13 @@ final class FeedsService extends AbstractSourcedGraphService<Feeds.Single, Feeds
     }
 
     @Override
-    protected FeedBrowser createSingleBrowser(FilterApplicator... path) {
-        return new FeedBrowser(context, path);
+    protected Feeds.Single createSingleBrowser(FilterApplicator... path) {
+        return FeedBrowser.single(context, path);
     }
 
     @Override
     protected Feeds.Multiple createMultiBrowser(FilterApplicator... path) {
-        return new FeedBrowser(context, path);
+        return FeedBrowser.multiple(context, path);
     }
 
     @Override

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricBrowser.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricBrowser.java
@@ -17,13 +17,61 @@
 package org.hawkular.inventory.impl.tinkerpop;
 
 import org.hawkular.inventory.api.Metrics;
+import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.model.Metric;
+
+import java.util.Set;
 
 /**
  * @author Lukas Krejci
  * @since 1.0
  */
-final class MetricBrowser extends AbstractBrowser<Metric> implements Metrics.Single, Metrics.Multiple {
+final class MetricBrowser extends AbstractBrowser<Metric> {
+
+    public static Metrics.Single single(InventoryContext context, FilterApplicator... path) {
+        MetricBrowser b = new MetricBrowser(context, path);
+
+        return new Metrics.Single() {
+
+            @Override
+            public Metric entity() {
+                return b.entity();
+            }
+
+            @Override
+            public Relationships.ReadWrite relationships() {
+                return b.relationships();
+            }
+
+            @Override
+            public Relationships.ReadWrite relationships(Relationships.Direction direction) {
+                return b.relationships(direction);
+            }
+        };
+    }
+
+    public static Metrics.Multiple multiple(InventoryContext context, FilterApplicator... path) {
+        MetricBrowser b = new MetricBrowser(context, path);
+
+        return new Metrics.Multiple() {
+
+            @Override
+            public Set<Metric> entities() {
+                return b.entities();
+            }
+
+            @Override
+            public Relationships.Read relationships() {
+                return b.relationships();
+            }
+
+            @Override
+            public Relationships.Read relationships(Relationships.Direction direction) {
+                return b.relationships(direction);
+            }
+        };
+    }
+
     MetricBrowser(InventoryContext context, FilterApplicator... path) {
         super(context, Metric.class, path);
     }

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricTypeBrowser.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricTypeBrowser.java
@@ -19,20 +19,75 @@ package org.hawkular.inventory.impl.tinkerpop;
 
 import org.hawkular.inventory.api.MetricTypes;
 import org.hawkular.inventory.api.Metrics;
+import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.model.MetricType;
+
+import java.util.Set;
 
 /**
  * @author Lukas Krejci
  * @since 1.0
  */
-final class MetricTypeBrowser extends AbstractBrowser<MetricType> implements MetricTypes.Single,
-        MetricTypes.Multiple {
+final class MetricTypeBrowser extends AbstractBrowser<MetricType> {
+
+    public static MetricTypes.Single single(InventoryContext context, FilterApplicator... path) {
+        MetricTypeBrowser b = new MetricTypeBrowser(context, path);
+
+        return new MetricTypes.Single() {
+
+            @Override
+            public MetricType entity() {
+                return b.entity();
+            }
+
+            @Override
+            public Relationships.ReadWrite relationships() {
+                return b.relationships();
+            }
+
+            @Override
+            public Relationships.ReadWrite relationships(Relationships.Direction direction) {
+                return b.relationships(direction);
+            }
+
+            @Override
+            public Metrics.Read metrics() {
+                return b.metrics();
+            }
+        };
+    }
+
+    public static MetricTypes.Multiple multiple(InventoryContext context, FilterApplicator... path) {
+        MetricTypeBrowser b = new MetricTypeBrowser(context, path);
+
+        return new MetricTypes.Multiple() {
+
+            @Override
+            public Set<MetricType> entities() {
+                return b.entities();
+            }
+
+            @Override
+            public Relationships.Read relationships() {
+                return b.relationships();
+            }
+
+            @Override
+            public Relationships.Read relationships(Relationships.Direction direction) {
+                return b.relationships(direction);
+            }
+
+            @Override
+            public Metrics.Read metrics() {
+                return b.metrics();
+            }
+        };
+    }
 
     MetricTypeBrowser(InventoryContext context, FilterApplicator... path) {
         super(context, MetricType.class, path);
     }
 
-    @Override
     public Metrics.Read metrics() {
         return new MetricsService(context, pathToHereWithSelect(null));
     }

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricTypesService.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricTypesService.java
@@ -61,12 +61,12 @@ final class MetricTypesService
 
     @Override
     protected MetricTypes.Single createSingleBrowser(FilterApplicator... path) {
-        return new MetricTypeBrowser(context, path);
+        return MetricTypeBrowser.single(context, path);
     }
 
     @Override
     protected MetricTypes.Multiple createMultiBrowser(FilterApplicator... path) {
-        return new MetricTypeBrowser(context, path);
+        return MetricTypeBrowser.multiple(context, path);
     }
 
     @Override

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricTypesService.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricTypesService.java
@@ -90,8 +90,8 @@ final class MetricTypesService
     }
 
     @Override
-    public void disassociate(String id) {
-        removeAssociation(resourceType, owns, id);
+    public Relationship disassociate(String id) {
+        return removeAssociation(resourceType, owns, id);
     }
 
     @Override

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricsService.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricsService.java
@@ -18,12 +18,14 @@ package org.hawkular.inventory.impl.tinkerpop;
 
 import com.tinkerpop.blueprints.Vertex;
 import org.hawkular.inventory.api.Metrics;
+import org.hawkular.inventory.api.RelationNotFoundException;
 import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.filters.Filter;
 import org.hawkular.inventory.api.filters.Related;
 import org.hawkular.inventory.api.filters.With;
 import org.hawkular.inventory.api.model.Environment;
 import org.hawkular.inventory.api.model.Metric;
+import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.Tenant;
 
 import java.util.ArrayList;
@@ -42,7 +44,7 @@ import static org.hawkular.inventory.impl.tinkerpop.Constants.Type.resource;
  */
 final class MetricsService
         extends AbstractSourcedGraphService<Metrics.Single, Metrics.Multiple, Metric, Metric.Blueprint>
-        implements Metrics.ReadWrite, Metrics.Read, Metrics.ReadRelate {
+        implements Metrics.ReadWrite, Metrics.Read, Metrics.ReadAssociate {
 
     MetricsService(InventoryContext context, PathContext ctx) {
         super(context, Metric.class, ctx);
@@ -94,17 +96,22 @@ final class MetricsService
     }
 
     @Override
-    public void add(String id) {
+    public Relationship associate(String id) {
         //in here I know the source is a resource...
         Iterable<Vertex> vs = source().in(contains) //up from resource to environment
                 .out(contains).hasType(metric) //down to metrics
                 .hasUid(id).cast(Vertex.class);
 
-        super.addRelationship(Constants.Type.resource, owns, vs);
+        return super.addAssociation(Constants.Type.resource, owns, vs);
     }
 
     @Override
-    public void remove(String id) {
-        removeRelationship(resource, owns, id);
+    public void disassociate(String id) {
+        removeAssociation(resource, owns, id);
+    }
+
+    @Override
+    public Relationship associationWith(String id) throws RelationNotFoundException {
+        return findAssociation(id, owns.name());
     }
 }

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricsService.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricsService.java
@@ -106,8 +106,8 @@ final class MetricsService
     }
 
     @Override
-    public void disassociate(String id) {
-        removeAssociation(resource, owns, id);
+    public Relationship disassociate(String id) {
+        return removeAssociation(resource, owns, id);
     }
 
     @Override

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricsService.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/MetricsService.java
@@ -82,7 +82,7 @@ final class MetricsService
 
     @Override
     protected Metrics.Single createSingleBrowser(FilterApplicator... path) {
-        return new MetricBrowser(context, path);
+        return MetricBrowser.single(context, path);
     }
 
     @Override
@@ -92,7 +92,7 @@ final class MetricsService
 
     @Override
     protected Metrics.Multiple createMultiBrowser(FilterApplicator... path) {
-        return new MetricBrowser(context, path);
+        return MetricBrowser.multiple(context, path);
     }
 
     @Override

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/RelationshipBrowser.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/RelationshipBrowser.java
@@ -74,7 +74,7 @@ final class RelationshipBrowser<E extends Entity> extends AbstractBrowser<E> {
                 }
                 Edge edge = edges.next();
 
-                Relationship relationship = new Relationship(edge.getId().toString(), edge.getLabel(), convert(edge
+                Relationship relationship = new Relationship(getUid(edge), edge.getLabel(), convert(edge
                          .getVertex(Direction.OUT)), convert(edge.getVertex(Direction.IN)));
                 Map<String, Object> properties = edge.getPropertyKeys().stream().collect(Collectors.toMap(Function
                         .<String>identity(), key -> edge.<Object>getProperty(key)));

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/ResourceBrowser.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/ResourceBrowser.java
@@ -43,7 +43,7 @@ final class ResourceBrowser extends AbstractBrowser<Resource> {
 
         return new Resources.Single() {
             @Override
-            public Metrics.ReadRelate metrics() {
+            public Metrics.ReadAssociate metrics() {
                 return b.metrics();
             }
 

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/ResourceTypeBrowser.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/ResourceTypeBrowser.java
@@ -68,7 +68,7 @@ final class ResourceTypeBrowser extends AbstractBrowser<ResourceType> {
             }
 
             @Override
-            public MetricTypes.ReadRelate metricTypes() {
+            public MetricTypes.ReadAssociate metricTypes() {
                 return b.metricTypes();
             }
         };
@@ -110,7 +110,7 @@ final class ResourceTypeBrowser extends AbstractBrowser<ResourceType> {
                 With.type(Resource.class))));
     }
 
-    private MetricTypes.ReadRelate metricTypes() {
+    private MetricTypes.ReadAssociate metricTypes() {
         return new MetricTypesService(context, pathToHereWithSelect(Filter.by(Related.by(owns),
                 With.type(MetricType.class))));
     }

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/ResourceTypesService.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/ResourceTypesService.java
@@ -21,7 +21,6 @@ import org.hawkular.inventory.api.ResourceTypes;
 import org.hawkular.inventory.api.filters.Filter;
 import org.hawkular.inventory.api.filters.Related;
 import org.hawkular.inventory.api.filters.With;
-import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.ResourceType;
 import org.hawkular.inventory.api.model.Tenant;
 

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/ResourceTypesService.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/ResourceTypesService.java
@@ -21,6 +21,7 @@ import org.hawkular.inventory.api.ResourceTypes;
 import org.hawkular.inventory.api.filters.Filter;
 import org.hawkular.inventory.api.filters.Related;
 import org.hawkular.inventory.api.filters.With;
+import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.ResourceType;
 import org.hawkular.inventory.api.model.Tenant;
 
@@ -33,7 +34,7 @@ import static org.hawkular.inventory.impl.tinkerpop.Constants.Type.tenant;
  */
 final class ResourceTypesService extends
         AbstractSourcedGraphService<ResourceTypes.Single, ResourceTypes.Multiple, ResourceType, ResourceType.Blueprint>
-        implements ResourceTypes.ReadWrite, ResourceTypes.Read, ResourceTypes.ReadRelate {
+        implements ResourceTypes.ReadWrite, ResourceTypes.Read {
 
     ResourceTypesService(InventoryContext context, PathContext ctx) {
         super(context, ResourceType.class, ctx);
@@ -71,15 +72,5 @@ final class ResourceTypesService extends
     @Override
     protected void updateExplicitProperties(ResourceType entity, Vertex vertex) {
         vertex.setProperty(Constants.Property.version.name(), entity.getVersion().toString());
-    }
-
-    @Override
-    public void add(String id) {
-        //TODO implement
-    }
-
-    @Override
-    public void remove(String id) {
-        //TODO implement
     }
 }

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/ResourcesService.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/ResourcesService.java
@@ -39,7 +39,7 @@ import static org.hawkular.inventory.impl.tinkerpop.Constants.Type.resourceType;
  */
 final class ResourcesService
         extends AbstractSourcedGraphService<Resources.Single, Resources.Multiple, Resource, Resource.Blueprint>
-        implements Resources.ReadWrite, Resources.Read, Resources.ReadRelate {
+        implements Resources.ReadWrite, Resources.Read {
 
     public ResourcesService(InventoryContext context, PathContext ctx) {
         super(context, Resource.class, ctx);
@@ -84,15 +84,5 @@ final class ResourcesService
     @Override
     protected String getProposedId(Resource.Blueprint b) {
         return b.getId();
-    }
-
-    @Override
-    public void add(String id) {
-        // TODO implelent
-    }
-
-    @Override
-    public void remove(String id) {
-        // TODO implelent
     }
 }

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/TenantsService.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/TenantsService.java
@@ -20,7 +20,6 @@ import com.tinkerpop.blueprints.Vertex;
 import org.hawkular.inventory.api.Tenants;
 import org.hawkular.inventory.api.filters.Filter;
 import org.hawkular.inventory.api.filters.With;
-import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.Tenant;
 
 /**

--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/TenantsService.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/TenantsService.java
@@ -20,6 +20,7 @@ import com.tinkerpop.blueprints.Vertex;
 import org.hawkular.inventory.api.Tenants;
 import org.hawkular.inventory.api.filters.Filter;
 import org.hawkular.inventory.api.filters.With;
+import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.Tenant;
 
 /**
@@ -27,7 +28,7 @@ import org.hawkular.inventory.api.model.Tenant;
 * @since 1.0
 */
 final class TenantsService extends AbstractSourcedGraphService<Tenants.Single, Tenants.Multiple, Tenant, String>
-        implements Tenants.ReadWrite, Tenants.Read, Tenants.ReadRelate {
+        implements Tenants.ReadWrite, Tenants.Read {
 
     public TenantsService(InventoryContext context) {
         super(context, Tenant.class, new PathContext(FilterApplicator.fromPath().get(),
@@ -56,17 +57,5 @@ final class TenantsService extends AbstractSourcedGraphService<Tenants.Single, T
     @Override
     protected String getProposedId(String b) {
         return b;
-    }
-
-    @Override
-    public void add(String id) {
-        //TODO implement
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void remove(String id) {
-        //TODO implement
-        throw new UnsupportedOperationException();
     }
 }

--- a/impl-tinkerpop-parent/impl/src/test/java/org/hawkular/inventory/impl/tinkerpop/test/BasicTest.java
+++ b/impl-tinkerpop-parent/impl/src/test/java/org/hawkular/inventory/impl/tinkerpop/test/BasicTest.java
@@ -126,7 +126,7 @@ public class BasicTest {
                 .create(new MetricType.Blueprint("ResponseTime", MetricUnit.MILLI_SECOND)).entity().getId()
                 .equals("ResponseTime");
 
-        inventory.tenants().get("com.acme.tenant").resourceTypes().get("URL").metricTypes().add("ResponseTime");
+        inventory.tenants().get("com.acme.tenant").resourceTypes().get("URL").metricTypes().associate("ResponseTime");
 
         assert inventory.tenants().get("com.acme.tenant").environments().get("production").metrics()
                 .create(new Metric.Blueprint(
@@ -136,7 +136,7 @@ public class BasicTest {
                 .create(new Resource.Blueprint("host1", new ResourceType("com.acme.tenant", "URL", "1.0"))).entity()
                 .getId().equals("host1");
         inventory.tenants().get("com.acme.tenant").environments().get("production").resources()
-                .get("host1").metrics().add("host1_ping_response");
+                .get("host1").metrics().associate("host1_ping_response");
 
         assert inventory.tenants().create("com.example.tenant").entity().getId().equals("com.example.tenant");
         assert inventory.tenants().get("com.example.tenant").environments().create("test").entity().getId()
@@ -147,7 +147,7 @@ public class BasicTest {
                 .create(new ResourceType.Blueprint("Playroom", new Version("1.0"))).entity().getId().equals("Playroom");
         assert inventory.tenants().get("com.example.tenant").metricTypes()
                 .create(new MetricType.Blueprint("Size", MetricUnit.BYTE)).entity().getId().equals("Size");
-        inventory.tenants().get("com.example.tenant").resourceTypes().get("Playroom").metricTypes().add("Size");
+        inventory.tenants().get("com.example.tenant").resourceTypes().get("Playroom").metricTypes().associate("Size");
 
         assert inventory.tenants().get("com.example.tenant").environments().get("test").metrics()
                 .create(new Metric.Blueprint(
@@ -165,9 +165,9 @@ public class BasicTest {
                 .entity().getId().equals("playroom2");
 
         inventory.tenants().get("com.example.tenant").environments().get("test").resources()
-                .get("playroom1").metrics().add("playroom1_size");
+                .get("playroom1").metrics().associate("playroom1_size");
         inventory.tenants().get("com.example.tenant").environments().get("test").resources()
-                .get("playroom2").metrics().add("playroom2_size");
+                .get("playroom2").metrics().associate("playroom2_size");
 
         // some ad-hoc relationships
         Environment test = inventory.tenants().get("com.example.tenant").environments().get("test").entity();

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/RestResourceTypes.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/RestResourceTypes.java
@@ -163,7 +163,7 @@ public class RestResourceTypes {
                                   @PathParam("resourceTypeId") String resourceTypeId,
                                   IdJSON metricTypeId) {
         inventory.tenants().get(tenantId).resourceTypes().get(resourceTypeId).metricTypes()
-                .add(metricTypeId.getId());
+                .associate(metricTypeId.getId());
         return Response.noContent().build();
     }
 
@@ -179,7 +179,7 @@ public class RestResourceTypes {
     public Response removeMetricType(@PathParam("tenantId") String tenantId,
                                      @PathParam("resourceTypeId") String resourceTypeId,
                                      @PathParam("metricTypeId") String metricTypeId) {
-        inventory.tenants().get(tenantId).resourceTypes().get(resourceTypeId).metricTypes().remove(metricTypeId);
+        inventory.tenants().get(tenantId).resourceTypes().get(resourceTypeId).metricTypes().disassociate(metricTypeId);
         return Response.noContent().build();
     }
 }

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/RestResources.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/RestResources.java
@@ -162,10 +162,10 @@ public class RestResources {
                                         @PathParam("environmentId") String environmentId,
                                         @PathParam("resourceId") String resourceId,
                                         Collection<String> metricIds) {
-        Metrics.ReadRelate metricDao = inventory.tenants().get(tenantId).environments().get(environmentId)
+        Metrics.ReadAssociate metricDao = inventory.tenants().get(tenantId).environments().get(environmentId)
                 .resources().get(resourceId).metrics();
 
-        metricIds.forEach(metricDao::add);
+        metricIds.forEach(metricDao::associate);
 
         return Response.noContent().build();
     }


### PR DESCRIPTION
Observable inventory is implemented as a wrapper around an "ordinary" inventory instance and uses rxjava to propagate the events.

Right now we can only observe changes in the inventory - creation, updates or deletes of entities of different types with no filtering to reduce the "scope" of where in the inventory the observer is interested in changes happening.
