### PR TITLE
Inspect by path

### DIFF
--- a/api/src/main/java/org/hawkular/inventory/api/Inventory.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Inventory.java
@@ -16,12 +16,15 @@
  */
 package org.hawkular.inventory.api;
 
+import org.hawkular.inventory.api.model.AbstractElement;
+import org.hawkular.inventory.api.model.ElementTypeVisitor;
 import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.model.EntityVisitor;
 import org.hawkular.inventory.api.model.Environment;
 import org.hawkular.inventory.api.model.Feed;
 import org.hawkular.inventory.api.model.Metric;
 import org.hawkular.inventory.api.model.MetricType;
+import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.api.model.ResourceType;
 import org.hawkular.inventory.api.model.Tenant;
@@ -51,30 +54,31 @@ import org.hawkular.inventory.api.model.Tenant;
  *
  * <p>The interfaces composing the inventory API are of 2 kinds:
  * <ol>
- *     <li>CRUD interfaces that provide manipulation of the entities as well as the retrieval of the actual entity
- *     instances (various {@code Read}, {@code ReadWrite} or {@code ReadRelate} interfaces, e.g.
- *     {@link org.hawkular.inventory.api.Environments.ReadWrite}),
- *     <li>browse interfaces that offer further navigation methods to "hop" onto other entities somehow related to the
- *     one(s) in the current position in the inventory traversal. These interfaces are further divided into 2 groups:
- *      <ul>
- *          <li><b>{@code Single}</b> interfaces that provide methods for navigating from a single entity.
- *          These interfaces generally contain methods that enable modification of the entity or its relationships.
- *          See {@link org.hawkular.inventory.api.Environments.Single} for an example.
- *          <li><b>{@code Multiple}</b> interfaces that provide methods for navigating from multiple entities at once.
- *          These interfaces strictly offer only read-only access to the entities, because the semantics of what should
- *          be done when modifying or relating multiple entities at once is not uniformly defined on all types of
- *          entities and therefore would make the API more confusing than necessary. See
- *          {@link org.hawkular.inventory.api.Environments.Multiple} for example.
- *      </ul>
+ * <li>CRUD interfaces that provide manipulation of the entities as well as the retrieval of the actual entity
+ * instances (various {@code Read}, {@code ReadWrite} or {@code ReadRelate} interfaces, e.g.
+ * {@link org.hawkular.inventory.api.Environments.ReadWrite}),
+ * <li>browse interfaces that offer further navigation methods to "hop" onto other entities somehow related to the
+ * one(s) in the current position in the inventory traversal. These interfaces are further divided into 2 groups:
+ * <ul>
+ * <li><b>{@code Single}</b> interfaces that provide methods for navigating from a single entity.
+ * These interfaces generally contain methods that enable modification of the entity or its relationships.
+ * See {@link org.hawkular.inventory.api.Environments.Single} for an example.
+ * <li><b>{@code Multiple}</b> interfaces that provide methods for navigating from multiple entities at once.
+ * These interfaces strictly offer only read-only access to the entities, because the semantics of what should
+ * be done when modifying or relating multiple entities at once is not uniformly defined on all types of
+ * entities and therefore would make the API more confusing than necessary. See
+ * {@link org.hawkular.inventory.api.Environments.Multiple} for example.
+ * </ul>
  * </ol>
  *
  * @author Lukas Krejci
- * @since 1.0
+ * @since 0.0.1
  */
 public interface Inventory extends AutoCloseable {
 
     /**
      * Initializes the inventory from the provided configuration object.
+     *
      * @param configuration the configuration to use.
      */
     void initialize(Configuration configuration);
@@ -178,15 +182,14 @@ public interface Inventory extends AutoCloseable {
      * all access interfaces returned from this method (which makes it almost useless but at least you can get the
      * instance of it).
      *
-     * @param entity the entity to inspect
+     * @param entity          the entity to inspect
      * @param accessInterface the expected access interface
-     * @param <E> the type of the entity
-     * @param <Single> the type of the access interface
+     * @param <E>             the type of the entity
+     * @param <Single>        the type of the access interface
      * @return the access interface instance
-     *
      * @throws java.lang.ClassCastException if the provided access interface doesn't match the entity
      */
-    default <E extends Entity<?, ?>, Single extends ResolvableToSingle<E>> Single inspect(E entity,
+    default <E extends Entity<?, ?>, Single extends ResolvableToSingleWithRelationships<E>> Single inspect(E entity,
             Class<Single> accessInterface) {
         return entity.accept(new EntityVisitor<Single, Void>() {
             @Override
@@ -224,5 +227,92 @@ public interface Inventory extends AutoCloseable {
                 return accessInterface.cast(inspect(type));
             }
         }, null);
+    }
+
+    /**
+     * This method enables lookup of an element (relationship or entity) based on its provided type and the set of ids
+     * that identify it.
+     *
+     * <p>The ids are provided in the "hierarchical" order, starting at tenants. For example, to inspect a resource type
+     * one can issue:
+     *
+     * <pre>{@code
+     *     ResourceTypes.Single access = inventory.inspect(ResourceType.class, ResourceTypes.Single, "myTenantId",
+     *     "myResourceTypeId");
+     * }</pre>
+     *
+     * for inspecting a resource that lives under a feed, one can issue:
+     *
+     * <pre>{@code
+     *     Resources.Single access = inventory.inspect(Resource.class, Resources.Single, "myTenantId",
+     *         "myEnvironmentId", "myFeedId", "myResourceId");
+     * }</pre>
+     *
+     * @param elementType     the type of the element to access
+     * @param accessInterface the access interface type to the elements of the given type
+     * @param ids             the set of ids using which one can navigate to the element
+     * @param <E>             the type of the element, either {@link Relationship} or any of the final {@link Entity}
+     *                        subclasses
+     * @param <Single>        the type of the access interface
+     * @return the access interface to the entity on given path no matter if an entity truly exists on that path.
+     * @throws IndexOutOfBoundsException if the length of the {@code ids} array does not correspond to the length of the
+     *                                   path to elements of given type.
+     */
+    default <E extends AbstractElement<?, ?>, Single extends ResolvableToSingle<E>> Single inspect(Class<E> elementType,
+            Class<Single> accessInterface, String... ids) {
+        return ElementTypeVisitor.accept(new ElementTypeVisitor<Single, Void>() {
+            @Override
+            public Single visitTenant(Void parameter) {
+                return accessInterface.cast(tenants().get(ids[0]));
+            }
+
+            @Override
+            public Single visitEnvironment(Void parameter) {
+                return accessInterface.cast(tenants().get(ids[0]).environments().get(ids[1]));
+            }
+
+            @Override
+            public Single visitResourceType(Void parameter) {
+                return accessInterface.cast(tenants().get(ids[0]).resourceTypes().get(ids[1]));
+            }
+
+            @Override
+            public Single visitMetricType(Void parameter) {
+                return accessInterface.cast(tenants().get(ids[0]).metricTypes().get(ids[1]));
+            }
+
+            @Override
+            public Single visitFeed(Void parameter) {
+                return accessInterface.cast(tenants().get(ids[0]).environments().get(ids[1]).feeds().get(ids[2]));
+            }
+
+            @Override
+            public Single visitResource(Void parameter) {
+                if (ids.length == 3) {
+                    return accessInterface.cast(tenants().get(ids[0]).environments().get(ids[1]).feedlessResources()
+                            .get(ids[3]));
+                } else {
+                    return accessInterface.cast(tenants().get(ids[0]).environments().get(ids[1]).feeds().get(ids[3])
+                            .resources().get(ids[4]));
+                }
+            }
+
+            @Override
+            public Single visitMetric(Void parameter) {
+                if (ids.length == 3) {
+                    return accessInterface.cast(tenants().get(ids[0]).environments().get(ids[1]).feedlessMetrics()
+                            .get(ids[3]));
+                } else {
+                    return accessInterface.cast(tenants().get(ids[0]).environments().get(ids[1]).feeds().get(ids[3])
+                            .metrics().get(ids[4]));
+                }
+            }
+
+            @Override
+            public Single visitRelationship(Void parameter) {
+                //TODO this needs support for retrieving relationships by their ID
+                throw new UnsupportedOperationException();
+            }
+        }, elementType, null);
     }
 }

--- a/api/src/main/java/org/hawkular/inventory/api/ResolvableToManyWithRelationships.java
+++ b/api/src/main/java/org/hawkular/inventory/api/ResolvableToManyWithRelationships.java
@@ -24,7 +24,8 @@ package org.hawkular.inventory.api;
  *
  * @author Lukas Krejci
  * @author Jirka Kremser
- * @since 1.0
+ * @since 0.0.1
  */
-interface ResolvableToManyWithRelationships<Entity> extends ResolvableToMany<Entity>, Relatable<Relationships.Read> {
+public interface ResolvableToManyWithRelationships<Entity> extends ResolvableToMany<Entity>,
+                                                                   Relatable<Relationships.Read> {
 }

--- a/api/src/main/java/org/hawkular/inventory/api/ResolvableToSingleWithRelationships.java
+++ b/api/src/main/java/org/hawkular/inventory/api/ResolvableToSingleWithRelationships.java
@@ -24,8 +24,8 @@ package org.hawkular.inventory.api;
  *
  * @author Lukas Krejci
  * @author Jirka Kremser
- * @since 1.0
+ * @since 0.0.1
  */
-interface ResolvableToSingleWithRelationships<Entity> extends ResolvableToSingle<Entity>,
+public interface ResolvableToSingleWithRelationships<Entity> extends ResolvableToSingle<Entity>,
         Relatable<Relationships.ReadWrite> {
 }

--- a/api/src/main/java/org/hawkular/inventory/api/model/ElementTypeVisitor.java
+++ b/api/src/main/java/org/hawkular/inventory/api/model/ElementTypeVisitor.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.model;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+public interface ElementTypeVisitor<R, P> {
+
+    static <P, R> R accept(ElementTypeVisitor<R, P> visitor, Class<? extends AbstractElement<?, ?>> elementType,
+            P parameter) {
+
+        if (Tenant.class.isAssignableFrom(elementType)) {
+            return visitor.visitTenant(parameter);
+        } else if (Environment.class.isAssignableFrom(elementType)) {
+            return visitor.visitEnvironment(parameter);
+        } else if (ResourceType.class.isAssignableFrom(elementType)) {
+            return visitor.visitResourceType(parameter);
+        } else if (MetricType.class.isAssignableFrom(elementType)) {
+            return visitor.visitMetricType(parameter);
+        } else if (Feed.class.isAssignableFrom(elementType)) {
+            return visitor.visitFeed(parameter);
+        } else if (Resource.class.isAssignableFrom(elementType)) {
+            return visitor.visitResource(parameter);
+        } else if (Metric.class.isAssignableFrom(elementType)) {
+            return visitor.visitMetric(parameter);
+        } else if (Relationship.class.isAssignableFrom(elementType)) {
+            return visitor.visitRelationship(parameter);
+        } else {
+            throw new IllegalArgumentException("Unknown type of inventory element: " + elementType);
+        }
+    }
+
+    R visitTenant(P parameter);
+
+    R visitEnvironment(P parameter);
+
+    R visitResourceType(P parameter);
+
+    R visitMetricType(P parameter);
+
+    R visitFeed(P parameter);
+
+    R visitResource(P parameter);
+
+    R visitMetric(P parameter);
+
+    R visitRelationship(P parameter);
+
+    class Simple<R, P> implements ElementTypeVisitor<R, P> {
+
+        private final R defaultValue;
+
+        public Simple() {
+            defaultValue = null;
+        }
+
+        public Simple(R defaultValue) {
+            this.defaultValue = defaultValue;
+        }
+
+        @Override
+        public R visitTenant(P parameter) {
+            return defaultValue;
+        }
+
+        @Override
+        public R visitEnvironment(P parameter) {
+            return defaultValue;
+        }
+
+        @Override
+        public R visitResourceType(P parameter) {
+            return defaultValue;
+        }
+
+        @Override
+        public R visitMetricType(P parameter) {
+            return defaultValue;
+        }
+
+        @Override
+        public R visitFeed(P parameter) {
+            return defaultValue;
+        }
+
+        @Override
+        public R visitResource(P parameter) {
+            return defaultValue;
+        }
+
+        @Override
+        public R visitMetric(P parameter) {
+            return defaultValue;
+        }
+
+        @Override
+        public R visitRelationship(P parameter) {
+            return defaultValue;
+        }
+    }
+}

--- a/impl-tinkerpop-parent/impl/src/test/java/org/hawkular/inventory/impl/tinkerpop/test/BasicTest.java
+++ b/impl-tinkerpop-parent/impl/src/test/java/org/hawkular/inventory/impl/tinkerpop/test/BasicTest.java
@@ -30,7 +30,7 @@ import org.hawkular.inventory.api.Metrics;
 import org.hawkular.inventory.api.RelationNotFoundException;
 import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.ResolvableToMany;
-import org.hawkular.inventory.api.ResolvableToSingle;
+import org.hawkular.inventory.api.ResolvableToSingleWithRelationships;
 import org.hawkular.inventory.api.feeds.AcceptWithFallbackFeedIdStrategy;
 import org.hawkular.inventory.api.feeds.RandomUUIDFeedIdStrategy;
 import org.hawkular.inventory.api.filters.Defined;
@@ -256,7 +256,7 @@ public class BasicTest {
 
     private void assertDoesNotExist(Entity e) {
         try {
-            inventory.inspect(e, ResolvableToSingle.class).entity();
+            inventory.inspect(e, ResolvableToSingleWithRelationships.class).entity();
             Assert.fail(e + " should have been deleted");
         } catch (EntityNotFoundException ignored) {
             //good
@@ -265,7 +265,7 @@ public class BasicTest {
 
     private void assertExists(Entity e) {
         try {
-            inventory.inspect(e, ResolvableToSingle.class);
+            inventory.inspect(e, ResolvableToSingleWithRelationships.class);
         } catch (EntityNotFoundException ignored) {
             Assert.fail(e + " should have been present in the inventory.");
         }
@@ -584,7 +584,7 @@ public class BasicTest {
 
         Set<Resource> resources = inventory.tenants().get("com.example.tenant").resourceTypes().get("Playroom")
                 .relationships().named
-                ("defines").resources().getAll().entities();
+                        ("defines").resources().getAll().entities();
         assert resources.stream().allMatch(res -> "playroom1".equals(res.getId()) || "playroom2".equals(res.getId()))
                 : "ResourceType[Playroom] -defines-> resources called playroom1 and playroom2";
 


### PR DESCRIPTION
Introduce a new way of traversing to a specific entity by specifying its class and the ids starting at tenant down the hierarchy to the entity.

This will prove useful in REST and other places that can compose the traversals more succinctly.
