### PR TITLE
org.jboss.logging.{LogMessage|MessageLogger|etc.} have been deprecate…

### DIFF
--- a/api/src/main/java/org/hawkular/inventory/api/Log.java
+++ b/api/src/main/java/org/hawkular/inventory/api/Log.java
@@ -17,11 +17,11 @@
 package org.hawkular.inventory.api;
 
 import org.jboss.logging.BasicLogger;
-import org.jboss.logging.LogMessage;
 import org.jboss.logging.Logger;
-import org.jboss.logging.MessageLogger;
 import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
 /**


### PR DESCRIPTION
…d (just a change in the package name)
