### PR TITLE
HWKINVENT-109 | BUS - new connection is created every time

### DIFF
--- a/hawkular-inventory-bus/src/main/java/org/hawkular/inventory/bus/BusIntegration.java
+++ b/hawkular-inventory-bus/src/main/java/org/hawkular/inventory/bus/BusIntegration.java
@@ -24,7 +24,6 @@ import javax.jms.TopicConnectionFactory;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
-import org.hawkular.bus.common.ConnectionContextFactory;
 import org.hawkular.inventory.api.Action;
 import org.hawkular.inventory.api.Interest;
 import org.hawkular.inventory.api.Inventory;
@@ -70,9 +69,7 @@ public final class BusIntegration {
         TopicConnectionFactory tcf = (TopicConnectionFactory) namingContext.lookup(
                 configuration.getConnectionFactoryJndiName());
 
-        ConnectionContextFactory ccf = new ConnectionContextFactory(tcf);
-
-        this.messageSender = new MessageSender(ccf, configuration.getInventoryChangesTopicName());
+        this.messageSender = new MessageSender(tcf, configuration.getInventoryChangesTopicName());
 
         install();
     }


### PR DESCRIPTION
see  https://developer.jboss.org/wiki/ShouldICacheJMSConnectionsAndJMSSessions

The reason is, when you use the JMS API from inside an EJB (including an MDB), or a servlet, (or a MBean in JBoss), then when you call createConnection() or createSession() on your JMS connection factory or JMS connection, you're not actually making those calls on a real JMS connection factory or JMS connection.

The JEE specification mandates that the connection factory you use is actually a JCA managed connection factory (see the JCA specification). The JCA managed connection factory wraps the real underlying JMS connection factory and implements the same interface so to you, the user, you're just using a normal connection factory, right?
