### PR TITLE
HWKINVENT-48 Create feed API should return error if feed ID already exists

### DIFF
--- a/api/src/main/java/org/hawkular/inventory/api/EntityAlreadyExistsException.java
+++ b/api/src/main/java/org/hawkular/inventory/api/EntityAlreadyExistsException.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
  * @author Lukas Krejci
  * @since 1.0
  */
-public final class EntityAlreadyExistsException extends InventoryException {
+public class EntityAlreadyExistsException extends InventoryException {
 
     private final String entityId;
     private final Filter[][] paths;
@@ -65,7 +65,7 @@ public final class EntityAlreadyExistsException extends InventoryException {
                 + Arrays.deepToString(paths);
     }
 
-    private static Filter[][] asPaths(Entity entity) {
+    static Filter[][] asPaths(Entity entity) {
         Filter[][] ret = new Filter[1][];
         ret[0] = Filter.pathTo(entity);
         return ret;

--- a/api/src/main/java/org/hawkular/inventory/api/FeedAlreadyRegisteredException.java
+++ b/api/src/main/java/org/hawkular/inventory/api/FeedAlreadyRegisteredException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.inventory.api;
+
+import org.hawkular.inventory.api.model.Feed;
+
+/**
+ * @author jkremser
+ * @since 1.0
+ */
+public final class FeedAlreadyRegisteredException extends EntityAlreadyExistsException {
+    private Feed feed;
+
+    public FeedAlreadyRegisteredException(Feed feed) {
+        super(feed.getId(), asPaths(feed));
+        this.feed = feed;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Feed with id '" + feed + "' has been already registered. " + super.getMessage();
+    }
+}

--- a/api/src/main/java/org/hawkular/inventory/api/FeedAlreadyRegisteredException.java
+++ b/api/src/main/java/org/hawkular/inventory/api/FeedAlreadyRegisteredException.java
@@ -21,7 +21,7 @@ import org.hawkular.inventory.api.model.Feed;
 
 /**
  * @author jkremser
- * @since 1.0
+ * @since 0.1.0
  */
 public final class FeedAlreadyRegisteredException extends EntityAlreadyExistsException {
     private Feed feed;

--- a/api/src/main/java/org/hawkular/inventory/api/model/Feed.java
+++ b/api/src/main/java/org/hawkular/inventory/api/model/Feed.java
@@ -69,6 +69,7 @@ public final class Feed extends EnvironmentBasedEntity<Feed.Blueprint, Feed.Upda
         public static Builder builder() {
             return new Builder();
         }
+        private static final String AUTO_ID_FLAG = "__auto-generate-id";
 
         //JAXB support
         @SuppressWarnings("unused")
@@ -77,7 +78,7 @@ public final class Feed extends EnvironmentBasedEntity<Feed.Blueprint, Feed.Upda
         }
 
         public Blueprint(String id, Map<String, Object> properties) {
-            super(id, properties);
+            super(id == null ? AUTO_ID_FLAG : id, properties);
         }
 
         @Override
@@ -91,6 +92,10 @@ public final class Feed extends EnvironmentBasedEntity<Feed.Blueprint, Feed.Upda
             public Blueprint build() {
                 return new Blueprint(id, properties);
             }
+        }
+
+        public static boolean shouldAutogenerateId(Feed proposedFeed) {
+            return AUTO_ID_FLAG.equals(proposedFeed.getId());
         }
     }
 

--- a/api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryPersistenceCheck.java
+++ b/api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryPersistenceCheck.java
@@ -19,6 +19,7 @@ package org.hawkular.inventory.api.test;
 import org.hawkular.inventory.api.Action;
 import org.hawkular.inventory.api.Configuration;
 import org.hawkular.inventory.api.EntityNotFoundException;
+import org.hawkular.inventory.api.FeedAlreadyRegisteredException;
 import org.hawkular.inventory.api.Feeds;
 import org.hawkular.inventory.api.Interest;
 import org.hawkular.inventory.api.Metrics;
@@ -769,8 +770,13 @@ public abstract class AbstractBaseInventoryPersistenceCheck<E> {
                 .feeds();
 
         Feed f1 = feeds.create(new Feed.Blueprint("feed", null)).entity();
-        Feed f2 = feeds.create(new Feed.Blueprint("feed", null)).entity();
-
+        Feed f2 = null;
+        try {
+            f2 = feeds.create(new Feed.Blueprint("feed", null)).entity();
+        } catch (FeedAlreadyRegisteredException fare) {
+            //good
+        }
+        f2 = feeds.create(new Feed.Blueprint(null, null)).entity();
         assert f1.getId().equals("feed");
         assert !f1.getId().equals(f2.getId());
     }


### PR DESCRIPTION
Throwing an exception when registering with the same feed id more than once.

Good practice from the relation db world is to set the id to null and let the backend generate the id. However, it's not possible to create the `Feed` instance with `null` id, because there is a check in the `AbstractElement` class, so I was little bit cheating and set some predefined string there when calling `new Feed(null)` to determine if the id generation is wanted.
