### PR TITLE
HWKINVENT-56 Some REST endpoints of inventory API require the Accept:…

### DIFF
--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/RestFeeds.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/RestFeeds.java
@@ -20,6 +20,8 @@ import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
 import com.wordnik.swagger.annotations.ApiResponse;
 import com.wordnik.swagger.annotations.ApiResponses;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
 import org.hawkular.inventory.api.model.Environment;
 import org.hawkular.inventory.api.model.Feed;
 import org.hawkular.inventory.api.paging.Page;
@@ -36,6 +38,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.util.Set;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static org.hawkular.inventory.rest.RequestUtil.extractPaging;
 import static org.hawkular.inventory.rest.ResponseUtil.pagedResponse;
@@ -45,6 +48,8 @@ import static org.hawkular.inventory.rest.ResponseUtil.pagedResponse;
  * @since 0.0.1
  */
 @Path("/")
+@Produces(value = APPLICATION_JSON)
+@Consumes(value = APPLICATION_JSON)
 public class RestFeeds extends RestBase {
 
     @POST
@@ -101,7 +106,7 @@ public class RestFeeds extends RestBase {
 
     @PUT
     @Path("/{tenantId}/{environmentId}/feeds/{feedId}")
-    @ApiOperation("Updates a metric")
+    @ApiOperation("Updates a feed")
     @ApiResponses({
             @ApiResponse(code = 204, message = "OK"),
             @ApiResponse(code = 404, message = "Tenant, environment or the feed doesn't exist",


### PR DESCRIPTION
jira title: Some REST endpoints of inventory API require the Accept: and Content-Type: headers and some not. 

The issue was there only for feeds.
