### PR TITLE
[HWKINVENT-46] Make event handling error-resilient.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -50,6 +50,24 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Logging -->
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Wildfly provided -->
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
@@ -57,6 +75,7 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- test -->
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/api/src/main/java/org/hawkular/inventory/api/Inventory.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Inventory.java
@@ -346,6 +346,9 @@ public interface Inventory extends AutoCloseable {
             boolean hasObservers(Interest<?, ?> interest);
 
             /**
+             * <b>NOTE</b>: The subscribers will receive the notifications even after they failed. I.e. it is the
+             * subscribers responsibility to unsubscribe on error
+             *
              * @param interest the interest in changes of some inventory entity type
              * @param <C>      the type of object that will be passed to the subscribers of the returned observable
              * @param <E>      the type of the entity the interest is expressed on

--- a/api/src/main/java/org/hawkular/inventory/api/Log.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Log.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.LogMessage;
+import org.jboss.logging.Logger;
+import org.jboss.logging.MessageLogger;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.Message;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.0.6
+ */
+@MessageLogger(projectCode = "HAWKINV")
+public interface Log extends BasicLogger {
+    Log LOGGER = Logger.getMessageLogger(Log.class, "org.hawkular.inventory.api");
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 1, value = "Error while sending inventory event.")
+    void wErrorSendingEvent(@Cause Throwable cause);
+}

--- a/api/src/main/java/org/hawkular/inventory/api/ObservableContext.java
+++ b/api/src/main/java/org/hawkular/inventory/api/ObservableContext.java
@@ -17,7 +17,9 @@
 package org.hawkular.inventory.api;
 
 import rx.Observable;
+import rx.Subscriber;
 import rx.functions.Action0;
+import rx.observers.SafeSubscriber;
 import rx.subjects.PublishSubject;
 import rx.subjects.Subject;
 
@@ -55,7 +57,15 @@ final class ObservableContext {
         if (initialize && sub == null) {
             SubscriptionTracker tracker = new SubscriptionTracker(() -> observables.remove(interest));
             Subject<C, C> subject = PublishSubject.<C>create().toSerialized();
-            Observable<C> wrapper = subject.doOnSubscribe(tracker.onSubscribe())
+
+            //error handling:
+            //onErrorResumeNext - error in the producer, i.e. the inventory API itself failed to send the event
+            //OperatorIgnoreError - in case subscribers and us run in the same thread, an error in the subscriber
+            //may error out the whole observable, which is definitely NOT what we want.
+            Observable<C> wrapper = subject.onErrorResumeNext((t) -> {
+                Log.LOGGER.wErrorSendingEvent(t);
+                return Observable.empty();
+            }).lift(new OperatorIgnoreError<>()).doOnSubscribe(tracker.onSubscribe())
                     .doOnUnsubscribe(tracker.onUnsubscribe());
 
             sub = new SubjectAndWrapper<>(subject, wrapper);
@@ -94,6 +104,47 @@ final class ObservableContext {
         private SubjectAndWrapper(Subject<T, T> subject, Observable<T> wrapper) {
             this.subject = subject;
             this.wrapper = wrapper;
+        }
+    }
+
+    private static final class OperatorIgnoreError<T> implements Observable.Operator<T, T> {
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Subscriber<? super T> call(Subscriber<? super T> subscriber) {
+            return new SafeSubscriber<T>(subscriber) {
+                private boolean done = false;
+
+                private final Subscriber<? super T> actual;
+
+                {
+                    Subscriber<? super T> s = subscriber;
+                    while (s instanceof SafeSubscriber) {
+                        s = ((SafeSubscriber<? super T>) s).getActual();
+                    }
+
+                    actual = s;
+                }
+
+                @Override
+                public void onNext(T t) {
+                    if (done) {
+                        return;
+                    }
+
+                    try {
+                        actual.onNext(t);
+                    } catch (Exception e) {
+                        Log.LOGGER.debugf(e, "Subscriber %s failed to process %s.", actual, t);
+                    }
+                }
+
+                @Override
+                protected void _onError(Throwable e) {
+                    done = true;
+                    super._onError(e);
+                }
+            };
         }
     }
 }

--- a/api/src/main/java/org/hawkular/inventory/api/ObservableContext.java
+++ b/api/src/main/java/org/hawkular/inventory/api/ObservableContext.java
@@ -59,13 +59,10 @@ final class ObservableContext {
             Subject<C, C> subject = PublishSubject.<C>create().toSerialized();
 
             //error handling:
-            //onErrorResumeNext - error in the producer, i.e. the inventory API itself failed to send the event
             //OperatorIgnoreError - in case subscribers and us run in the same thread, an error in the subscriber
             //may error out the whole observable, which is definitely NOT what we want.
-            Observable<C> wrapper = subject.onErrorResumeNext((t) -> {
-                Log.LOGGER.wErrorSendingEvent(t);
-                return Observable.empty();
-            }).lift(new OperatorIgnoreError<>()).doOnSubscribe(tracker.onSubscribe())
+            Observable<C> wrapper = null;
+            wrapper = subject.lift(new OperatorIgnoreError<>()).doOnSubscribe(tracker.onSubscribe())
                     .doOnUnsubscribe(tracker.onUnsubscribe());
 
             sub = new SubjectAndWrapper<>(subject, wrapper);


### PR DESCRIPTION
This required a little bit of hackery on rxjava but I think it is the
correct way of doing it in the face of possibly buggy observers.

One could argue that it is the observer's responsibility to obey a contract
(not throw exception in onNext() ) but on the other hand, it is the library
author's responsibility to handle buggy "inputs".
