### PR TITLE
[HWKINVENT-62] Simplify the API.

### DIFF
--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Data.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Data.java
@@ -27,26 +27,17 @@ import org.hawkular.inventory.api.paging.Pager;
  * @author Lukas Krejci
  * @since 0.3.0
  */
-public final class Datas {
+public final class Data {
 
-    private Datas() {
+    private Data() {
 
     }
 
-    protected interface ReadBase {
-
-        /**
-         * @return the access to the resource this data belongs to.
-         */
-        Resources.Single resource();
-    }
-
-    public interface Read extends ReadInterface<Single, Multiple, Void>, ReadBase {
+    public interface Read extends ReadInterface<Single, Multiple, DataEntity.Role> {
     }
 
     public interface ReadWrite
-            extends ReadWriteInterface<DataEntity.Update, DataEntity.Blueprint, Single, Multiple, Void>,
-            ReadBase {
+            extends ReadWriteInterface<DataEntity.Update, DataEntity.Blueprint, Single, Multiple, DataEntity.Role> {
     }
 
     public interface Single extends ResolvableToSingle<DataEntity, DataEntity.Update> {
@@ -125,7 +116,7 @@ public final class Datas {
          * @param pager    pager to use to page the data
          * @return the page of the data entries
          */
-        Page<StructuredData> datas(RelativePath dataPath, Pager pager);
+        Page<StructuredData> data(RelativePath dataPath, Pager pager);
 
         /**
          * Similar to {@link Single#flatData(RelativePath)}, only resolved over multiple entities.
@@ -134,11 +125,11 @@ public final class Datas {
          * @param pager    pager to use to page the data
          * @return the page of the data entries
          */
-        Page<StructuredData> flatDatas(RelativePath dataPath, Pager pager);
+        Page<StructuredData> flatData(RelativePath dataPath, Pager pager);
 
         @Override
         default boolean anyExists() {
-            return !flatDatas(RelativePath.empty().get(),
+            return !flatData(RelativePath.empty().get(),
                     Pager.builder().withPageSize(1).orderBy(Order.unspecified()).build()).isEmpty();
         }
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
@@ -1108,14 +1108,10 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public Datas.ReadWrite configuration() {
-            return new DatasReadWrite();
+        public Data.ReadWrite data() {
+            return new DataReadWrite();
         }
 
-        @Override
-        public Datas.ReadWrite connectionConfiguration() {
-            return new DatasReadWrite();
-        }
     }
 
     public static class ResourcesMultiple implements Resources.Multiple {
@@ -1156,14 +1152,10 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public Datas.Read configuration() {
-            return new DatasRead();
+        public Data.Read data() {
+            return new DataRead();
         }
 
-        @Override
-        public Datas.Read connectionConfiguration() {
-            return new DatasRead();
-        }
     }
 
     public static class ResourcesReadAssociate implements Resources.ReadAssociate {
@@ -1195,58 +1187,48 @@ public class EmptyInventory implements Inventory {
         }
     }
 
-    public static class DatasRead implements Datas.Read {
+    public static class DataRead implements Data.Read {
 
         @Override
-        public Datas.Multiple getAll(Filter[][] filters) {
+        public Data.Multiple getAll(Filter[][] filters) {
             return new DatasMultiple();
         }
 
         @Override
-        public Datas.Single get(Void ignored) throws EntityNotFoundException {
+        public Data.Single get(DataEntity.Role ignored) throws EntityNotFoundException {
             return new DatasSingle();
-        }
-
-        @Override
-        public Resources.Single resource() {
-            return new ResourcesSingle();
         }
     }
 
-    public static class DatasReadWrite implements Datas.ReadWrite {
+    public static class DataReadWrite implements Data.ReadWrite {
 
         @Override
-        public Resources.Single resource() {
-            return new ResourcesSingle();
-        }
-
-        @Override
-        public Datas.Multiple getAll(Filter[][] filters) {
+        public Data.Multiple getAll(Filter[][] filters) {
             return new DatasMultiple();
         }
 
         @Override
-        public Datas.Single get(Void ignored) throws EntityNotFoundException {
+        public Data.Single get(DataEntity.Role ignored) throws EntityNotFoundException {
             return new DatasSingle();
         }
 
         @Override
-        public Datas.Single create(DataEntity.Blueprint blueprint) throws EntityAlreadyExistsException {
+        public Data.Single create(DataEntity.Blueprint blueprint) throws EntityAlreadyExistsException {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public void update(Void ignored, DataEntity.Update update) throws EntityNotFoundException {
+        public void update(DataEntity.Role ignored, DataEntity.Update update) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public void delete(Void ignored) throws EntityNotFoundException {
+        public void delete(DataEntity.Role ignored) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
     }
 
-    public static class DatasSingle implements Datas.Single {
+    public static class DatasSingle implements Data.Single {
         @Override
         public StructuredData flatData(RelativePath dataPath) {
             throw entityNotFound(null);
@@ -1273,19 +1255,19 @@ public class EmptyInventory implements Inventory {
         }
     }
 
-    public static class DatasMultiple implements Datas.Multiple {
+    public static class DatasMultiple implements Data.Multiple {
         @Override
         public Page<DataEntity> entities(Pager pager) {
             return emptyPage(pager);
         }
 
         @Override
-        public Page<StructuredData> datas(RelativePath dataPath, Pager pager) {
+        public Page<StructuredData> data(RelativePath dataPath, Pager pager) {
             return emptyPage(pager);
         }
 
         @Override
-        public Page<StructuredData> flatDatas(RelativePath dataPath, Pager pager) {
+        public Page<StructuredData> flatData(RelativePath dataPath, Pager pager) {
             return emptyPage(pager);
         }
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Inventory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Inventory.java
@@ -288,7 +288,7 @@ public interface Inventory extends AutoCloseable {
      * <p>Note that this does NOT support paths that end inside a structured data, because structured data is not a
      * standalone inventory entity and does not have a separate access interface. For such paths, you need to extract
      * the parent path to the data entity, pass it to this method and then use the
-     * {@link org.hawkular.inventory.api.Datas.Single#data(RelativePath)} or {@link Datas.Single#flatData(RelativePath)}
+     * {@link Data.Single#data(RelativePath)} or {@link Data.Single#flatData(RelativePath)}
      * methods to get at the target portion of the structured data specified by the path.
      *
      * @param path            the path to the element (entity or relationship)
@@ -378,17 +378,9 @@ public interface Inventory extends AutoCloseable {
 
             @Override
             public Single visitData(Void parameter) {
-
                 Resources.Single res = inspect(path.up(), Resources.Single.class);
 
-                switch (path.ids().getDataRole()) {
-                    case configuration:
-                        return accessInterface.cast(res.configuration().get(null));
-                    case connectionConfiguration:
-                        return accessInterface.cast(res.connectionConfiguration().get(null));
-                    default:
-                        throw new IllegalStateException("Incomplete mapping of data roles in Inventory#inspect()");
-                }
+                return accessInterface.cast(res.data().get(path.ids().getDataRole()));
             }
 
             @Override

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Relationships.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Relationships.java
@@ -90,21 +90,6 @@ public final class Relationships {
         isParentOf,
 
         /**
-         * A relationship from a resource to a structural data that contains the configuration of that resource.
-         *
-         * <p>The relationship is 1-to-1. There is no sharing of configuration objects between different resources.
-         */
-        isConfiguredBy,
-
-        /**
-         * A relationship from a resource to a structural data that stores info about how the feed should connect to
-         * the resource.
-         *
-         * <p>The relationship is 1-to-1. There is no sharing of configuration objects between different resources.
-         */
-        connectsUsing,
-
-        /**
          * This relationship is used to link the {@link org.hawkular.inventory.api.model.DataEntity} to its data.
          * This relationship is invisible to the API users, because one cannot obtain a {@link Relationship} object
          * of it using the API but it is specified here nevertheless because it is a part of the contract of the API

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Resources.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Resources.java
@@ -62,16 +62,18 @@ public final class Resources {
          */
         Read parents();
 
-        Data configuration();
-
-        Data connectionConfiguration();
+        /**
+         * @return data associated with the resource. See {@link org.hawkular.inventory.api.model.DataEntity.Role} for
+         * possible kinds of data associated with a resource.
+         */
+        Data data();
     }
 
     /**
      * Interface for accessing a single resource in a writable manner.
      */
     public interface Single extends ResolvableToSingleWithRelationships<Resource, Resource.Update>,
-            BrowserBase<Metrics.ReadAssociate, Datas.ReadWrite, ReadWrite, ReadAssociate> {
+            BrowserBase<Metrics.ReadAssociate, Data.ReadWrite, ReadWrite, ReadAssociate> {
 
         /**
          * @return access to the parent resource (if any) that contains the resource on the current position in the
@@ -89,7 +91,7 @@ public final class Resources {
      * {@link ReadInterface#get(Object)} method).
      */
     public interface Multiple
-            extends ResolvableToManyWithRelationships<Resource>, BrowserBase<Metrics.Read, Datas.Read,
+            extends ResolvableToManyWithRelationships<Resource>, BrowserBase<Metrics.Read, Data.Read,
             ReadContained, Read> {}
 
     public interface ReadBase<Address> extends ReadInterface<Single, Multiple, Address> {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/DataEntity.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/DataEntity.java
@@ -18,8 +18,6 @@ package org.hawkular.inventory.api.model;
 
 import java.util.Map;
 
-import org.hawkular.inventory.api.Relationships;
-
 /**
  * A data entity is an entity wrapping the data. It's sole purpose is to give a path to the piece of structured data.
  *
@@ -72,37 +70,28 @@ public class DataEntity extends Entity<DataEntity.Blueprint, DataEntity.Update> 
 
     public enum Role {
         configuration, connectionConfiguration;
-
-        /**
-         * @return the relationship that is used to express the role of the data entity. The data entity is related
-         * to its owner by this relationship (going from the owner to the data entity).
-         */
-        public Relationships.WellKnown getCorrespondingRelationship() {
-            switch (this) {
-                case configuration:
-                    return Relationships.WellKnown.isConfiguredBy;
-                case connectionConfiguration:
-                    return Relationships.WellKnown.connectsUsing;
-                default:
-                    throw new AssertionError("Incomplete data entity role to relationship mapping.");
-            }
-        }
     }
 
     public static final class Blueprint extends AbstractElement.Blueprint {
         private final StructuredData value;
+        private final DataEntity.Role role;
 
         public static Builder builder() {
             return new Builder();
         }
 
-        public Blueprint(StructuredData value, Map<String, Object> properties) {
+        public Blueprint(DataEntity.Role role, StructuredData value, Map<String, Object> properties) {
             super(properties);
+            this.role = role;
             this.value = value;
         }
 
         public StructuredData getValue() {
             return value;
+        }
+
+        public Role getRole() {
+            return role;
         }
 
         @Override
@@ -112,6 +101,7 @@ public class DataEntity extends Entity<DataEntity.Blueprint, DataEntity.Update> 
 
         public static final class Builder extends Entity.Blueprint.Builder<Blueprint, Builder> {
 
+            private DataEntity.Role role;
             private StructuredData value;
 
             public Builder withValue(StructuredData value) {
@@ -119,9 +109,17 @@ public class DataEntity extends Entity<DataEntity.Blueprint, DataEntity.Update> 
                 return this;
             }
 
+            public Builder withRole(DataEntity.Role role) {
+                this.role = role;
+                return this;
+            }
+
             @Override
             public Blueprint build() {
-                return new Blueprint(value, properties);
+                if (role == null) {
+                    throw new NullPointerException("Data entity role not specified.");
+                }
+                return new Blueprint(role, value, properties);
             }
         }
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
@@ -22,13 +22,11 @@ import static org.hawkular.inventory.api.Relationships.WellKnown.defines;
 import static org.hawkular.inventory.api.Relationships.WellKnown.incorporates;
 import static org.hawkular.inventory.api.Relationships.WellKnown.isParentOf;
 import static org.hawkular.inventory.api.filters.With.id;
-import static org.hawkular.inventory.api.model.DataEntity.Role.configuration;
-import static org.hawkular.inventory.api.model.DataEntity.Role.connectionConfiguration;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hawkular.inventory.api.Datas;
+import org.hawkular.inventory.api.Data;
 import org.hawkular.inventory.api.EntityAlreadyExistsException;
 import org.hawkular.inventory.api.EntityNotFoundException;
 import org.hawkular.inventory.api.Metrics;
@@ -241,16 +239,10 @@ public final class BaseResources {
         }
 
         @Override
-        public Datas.ReadWrite configuration() {
-            return new BaseDatas.ReadWrite<>(configuration,
-                    context.proceedTo(configuration.getCorrespondingRelationship(), DataEntity.class).get());
+        public Data.ReadWrite data() {
+            return new BaseData.ReadWrite<>(context.proceedTo(contains, DataEntity.class).get());
         }
 
-        @Override
-        public Datas.ReadWrite connectionConfiguration() {
-            return new BaseDatas.ReadWrite<>(connectionConfiguration,
-                    context.proceedTo(connectionConfiguration.getCorrespondingRelationship(), DataEntity.class).get());
-        }
     }
 
     public static class Multiple<BE> extends MultipleEntityFetcher<BE, Resource, Resource.Update>
@@ -281,15 +273,9 @@ public final class BaseResources {
         }
 
         @Override
-        public Datas.Read configuration() {
-            return new BaseDatas.Read<>(configuration, context.proceedTo(configuration.getCorrespondingRelationship(),
-                    DataEntity.class).get());
+        public Data.Read data() {
+            return new BaseData.Read<>(context.proceedTo(contains, DataEntity.class).get());
         }
 
-        @Override
-        public Datas.Read connectionConfiguration() {
-            return new BaseDatas.Read<>(connectionConfiguration,
-                    context.proceedTo(connectionConfiguration.getCorrespondingRelationship(), DataEntity.class).get());
-        }
     }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/RelationshipRules.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/RelationshipRules.java
@@ -18,10 +18,8 @@ package org.hawkular.inventory.base;
 
 import static org.hawkular.inventory.api.Relationships.Direction.incoming;
 import static org.hawkular.inventory.api.Relationships.Direction.outgoing;
-import static org.hawkular.inventory.api.Relationships.WellKnown.connectsUsing;
 import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
 import static org.hawkular.inventory.api.Relationships.WellKnown.hasData;
-import static org.hawkular.inventory.api.Relationships.WellKnown.isConfiguredBy;
 import static org.hawkular.inventory.api.Relationships.WellKnown.isParentOf;
 
 import java.util.ArrayList;
@@ -60,15 +58,11 @@ public final class RelationshipRules {
 
         CREATE_RULES.put(contains, Arrays.asList(RelationshipRules::checkDiamonds, RelationshipRules::checkLoops));
         CREATE_RULES.put(isParentOf, Collections.singletonList(RelationshipRules::checkLoops));
-        CREATE_RULES.put(isConfiguredBy, Collections.singletonList(RelationshipRules::checkIs1To1));
-        CREATE_RULES.put(connectsUsing, Collections.singletonList(RelationshipRules::checkIs1To1));
         CREATE_RULES.put(hasData, Collections.singletonList(RelationshipRules::disallowCreate));
 
         DELETE_RULES.put(contains, Collections.singletonList(RelationshipRules::disallowDelete));
         DELETE_RULES.put(isParentOf, Collections.singletonList(
                 RelationshipRules::disallowDeleteOfIsParentOfWhenTheresContainsToo));
-        DELETE_RULES.put(isConfiguredBy, Collections.singletonList(RelationshipRules::disallowDelete));
-        DELETE_RULES.put(connectsUsing, Collections.singletonList(RelationshipRules::disallowDelete));
         DELETE_RULES.put(hasData, Collections.singletonList(RelationshipRules::disallowDelete));
     }
 
@@ -184,20 +178,6 @@ public final class RelationshipRules {
     private static <E> void disallowCreateAcrossTenants(InventoryBackend<E> backend, E origin,
             Relationships.Direction direction, String relationship, E target) {
 
-    }
-
-    private static <E> void checkIs1To1(InventoryBackend<E> backend, E origin, Relationships.Direction direction,
-            String relationship, E target) {
-
-        if (backend.hasRelationship(origin, direction, relationship)) {
-            throw new IllegalArgumentException("Relationship '" + relationship + "' is 1-to-1 but there already is"
-                    + " a relationship coming " + (direction == incoming ? "in" : "out") + " of the entity on path '"
-                    + backend.extractCanonicalPath(origin) + "'.");
-        } else if (backend.hasRelationship(target, direction.opposite(), relationship)) {
-            throw new IllegalArgumentException("Relationship '" + relationship + "' is 1-to-1 but there already is"
-                    + " a relationship coming " + (direction == incoming ? "out" : "in") + " of the entity on path '"
-                    + backend.extractCanonicalPath(target) + "'.");
-        }
     }
 
     @FunctionalInterface


### PR DESCRIPTION
Resources.*.configuration and connectionConfiguration methods replaced
by data() method. The different kinds of data are then determined by the
get(DataEntity.Role) method on the data entity access interfaces.

This change enabled us to get rid of the special relationships for data
roles.

Also renamed Datas -> Data.
