### PR TITLE
HWKINVENT-103 | removed tinkergraph from classpath

### DIFF
--- a/hawkular-inventory-cdi/src/main/java/org/hawkular/inventory/cdi/OfficialInventoryProducer.java
+++ b/hawkular-inventory-cdi/src/main/java/org/hawkular/inventory/cdi/OfficialInventoryProducer.java
@@ -99,7 +99,7 @@ public class OfficialInventoryProducer {
         int failures = 0;
         int maxFailures = 5;
         boolean initialized = false;
-        while (failures++ < maxFailures) {
+        while (!initialized && failures++ < maxFailures) {
             try {
                 inventory.initialize(cfg);
 

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/pom.xml
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/pom.xml
@@ -105,7 +105,7 @@
           <groupId>org.hawkular.inventory</groupId>
           <artifactId>hawkular-inventory-impl-tinkerpop-tinkergraph-provider</artifactId>
           <version>${project.version}</version>
-          <scope>runtime</scope>
+          <scope>test</scope>
         </dependency>
       </dependencies>
 


### PR DESCRIPTION
Removed dependency on tinkerGraph from runtime. 

See OfficialInventoryProducer.java#102  I think this was also causing long startup of inventory.
