### PR TITLE
HWKINVENT-54 + HWKINVENT-77 bad return codes, second attempt

### DIFF
--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/BadRequestExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/BadRequestExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/BadRequestExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/BadRequestExceptionMapper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.api.jaxrs.exception.mappers;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.hawkular.inventory.rest.exception.mappers.ExceptionMapperUtils;
+import org.jboss.resteasy.spi.BadRequestException;
+
+/**
+ * Exception mapper for any exception thrown by RESTEasy when HTTP Bad Request (400) is encountered.
+ * <p>
+ * This mapper let us reply to the user with a pre-determined message format if, for example, a {@link
+ * javax.ws.rs.ext.ParamConverter} throws an {@link java.lang.IllegalArgumentException}.
+ *
+ * @author Thomas Segismont
+ */
+@Provider
+public class BadRequestExceptionMapper implements ExceptionMapper<BadRequestException> {
+
+    @Override
+    public Response toResponse(BadRequestException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, Response.Status.BAD_REQUEST);
+    }
+}

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/EntityAlreadyExistsExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/EntityAlreadyExistsExceptionMapper.java
@@ -17,7 +17,7 @@
 
 package org.hawkular.inventory.rest.exception.mappers;
 
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -34,7 +34,7 @@ public class EntityAlreadyExistsExceptionMapper implements ExceptionMapper<Entit
 
     @Override
     public Response toResponse(EntityAlreadyExistsException exception) {
-            return Response.status(NOT_FOUND).entity(new ApiError(exception.getMessage(), ExceptionMapperUtils
-                    .EntityIdAndPath.fromException(exception))).build();
+        return ExceptionMapperUtils.buildResponse(new ApiError(exception.getMessage(), ExceptionMapperUtils
+                .EntityIdAndPath.fromException(exception)), exception, CONFLICT);
     }
 }

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/ExceptionMapperUtils.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/ExceptionMapperUtils.java
@@ -38,14 +38,16 @@ public class ExceptionMapperUtils {
 
     }
 
-    public static Response buildResponse(Throwable exception, Response.Status status){
-        if (RestApiLogger.LOGGER.isTraceEnabled()) {
-            RestApiLogger.LOGGER.trace("RestEasy exception,", exception);
-        }
+    public static Response buildResponse(ApiError error, Throwable exception, Response.Status status){
+        RestApiLogger.LOGGER.warn("RestEasy exception, ", exception);
         return Response.status(status)
-                .entity(new ApiError(Throwables.getRootCause(exception).getMessage()))
+                .entity(error)
                 .type(MediaType.APPLICATION_JSON_TYPE)
                 .build();
+    }
+
+    public static Response buildResponse(Throwable exception, Response.Status status){
+        return buildResponse(new ApiError(Throwables.getRootCause(exception).getMessage()), exception, status);
     }
 
     public static class EntityTypeAndPath {

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/FallbackExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/FallbackExceptionMapper.java
@@ -17,11 +17,11 @@
 
 package org.hawkular.inventory.rest.exception.mappers;
 
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-import org.hawkular.inventory.rest.RestApiLogger;
-import org.hawkular.inventory.rest.json.ApiError;
 
 /**
  * @author Jirka Kremser
@@ -32,7 +32,6 @@ public class FallbackExceptionMapper implements ExceptionMapper<Exception> {
 
     @Override
     public Response toResponse(Exception exception) {
-        RestApiLogger.LOGGER.warn(exception);
-        return Response.serverError().entity(new ApiError(exception.getMessage())).build();
+        return ExceptionMapperUtils.buildResponse(exception, INTERNAL_SERVER_ERROR);
     }
 }

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotAcceptableExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotAcceptableExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotAcceptableExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotAcceptableExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,27 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.inventory.rest.exception.mappers;
 
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
-
+import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-import org.hawkular.inventory.api.EntityNotFoundException;
-import org.hawkular.inventory.rest.json.ApiError;
+import org.hawkular.inventory.rest.exception.mappers.ExceptionMapperUtils;
 
 /**
- * @author Jirka Kremser
- * @since 0.1.0
+ * Exception mapper for any exception thrown by RESTEasy when HTTP Not Acceptable (406) is encountered.
+ * <p>
+ * This mapper let us reply to the user with a pre-determined message format if, for example, receive a
+ * HTTP GET request with unsupported media type.
+ *
+ * @author Jeeva Kandasamy
  */
 @Provider
-public class EntityNotFoundExceptionMapper implements ExceptionMapper<EntityNotFoundException> {
+public class NotAcceptableExceptionMapper implements ExceptionMapper<NotAcceptableException> {
 
     @Override
-    public Response toResponse(EntityNotFoundException exception) {
-        return ExceptionMapperUtils.buildResponse(new ApiError(exception.getMessage(), ExceptionMapperUtils
-                .EntityTypeAndPath.fromException(exception)), exception, NOT_FOUND);
+    public Response toResponse(NotAcceptableException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, Response.Status.NOT_ACCEPTABLE);
     }
+
 }

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotAcceptableExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotAcceptableExceptionMapper.java
@@ -20,7 +20,6 @@ import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-import org.hawkular.inventory.rest.exception.mappers.ExceptionMapperUtils;
 
 /**
  * Exception mapper for any exception thrown by RESTEasy when HTTP Not Acceptable (406) is encountered.

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotAllowedExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotAllowedExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotAllowedExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotAllowedExceptionMapper.java
@@ -20,7 +20,6 @@ import javax.ws.rs.NotAllowedException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-import org.hawkular.inventory.rest.exception.mappers.ExceptionMapperUtils;
 
 /**
  * Exception mapper for any exception thrown by RESTEasy when HTTP Method Not Allowed (405) is encountered.

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotAllowedExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotAllowedExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,27 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.inventory.rest.exception.mappers;
 
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
-
+import javax.ws.rs.NotAllowedException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-import org.hawkular.inventory.api.EntityNotFoundException;
-import org.hawkular.inventory.rest.json.ApiError;
+import org.hawkular.inventory.rest.exception.mappers.ExceptionMapperUtils;
 
 /**
- * @author Jirka Kremser
- * @since 0.1.0
+ * Exception mapper for any exception thrown by RESTEasy when HTTP Method Not Allowed (405) is encountered.
+ * <p>
+ * This mapper let us reply to the user with a pre-determined message format if, for example, receive
+ * a HTTP POST request for a resource which does not support for HTTP POST method.
+ *
+ * @author Jeeva Kandasamy
  */
 @Provider
-public class EntityNotFoundExceptionMapper implements ExceptionMapper<EntityNotFoundException> {
+public class NotAllowedExceptionMapper implements ExceptionMapper<NotAllowedException> {
 
     @Override
-    public Response toResponse(EntityNotFoundException exception) {
-        return ExceptionMapperUtils.buildResponse(new ApiError(exception.getMessage(), ExceptionMapperUtils
-                .EntityTypeAndPath.fromException(exception)), exception, NOT_FOUND);
+    public Response toResponse(NotAllowedException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, Response.Status.METHOD_NOT_ALLOWED);
     }
+
 }

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotSupportedExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotSupportedExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotSupportedExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotSupportedExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,27 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.inventory.rest.exception.mappers;
 
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
-
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-import org.hawkular.inventory.api.EntityNotFoundException;
-import org.hawkular.inventory.rest.json.ApiError;
+import org.hawkular.inventory.rest.exception.mappers.ExceptionMapperUtils;
 
 /**
- * @author Jirka Kremser
- * @since 0.1.0
+ * Exception mapper for any exception thrown by RESTEasy when HTTP Unsupported Media Type (415) is encountered.
+ * <p>
+ * This mapper let us reply to the user with a pre-determined message format if, for example, receive a
+ * HTTP POST request with unsupported media type.
+ *
+ * @author Jeeva Kandasamy
  */
 @Provider
-public class EntityNotFoundExceptionMapper implements ExceptionMapper<EntityNotFoundException> {
+public class NotSupportedExceptionMapper implements ExceptionMapper<NotSupportedException> {
 
     @Override
-    public Response toResponse(EntityNotFoundException exception) {
-        return ExceptionMapperUtils.buildResponse(new ApiError(exception.getMessage(), ExceptionMapperUtils
-                .EntityTypeAndPath.fromException(exception)), exception, NOT_FOUND);
+    public Response toResponse(NotSupportedException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, Response.Status.UNSUPPORTED_MEDIA_TYPE);
     }
+
 }

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotSupportedExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/NotSupportedExceptionMapper.java
@@ -20,7 +20,6 @@ import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-import org.hawkular.inventory.rest.exception.mappers.ExceptionMapperUtils;
 
 /**
  * Exception mapper for any exception thrown by RESTEasy when HTTP Unsupported Media Type (415) is encountered.

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/ReaderExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/ReaderExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/ReaderExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/ReaderExceptionMapper.java
@@ -20,7 +20,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import org.hawkular.inventory.rest.exception.mappers.ExceptionMapperUtils;
 import org.jboss.resteasy.spi.ReaderException;
 
 /**

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/ReaderExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/ReaderExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,27 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.inventory.rest.exception.mappers;
-
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-import org.hawkular.inventory.api.EntityNotFoundException;
-import org.hawkular.inventory.rest.json.ApiError;
+
+import org.hawkular.inventory.rest.exception.mappers.ExceptionMapperUtils;
+import org.jboss.resteasy.spi.ReaderException;
 
 /**
- * @author Jirka Kremser
- * @since 0.1.0
+ * Exception mapper for any exception thrown by a body reader chain.
+ * <p>
+ * This mapper let us reply to the user with a pre-determined message format if, for example, a JSON entity cannot be
+ * parsed.
+ *
+ * @author Thomas Segismont
  */
 @Provider
-public class EntityNotFoundExceptionMapper implements ExceptionMapper<EntityNotFoundException> {
+public class ReaderExceptionMapper implements ExceptionMapper<ReaderException> {
 
     @Override
-    public Response toResponse(EntityNotFoundException exception) {
-        return ExceptionMapperUtils.buildResponse(new ApiError(exception.getMessage(), ExceptionMapperUtils
-                .EntityTypeAndPath.fromException(exception)), exception, NOT_FOUND);
+    public Response toResponse(ReaderException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, Response.Status.BAD_REQUEST);
     }
 }

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/RelationAlreadyExistsExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/RelationAlreadyExistsExceptionMapper.java
@@ -17,7 +17,7 @@
 
 package org.hawkular.inventory.rest.exception.mappers;
 
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -34,7 +34,7 @@ public class RelationAlreadyExistsExceptionMapper implements ExceptionMapper<Rel
 
     @Override
     public Response toResponse(RelationAlreadyExistsException exception) {
-            return Response.status(NOT_FOUND).entity(new ApiError(exception.getMessage(), ExceptionMapperUtils
-                    .RelationshipNameAndPath.fromException(exception))).build();
+        return ExceptionMapperUtils.buildResponse(new ApiError(exception.getMessage(), ExceptionMapperUtils
+                .RelationshipNameAndPath.fromException(exception)), exception, CONFLICT);
     }
 }

--- a/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/RelationNotFoundExceptionMapper.java
+++ b/rest-servlet/src/main/java/org/hawkular/inventory/rest/exception/mappers/RelationNotFoundExceptionMapper.java
@@ -34,7 +34,7 @@ public class RelationNotFoundExceptionMapper implements ExceptionMapper<Relation
 
     @Override
     public Response toResponse(RelationNotFoundException exception) {
-            return Response.status(NOT_FOUND).entity(new ApiError(exception.getMessage(), ExceptionMapperUtils
-                    .RelationshipNameAndPath.fromException(exception))).build();
+            return ExceptionMapperUtils.buildResponse(new ApiError(exception.getMessage(), ExceptionMapperUtils
+                    .RelationshipNameAndPath.fromException(exception)), exception, NOT_FOUND);
     }
 }


### PR DESCRIPTION
Second attempt after https://github.com/hawkular/hawkular-inventory/pull/91
There was a copy&paste issue. This PR is also adding the exception mappers metrics use (kudos to @jkandasa )

Also, I think it's good to at least produce a warning to the server log instead of silently swallowing it, so instead of `log.trace(exception)` it's now `log.warn(exception)`
