### PR TITLE
'overriding' the scope of activemq dependencies to provided

### DIFF
--- a/bus-api/pom.xml
+++ b/bus-api/pom.xml
@@ -48,6 +48,21 @@
       <version>0.0.5</version>
     </dependency>
 
+    <!-- these will be provided by our RA - the MDB itself will never need ActiveMQ specific classes -->
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-all</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-jaas</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>

--- a/bus/pom.xml
+++ b/bus/pom.xml
@@ -54,6 +54,21 @@
       <version>0.0.5</version>
     </dependency>
 
+    <!-- these will be provided by our RA - the MDB itself will never need ActiveMQ specific classes -->
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-all</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-jaas</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>

--- a/hawkular-integrated-inventory-rest/pom.xml
+++ b/hawkular-integrated-inventory-rest/pom.xml
@@ -50,6 +50,21 @@
       <version>${project.version}</version>
     </dependency>
 
+    <!-- these will be provided by our RA - the MDB itself will never need ActiveMQ specific classes -->
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-all</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-jaas</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.hawkular.inventory</groupId>
       <artifactId>inventory-rest-api</artifactId>

--- a/rest-servlet/pom.xml
+++ b/rest-servlet/pom.xml
@@ -74,6 +74,21 @@
       <version>${project.version}</version>
     </dependency>
 
+    <!-- these will be provided by our RA - the MDB itself will never need ActiveMQ specific classes -->
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-all</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-jaas</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.hawkular.accounts</groupId>
       <artifactId>hawkular-accounts-api</artifactId>


### PR DESCRIPTION
In order,  not to bring them to the WF classpath twice and cause the deployment issue (http://activemq.2283324.n4.nabble.com/org-apache-activemq-ActiveMQConnectionFactory-cannot-be-cast-to-javax-jms-ConnectionFactory-td2367460.html)

They got transitively pulled together with `hawkular-bus-common` module.

this ugliness is the server log error this PR fixes: http://pastebin.com/yPt9HDas

I think it would be much better to declare the dependencies as provided on the `hawkular-bus-common` module level, but mazz needs them as compiled. Perhaps some default exclusions on the hawkular parent for the `hawkular-bus-common` dependency could do the same trick.

As for now, let's do the same what alert does here and here:
- https://github.com/hawkular/hawkular-alerts/blob/2a910970f14bafcedd3e56947ee801cc3ef76a80/hawkular-alerts-bus/pom.xml#L79:l92
- https://github.com/hawkular/hawkular-alerts/blob/2a910970f14bafcedd3e56947ee801cc3ef76a80/hawkular-actions-plugins/pom.xml#L79:l92
