### PR TITLE
HAWKULAR-255 Adding the DuplicateFilterPipe to the end of the query pipe line.

### DIFF
--- a/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterApplicator.java
+++ b/impl-tinkerpop-parent/impl/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterApplicator.java
@@ -91,7 +91,9 @@ abstract class FilterApplicator<T extends Filter> {
                 branches.add(branch);
             }
 
-            q.copySplit(branches.toArray(new HawkularPipeline[branches.size()])).exhaustMerge();
+            // HAWKULAR-255: the dedup pipe in the end could go away once we find out why there are duplicates
+            // TODO: find out what is really happening here
+            q.copySplit(branches.toArray(new HawkularPipeline[branches.size()])).exhaustMerge().dedup();
         }
     }
 


### PR DESCRIPTION
This is not optimal, because now each query needs to run the dedup step. Internally, it uses `LinkedHashSet` so it is in `O(n)`
