### PR TITLE
Don't use the user-provided ID as a vertex identifier.

### DIFF
--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/AbstractSourcedGraphService.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/AbstractSourcedGraphService.java
@@ -82,7 +82,7 @@ abstract class AbstractSourcedGraphService<Single, Multiple, E extends Entity, B
                     + "' already exists.");
         }
 
-        Vertex v = context.getGraph().addVertex(id);
+        Vertex v = context.getGraph().addVertex(null);
         v.setProperty(Constants.Property.type.name(), Constants.Type.of(entityClass).name());
         v.setProperty(Constants.Property.uid.name(), id);
 


### PR DESCRIPTION
The user-provided IDs are meant to be unique only amongst the siblings
in the graph (which is something the user can manage), not graph-wide
(ensuring cross-tenant unique IDs would be close to impossible for
users).

Therefore we're using an autogenerated vertex ID and have an additional
"uid" property that is checked for uniqueness in the proper context.
