### PR TITLE
[HWKINVENT-106] Meaningful error when parent not found.

### DIFF
--- a/api/src/main/java/org/hawkular/inventory/api/EntityNotFoundException.java
+++ b/api/src/main/java/org/hawkular/inventory/api/EntityNotFoundException.java
@@ -65,6 +65,7 @@ public final class EntityNotFoundException extends InventoryException {
 
     @Override
     public String getMessage() {
-        return entityType.getSimpleName() + " not found on any of the following paths: " + Arrays.deepToString(filters);
+        return (entityType == null ? "Nothing" : ("No " + entityType.getSimpleName())) +
+                " found on any of the following paths: " + Arrays.deepToString(filters);
     }
 }

--- a/api/src/main/java/org/hawkular/inventory/base/Mutator.java
+++ b/api/src/main/java/org/hawkular/inventory/base/Mutator.java
@@ -207,9 +207,19 @@ abstract class Mutator<BE, E extends Entity<Blueprint, Update>, Blueprint extend
 
     private BE getParent() {
         return ElementTypeVisitor.accept(context.entityClass, new ElementTypeVisitor.Simple<BE, Void>() {
+            @SuppressWarnings("unchecked")
             @Override
             protected BE defaultAction() {
                 Page<BE> res = context.backend.query(context.sourcePath, Pager.single());
+
+                if (res.isEmpty()) {
+                    Class<? extends Entity<?, ?>> parentEntityClass = null;
+                    if (context.previous != null && Entity.class.isAssignableFrom(context.previous.entityClass)) {
+                        parentEntityClass = (Class<? extends Entity<?, ?>>) context.previous.entityClass;
+                    }
+
+                    throw new EntityNotFoundException(parentEntityClass, Query.filters(context.sourcePath));
+                }
 
                 return res.get(0);
             }

--- a/api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryPersistenceCheck.java
+++ b/api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryPersistenceCheck.java
@@ -1328,6 +1328,17 @@ public abstract class AbstractBaseInventoryPersistenceCheck<E> {
     }
 
     @Test
+    public void testCreationUnderNonExistentParentThrowsEntityNotFoundException() throws Exception {
+        try {
+            inventory.tenants().get("com.acme.tenant").environments().get("production").feeds().get("no-feed")
+                    .resources().create(Resource.Blueprint.builder().withId("blah").withResourceTypePath("../../URL")
+                    .build());
+        } catch (EntityNotFoundException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
     public void testObserveTenants() throws Exception {
         runObserverTest(Tenant.class, 0, 0, () -> {
             inventory.tenants().create(new Tenant.Blueprint("xxx"));
@@ -1413,7 +1424,7 @@ public abstract class AbstractBaseInventoryPersistenceCheck<E> {
             inventory.tenants().get("t").resourceTypes().create(ResourceType.Blueprint.builder().withId("rt").build());
             inventory.tenants().get("t").metricTypes()
                     .create(MetricType.Blueprint.builder(MetricDataType.COUNTER).withId("mt")
-                                    .withUnit(MetricUnit.BYTE).build());
+                            .withUnit(MetricUnit.BYTE).build());
 
             inventory.tenants().get("t").environments().get("e").feedlessResources()
                     .create(new Resource.Blueprint("r", "/rt"));


### PR DESCRIPTION
Instead of IOOBE we now throw an EntityNotFoundException pointing to the
parent.

Also, made the TraversalContext store reference to the "source" or previous
traversal context, so that we can access information about the previous
traversal steps. This is currently used only for error reporting in case
of missing parent but I imagine it could be used in other places, too.

Note that the contexts are short lived objects that only live during the
lifetime of a traversal, so it is IMHO not crucial to keep their numbers
at minimum.
