### PR TITLE
HWKINVENT-54 need special api response codes for "already exists"

### DIFF
--- a/api/src/main/java/org/hawkular/inventory/api/RelationAlreadyExistsException.java
+++ b/api/src/main/java/org/hawkular/inventory/api/RelationAlreadyExistsException.java
@@ -61,4 +61,12 @@ public final class RelationAlreadyExistsException extends InventoryException {
         return "Relation with id '" + relationName + "' already exists at some of the positions: "
                 + Arrays.deepToString(path);
     }
+
+    public String getRelationName() {
+        return relationName;
+    }
+
+    public Filter[][] getPath() {
+        return path;
+    }
 }

--- a/api/src/main/java/org/hawkular/inventory/api/RelationNotFoundException.java
+++ b/api/src/main/java/org/hawkular/inventory/api/RelationNotFoundException.java
@@ -84,4 +84,16 @@ public final class RelationNotFoundException extends InventoryException {
         ret[0] = elem;
         return ret;
     }
+
+    public String getNameOrId() {
+        return nameOrId;
+    }
+
+    public String getSourceEntityType() {
+        return sourceEntityType;
+    }
+
+    public Filter[][] getFilters() {
+        return filters;
+    }
 }

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/ResponseUtil.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/ResponseUtil.java
@@ -50,11 +50,13 @@ final class ResponseUtil {
 
         //extract the data out of the page
         List<T> data = new ArrayList<>(page);
+        return pagedResponse(response, uriInfo, page, data);
+    }
 
+    public static <T> Response.ResponseBuilder pagedResponse(Response.ResponseBuilder response, UriInfo uriInfo,
+                                                             Page<T> page, Object data) {
         response.entity(data);
-
         createPagingHeader(response, uriInfo, page);
-
         return response;
     }
 

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/RestRelationships.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/RestRelationships.java
@@ -165,12 +165,7 @@ public class RestRelationships extends RestBase {
         if (!Security.isValidId(securityId)) {
             return Response.status(NOT_FOUND).build();
         }
-        if (Arrays.asList(Relationships.WellKnown.values())
-                .stream().map(val -> val.name()).anyMatch(x -> x.equals(relation.getName()))) {
-            throw new IllegalArgumentException("Unable to delete a relationship with well defined name. " +
-                                                       "Restricted names: " +
-                                                       Arrays.asList(Relationships.WellKnown.values()));
-        }
+        checkForWellKnownLabels(relation.getName(), "delete");
         CanonicalPath cPath = Security.getCanonicalPath(securityId);
         ResolvableToSingleWithRelationships<Relationship> resolvable = getResolvableFromCanonicalPath(cPath);
 
@@ -202,11 +197,7 @@ public class RestRelationships extends RestBase {
         if (!Security.isValidId(securityId)) {
             return Response.status(NOT_FOUND).build();
         }
-        if (Arrays.asList(Relationships.WellKnown.values())
-                .stream().map(val -> val.name()).anyMatch(x -> x.equals(relation.getName()))) {
-            throw new IllegalArgumentException("Unable to create a relationship with well defined name. Restricted " +
-                                                       "names: " + Arrays.asList(Relationships.WellKnown.values()));
-        }
+        checkForWellKnownLabels(relation.getName(), "create");
         CanonicalPath cPath = Security.getCanonicalPath(securityId);
         ResolvableToSingleWithRelationships<Relationship> resolvable = getResolvableFromCanonicalPath(cPath);
 
@@ -255,11 +246,7 @@ public class RestRelationships extends RestBase {
         }
 
         // perhaps we could have allowed updating the properties of well-known rels
-        if (Arrays.asList(Relationships.WellKnown.values())
-                .stream().map(val -> val.name()).anyMatch(x -> x.equals(relation.getName()))) {
-            throw new IllegalArgumentException("Unable to update a relationship with well defined name. Restricted " +
-                                                       "names: " + Arrays.asList(Relationships.WellKnown.values()));
-        }
+        checkForWellKnownLabels(relation.getName(), "update");
         CanonicalPath cPath = Security.getCanonicalPath(securityId);
         ResolvableToSingleWithRelationships<Relationship> resolvable = getResolvableFromCanonicalPath(cPath);
 
@@ -354,4 +341,10 @@ public class RestRelationships extends RestBase {
         return filters.isEmpty() ? RelationFilter.all() : filters.toArray(new RelationFilter[filters.size()]);
     }
 
+    private void checkForWellKnownLabels(String name, String operation) {
+        if (Arrays.stream(Relationships.WellKnown.values()).anyMatch(x -> x.name().equals(name))) {
+            throw new IllegalArgumentException("Unable to " + operation + " a relationship with well defined name. " +
+                                               "Restricted names: " + Arrays.asList(Relationships.WellKnown.values()));
+        }
+    }
 }

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/RestRelationships.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/RestRelationships.java
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -67,6 +69,7 @@ import org.hawkular.inventory.api.model.Tenant;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
 import org.hawkular.inventory.base.spi.CanonicalPath;
+import org.hawkular.inventory.rest.json.ApiError;
 import org.hawkular.inventory.rest.json.EmbeddedObjectMapper;
 
 /**
@@ -102,6 +105,12 @@ public class RestRelationships extends RestBase {
     @GET
     @Path("{path:.*}/relationships")
     @ApiOperation("Retrieves relationships")
+    @ApiResponses({
+                          @ApiResponse(code = 200, message = "The list of relationships"),
+                          @ApiResponse(code = 404, message = "Accompanying entity doesn't exist", response = ApiError
+                                  .class),
+                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+                  })
     public Response get(@PathParam("path") String path,
                         @DefaultValue("both") @QueryParam("direction") String direction,
                         @DefaultValue("") @QueryParam("property") String propertyName,
@@ -143,6 +152,12 @@ public class RestRelationships extends RestBase {
     @DELETE
     @Path("{path:.*}/relationships")
     @ApiOperation("Deletes a relationship")
+    @ApiResponses({
+                          @ApiResponse(code = 200, message = "The list of relationships"),
+                          @ApiResponse(code = 404, message = "Accompanying entity doesn't exist", response = ApiError
+                                  .class),
+                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+                  })
     public Response delete(@PathParam("path") String path,
                            @ApiParam(required = true) Relationship relation,
                            @Context UriInfo uriInfo) {
@@ -172,6 +187,14 @@ public class RestRelationships extends RestBase {
     @POST
     @Path("{path:.*}/relationships")
     @ApiOperation("Creates a relationship")
+    @ApiResponses({
+                          @ApiResponse(code = 201, message = "OK"),
+                          @ApiResponse(code = 400, message = "Invalid input data", response = ApiError.class),
+                          @ApiResponse(code = 404, message = "Accompanying entity doesn't exist", response =
+                                  ApiError.class),
+                          @ApiResponse(code = 409, message = "Relationship already exists", response = ApiError.class),
+                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+                  })
     public Response create(@PathParam("path") String path,
                            @ApiParam(required = true) Relationship relation,
                            @Context UriInfo uriInfo) {
@@ -216,6 +239,13 @@ public class RestRelationships extends RestBase {
     @PUT
     @Path("{path:.*}/relationships")
     @ApiOperation("Updates a relationship")
+    @ApiResponses({
+                          @ApiResponse(code = 204, message = "OK"),
+                          @ApiResponse(code = 400, message = "Invalid input data", response = ApiError.class),
+                          @ApiResponse(code = 404, message = "Accompanying entity doesn't exist", response =
+                                  ApiError.class),
+                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+                  })
     public Response update(@PathParam("path") String path,
                            @ApiParam(required = true) Relationship relation,
                            @Context UriInfo uriInfo) {

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/DefaultOptionsMethodExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/DefaultOptionsMethodExceptionMapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.inventory.rest.exception.mappers;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import org.jboss.resteasy.spi.DefaultOptionsMethodException;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.1.0
+ */
+@Provider
+public class DefaultOptionsMethodExceptionMapper implements ExceptionMapper<DefaultOptionsMethodException> {
+
+    @Override
+    public Response toResponse(DefaultOptionsMethodException exception) {
+        return Response.ok().build();
+    }
+}

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/EntityAlreadyExistsExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/EntityAlreadyExistsExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.inventory.rest.exception.mappers;
+
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import org.hawkular.inventory.api.EntityAlreadyExistsException;
+import org.hawkular.inventory.rest.json.ApiError;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.1.0
+ */
+@Provider
+public class EntityAlreadyExistsExceptionMapper implements ExceptionMapper<EntityAlreadyExistsException> {
+
+    @Override
+    public Response toResponse(EntityAlreadyExistsException exception) {
+            return Response.status(NOT_FOUND).entity(new ApiError(exception.getMessage(), ExceptionMapperUtils
+                    .EntityIdAndPath.fromException(exception))).build();
+    }
+}

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/EntityNotFoundExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/EntityNotFoundExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.inventory.rest.exception.mappers;
+
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import org.hawkular.inventory.api.EntityNotFoundException;
+import org.hawkular.inventory.rest.json.ApiError;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.1.0
+ */
+@Provider
+public class EntityNotFoundExceptionMapper implements ExceptionMapper<EntityNotFoundException> {
+
+    @Override
+    public Response toResponse(EntityNotFoundException exception) {
+            return Response.status(NOT_FOUND).entity(new ApiError(exception.getMessage(), ExceptionMapperUtils
+                    .EntityTypeAndPath.fromException(exception))).build();
+    }
+}

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/FallbackExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/FallbackExceptionMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.inventory.rest.exception.mappers;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import org.hawkular.inventory.rest.RestApiLogger;
+import org.hawkular.inventory.rest.json.ApiError;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.1.0
+ */
+@Provider
+public class FallbackExceptionMapper implements ExceptionMapper<Exception> {
+
+    @Override
+    public Response toResponse(Exception exception) {
+        RestApiLogger.LOGGER.warn(exception);
+        return Response.serverError().entity(new ApiError(exception.getMessage())).build();
+    }
+}

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/IllegalArgumentExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/IllegalArgumentExceptionMapper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.inventory.rest.exception.mappers;
+
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.1.0
+ */
+@Provider
+public class IllegalArgumentExceptionMapper implements ExceptionMapper<IllegalArgumentException> {
+
+    @Override
+    public Response toResponse(IllegalArgumentException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, BAD_REQUEST);
+    }
+}

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/RelationAlreadyExistsExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/RelationAlreadyExistsExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.inventory.rest.exception.mappers;
+
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import org.hawkular.inventory.api.RelationAlreadyExistsException;
+import org.hawkular.inventory.rest.json.ApiError;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.1.0
+ */
+@Provider
+public class RelationAlreadyExistsExceptionMapper implements ExceptionMapper<RelationAlreadyExistsException> {
+
+    @Override
+    public Response toResponse(RelationAlreadyExistsException exception) {
+            return Response.status(NOT_FOUND).entity(new ApiError(exception.getMessage(), ExceptionMapperUtils
+                    .RelationshipNameAndPath.fromException(exception))).build();
+    }
+}

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/RelationNotFoundExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/RelationNotFoundExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.hawkular.inventory.rest.exception.mappers;
+
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import org.hawkular.inventory.api.RelationNotFoundException;
+import org.hawkular.inventory.rest.json.ApiError;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.1.0
+ */
+@Provider
+public class RelationNotFoundExceptionMapper implements ExceptionMapper<RelationNotFoundException> {
+
+    @Override
+    public Response toResponse(RelationNotFoundException exception) {
+            return Response.status(NOT_FOUND).entity(new ApiError(exception.getMessage(), ExceptionMapperUtils
+                    .RelationshipNameAndPath.fromException(exception))).build();
+    }
+}

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/json/EmbeddedObjectMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/json/EmbeddedObjectMapper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.rest.json;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.hawkular.inventory.api.model.Relationship;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.1.0
+ */
+public class EmbeddedObjectMapper extends ObjectMapper {
+
+    public EmbeddedObjectMapper() {
+        JacksonConfig.initializeObjectMapper(this);
+        SimpleModule relationshipModule = new SimpleModule("RelationshipEmbeddedModule", new Version(0, 1, 0, null,
+                                                           "org.hawkular.inventory", "inventory-rest-api"));
+        relationshipModule.addSerializer(Relationship.class, new RelationshipEmbeddedJacksonSerializer());
+        registerModule(relationshipModule);
+    }
+}

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/json/RelationshipEmbeddedJacksonSerializer.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/json/RelationshipEmbeddedJacksonSerializer.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.rest.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.util.Map;
+import org.hawkular.inventory.api.model.Entity;
+import org.hawkular.inventory.api.model.Relationship;
+import org.hawkular.inventory.rest.Security;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.1.0
+ */
+public class RelationshipEmbeddedJacksonSerializer extends JsonSerializer<Relationship> {
+    public static final String FIELD_CONTEXT_KEY = "@context";
+    public static final String FIELD_CONTEXT_URI = "http://hawkular.org/inventory/0.1.0/relationship.jsonld";
+    public static final String FIELD_ID = RelationshipJacksonSerializer.FIELD_ID;
+    public static final String FIELD_SHORT_ID = "shortId";
+    public static final String FIELD_NAME = RelationshipJacksonSerializer.FIELD_NAME;
+    public static final String FIELD_SOURCE = RelationshipJacksonSerializer.FIELD_SOURCE;
+    public static final String FIELD_TARGET = RelationshipJacksonSerializer.FIELD_TARGET;
+    public static final String FIELD_TYPE = "type";
+    public static final String FIELD_PROPERTIES = RelationshipJacksonSerializer.FIELD_PROPERTIES;
+
+    /**
+     * <pre>compact:
+     * {
+     *   "id": "1337",
+     *   "source": "/tenants/28026b36-8fe4-4332-84c8-524e173a68bf",
+     *   "name": "contains",
+     *   "target": "28026b36-8fe4-4332-84c8-524e173a68bf/environments/test"
+     * }</pre>
+     * <p>
+     * <pre>embedded:
+     * {
+     *   "@context": "http://hawkular.org/inventory/0.1.0/relationship.jsonld",
+     *   "id": "1337",
+     *   "name": "contains",
+     *   "source": {
+     *      id: "/tenants/28026b36-8fe4-4332-84c8-524e173a68bf",
+     *      shortId: "28026b36-8fe4-4332-84c8-524e173a68bf",
+     *      type: "Tenant"
+     *   },
+     *   "target": {
+     *      id: "28026b36-8fe4-4332-84c8-524e173a68bf/environments/test",
+     *      shortId: "test",
+     *      type: "Environment"
+     *   }
+     * }</pre>
+     */
+    @Override
+    public void serialize(Relationship relationship, JsonGenerator jg, SerializerProvider
+            serializerProvider) throws IOException {
+        jg.writeStartObject();
+
+        jg.writeFieldName(FIELD_CONTEXT_KEY);
+        jg.writeString(FIELD_CONTEXT_URI);
+
+        jg.writeFieldName(FIELD_ID);
+        jg.writeString(relationship.getId());
+
+        jg.writeFieldName(FIELD_NAME);
+        jg.writeString(relationship.getName());
+
+        serializeEntity(relationship.getSource(), jg, FIELD_SOURCE);
+        serializeEntity(relationship.getTarget(), jg, FIELD_TARGET);
+
+        if (relationship.getProperties() != null && !relationship.getProperties().isEmpty()) {
+            jg.writeFieldName(FIELD_PROPERTIES);
+            jg.writeStartObject();
+            for (Map.Entry<String, Object> property : relationship.getProperties().entrySet()) {
+                jg.writeFieldName(property.getKey());
+                jg.writeObject(property.getValue());
+            }
+            jg.writeEndObject();
+        }
+
+        jg.writeEndObject();
+    }
+
+    private void serializeEntity(Entity entity, JsonGenerator jsonGenerator, String fieldName)
+            throws IOException {
+        jsonGenerator.writeFieldName(fieldName);
+        jsonGenerator.writeStartObject();
+
+        jsonGenerator.writeFieldName(FIELD_ID);
+        jsonGenerator.writeString(Security.getStableId(entity));
+
+        jsonGenerator.writeFieldName(FIELD_SHORT_ID);
+        jsonGenerator.writeString(entity.getId());
+
+        jsonGenerator.writeFieldName(FIELD_TYPE);
+        jsonGenerator.writeString(entity.getClass().getSimpleName());
+
+        jsonGenerator.writeEndObject();
+    }
+}

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/json/RelationshipJacksonSerializer.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/json/RelationshipJacksonSerializer.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
+import java.util.Map;
 import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.rest.Security;
 
@@ -32,50 +33,61 @@ public class RelationshipJacksonSerializer extends JsonSerializer<Relationship> 
     public static final String FIELD_NAME = "name";
     public static final String FIELD_SOURCE = "source";
     public static final String FIELD_TARGET = "target";
+    public static final String FIELD_PROPERTIES = "properties";
 
     /**
      * <pre>compact:
      * {
      *   "id": "1337",
-     *   "source": "/tenant",
+     *   "source": "/tenants/28026b36-8fe4-4332-84c8-524e173a68bf",
      *   "name": "contains",
-     *   "target": "/environments/test"
+     *   "target": "28026b36-8fe4-4332-84c8-524e173a68bf/environments/test"
      * }</pre>
-     *
+     * <p>
      * <pre>embedded:
      * {
      *   "@context": "http://hawkular.org/inventory/0.1.0/relationship.jsonld",
      *   "id": "1337",
      *   "name": "contains",
      *   "source": {
-     *      id: "/tenant/28026b36-8fe4-4332-84c8-524e173a68bf",
+     *      id: "/tenants/28026b36-8fe4-4332-84c8-524e173a68bf",
      *      shortId: "28026b36-8fe4-4332-84c8-524e173a68bf",
      *      type: "Tenant"
      *   },
      *   "target": {
-     *      id: "/environments/test",
+     *      id: "28026b36-8fe4-4332-84c8-524e173a68bf/environments/test",
      *      shortId: "test",
      *      type: "Environment"
      *   }
      * }</pre>
      */
     @Override
-    public void serialize(Relationship relationship, JsonGenerator jsonGenerator, SerializerProvider
+    public void serialize(Relationship relationship, JsonGenerator jg, SerializerProvider
             serializerProvider) throws IOException {
-        jsonGenerator.writeStartObject();
+        jg.writeStartObject();
 
-        jsonGenerator.writeFieldName(FIELD_ID);
-        jsonGenerator.writeString(relationship.getId());
+        jg.writeFieldName(FIELD_ID);
+        jg.writeString(relationship.getId());
 
-        jsonGenerator.writeFieldName(FIELD_NAME);
-        jsonGenerator.writeString(relationship.getName());
+        jg.writeFieldName(FIELD_NAME);
+        jg.writeString(relationship.getName());
 
-        jsonGenerator.writeFieldName(FIELD_SOURCE);
-        jsonGenerator.writeString(Security.getStableId(relationship.getSource()));
+        jg.writeFieldName(FIELD_SOURCE);
+        jg.writeString(Security.getStableId(relationship.getSource()));
 
-        jsonGenerator.writeFieldName(FIELD_TARGET);
-        jsonGenerator.writeString(Security.getStableId(relationship.getTarget()));
+        jg.writeFieldName(FIELD_TARGET);
+        jg.writeString(Security.getStableId(relationship.getTarget()));
 
-        jsonGenerator.writeEndObject();
+        if (relationship.getProperties() != null && !relationship.getProperties().isEmpty()) {
+            jg.writeFieldName(FIELD_PROPERTIES);
+            jg.writeStartObject();
+            for (Map.Entry<String, Object> property : relationship.getProperties().entrySet()) {
+                jg.writeFieldName(property.getKey());
+                jg.writeObject(property.getValue());
+            }
+            jg.writeEndObject();
+        }
+
+        jg.writeEndObject();
     }
 }


### PR DESCRIPTION
- Adding exception mappers for `RelationNotFoundException` and `RelationAlreadyExistsException`, that was why the API wasn't returning proper return codes.
- Refactoring one big exception mapper into smaller ones and preparing the ground for Jeeva's general jax-rs mappers

THIS PR is based on #90
