### PR TITLE
Travis badge with status only of builds of master branch

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,7 @@ in their own GitHub repositories and integrated in this project.
 
 ifdef::env-github[]
 [link=https://travis-ci.org/hawkular/hawkular-inventory]
-image:https://travis-ci.org/hawkular/hawkular-inventory.svg["Build Status", link="https://travis-ci.org/hawkular/hawkular-inventory"]{nbsp}
+image:https://travis-ci.org/hawkular/hawkular-inventory.svg?branch=master["Build Status", link="https://travis-ci.org/hawkular/hawkular-inventory"]{nbsp}
 image:https://badges.gitter.im/Join%20Chat.svg[link="https://gitter.im/hawkular/hawkular-inventory?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
 endif::[]
 


### PR DESCRIPTION
Yet another 1 liner PR ;)

exactly the same change as in here https://github.com/hawkular/hawkular/pull/339

_travis shows red badge on the GitHub readme even if some build for other branch fails, in my opinion and in ideal world the badge should show the status of the branch I am looking at in the GitHub, unfortunatelly it's not currently possible (https://github.com/travis-ci/travis-ci/issues/1892). So at least let's make the icon mean the status of the last build for master branch, and not 'status of the last build of any branch'_
