### PR TITLE
[HWKINVENT-67] Configuration definitions.

### DIFF
--- a/hawkular-inventory-api/pom.xml
+++ b/hawkular-inventory-api/pom.xml
@@ -44,6 +44,12 @@
       <version>1.0.8</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.fge</groupId>
+      <artifactId>json-schema-validator</artifactId>
+      <version>2.2.6</version>
+    </dependency>
+
     <!-- Logging -->
     <dependency>
       <groupId>org.jboss.logging</groupId>

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Data.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Data.java
@@ -33,11 +33,17 @@ public final class Data {
 
     }
 
-    public interface Read extends ReadInterface<Single, Multiple, DataEntity.Role> {
+    public interface Read<Role extends DataEntity.Role> extends ReadInterface<Single, Multiple, Role> {
     }
 
-    public interface ReadWrite
-            extends ReadWriteInterface<DataEntity.Update, DataEntity.Blueprint, Single, Multiple, DataEntity.Role> {
+    public interface ReadWrite<Role extends DataEntity.Role>
+            extends ReadWriteInterface<DataEntity.Update, DataEntity.Blueprint<Role>, Single, Multiple, Role> {
+
+        @Override
+        Single create(DataEntity.Blueprint<Role> blueprint) throws EntityAlreadyExistsException, ValidationException;
+
+        @Override
+        void update(Role role, DataEntity.Update update) throws EntityNotFoundException, ValidationException;
     }
 
     public interface Single extends ResolvableToSingle<DataEntity, DataEntity.Update> {
@@ -95,6 +101,10 @@ public final class Data {
                 return false;
             }
         }
+
+        @Override
+        void update(DataEntity.Update update) throws EntityNotFoundException, RelationNotFoundException,
+                ValidationException;
     }
 
     public interface Multiple extends ResolvableToMany<DataEntity> {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
@@ -325,6 +325,11 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
+        public Data.ReadWrite<ResourceTypes.DataRole> data() {
+            return new DataReadWrite<>();
+        }
+
+        @Override
         public Relationships.ReadWrite relationships() {
             return new RelationshipsReadWrite();
         }
@@ -345,6 +350,11 @@ public class EmptyInventory implements Inventory {
         @Override
         public MetricTypes.ReadContained metricTypes() {
             return new MetricTypesReadContained();
+        }
+
+        @Override
+        public Data.Read<ResourceTypes.DataRole> data() {
+            return new DataRead<>();
         }
 
         @Override
@@ -1108,8 +1118,8 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public Data.ReadWrite data() {
-            return new DataReadWrite();
+        public Data.ReadWrite<Resources.DataRole> data() {
+            return new DataReadWrite<>();
         }
 
     }
@@ -1152,8 +1162,8 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public Data.Read data() {
-            return new DataRead();
+        public Data.Read<Resources.DataRole> data() {
+            return new DataRead<>();
         }
 
     }
@@ -1187,7 +1197,7 @@ public class EmptyInventory implements Inventory {
         }
     }
 
-    public static class DataRead implements Data.Read {
+    public static class DataRead<Role extends DataEntity.Role> implements Data.Read<Role> {
 
         @Override
         public Data.Multiple getAll(Filter[][] filters) {
@@ -1195,12 +1205,12 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public Data.Single get(DataEntity.Role ignored) throws EntityNotFoundException {
+        public Data.Single get(Role ignored) throws EntityNotFoundException {
             return new DatasSingle();
         }
     }
 
-    public static class DataReadWrite implements Data.ReadWrite {
+    public static class DataReadWrite<Role extends DataEntity.Role> implements Data.ReadWrite<Role> {
 
         @Override
         public Data.Multiple getAll(Filter[][] filters) {
@@ -1208,22 +1218,22 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public Data.Single get(DataEntity.Role ignored) throws EntityNotFoundException {
+        public Data.Single get(Role ignored) throws EntityNotFoundException {
             return new DatasSingle();
         }
 
         @Override
-        public Data.Single create(DataEntity.Blueprint blueprint) throws EntityAlreadyExistsException {
+        public Data.Single create(DataEntity.Blueprint<Role> blueprint) throws EntityAlreadyExistsException {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public void update(DataEntity.Role ignored, DataEntity.Update update) throws EntityNotFoundException {
+        public void update(Role ignored, DataEntity.Update update) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public void delete(DataEntity.Role ignored) throws EntityNotFoundException {
+        public void delete(Role ignored) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Inventory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Inventory.java
@@ -378,9 +378,15 @@ public interface Inventory extends AutoCloseable {
 
             @Override
             public Single visitData(Void parameter) {
-                Resources.Single res = inspect(path.up(), Resources.Single.class);
+                if (path.ids().getResourceTypeId() == null) {
+                    Resources.Single res = inspect(path.up(), Resources.Single.class);
 
-                return accessInterface.cast(res.data().get(path.ids().getDataRole()));
+                    return accessInterface.cast(res.data().get(path.ids().getDataRole()));
+                } else {
+                    ResourceTypes.Single rt = inspect(path.up(), ResourceTypes.Single.class);
+
+                    return accessInterface.cast(rt.data().get(path.ids().getDataRole()));
+                }
             }
 
             @Override

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResourceTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResourceTypes.java
@@ -16,6 +16,7 @@
  */
 package org.hawkular.inventory.api;
 
+import org.hawkular.inventory.api.model.DataEntity;
 import org.hawkular.inventory.api.model.Path;
 import org.hawkular.inventory.api.model.ResourceType;
 
@@ -31,7 +32,11 @@ public final class ResourceTypes {
 
     }
 
-    private interface BrowserBase<Resources, MetricTypes> {
+    public enum DataRole implements DataEntity.Role {
+        configurationSchema, connectionConfigurationSchema
+    }
+
+    private interface BrowserBase<Resources, MetricTypes, Data> {
         /**
          * @return access to resources defined by the resource type(s)
          */
@@ -41,13 +46,18 @@ public final class ResourceTypes {
          * @return access to metrics owned by the resource type(s)
          */
         MetricTypes metricTypes();
+
+        /**
+         * @return access to the data associated with the resource type.
+         */
+        Data data();
     }
 
     /**
      * Interface for accessing a single resource type in a writable manner.
      */
     public interface Single extends ResolvableToSingleWithRelationships<ResourceType, ResourceType.Update>,
-            BrowserBase<Resources.Read, MetricTypes.ReadAssociate> {}
+            BrowserBase<Resources.Read, MetricTypes.ReadAssociate, Data.ReadWrite<DataRole>> {}
 
     /**
      * Interface for traversing over a set of resource types.
@@ -57,7 +67,7 @@ public final class ResourceTypes {
      * {@link ReadInterface#get(Object)} method).
      */
     public interface Multiple extends ResolvableToManyWithRelationships<ResourceType>,
-            BrowserBase<Resources.Read, MetricTypes.ReadContained> {}
+            BrowserBase<Resources.Read, MetricTypes.ReadContained, Data.Read<DataRole>> {}
 
     /**
      * Provides read-only access to resource types.

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Resources.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Resources.java
@@ -16,6 +16,7 @@
  */
 package org.hawkular.inventory.api;
 
+import org.hawkular.inventory.api.model.DataEntity;
 import org.hawkular.inventory.api.model.Path;
 import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.Resource;
@@ -29,6 +30,10 @@ import org.hawkular.inventory.api.model.Resource;
 public final class Resources {
 
     private Resources() {
+    }
+
+    public enum DataRole implements DataEntity.Role {
+        configuration, connectionConfiguration
     }
 
     private interface BrowserBase<Metrics, Data, ContainedAccess, AllAccess> {
@@ -73,7 +78,7 @@ public final class Resources {
      * Interface for accessing a single resource in a writable manner.
      */
     public interface Single extends ResolvableToSingleWithRelationships<Resource, Resource.Update>,
-            BrowserBase<Metrics.ReadAssociate, Data.ReadWrite, ReadWrite, ReadAssociate> {
+            BrowserBase<Metrics.ReadAssociate, Data.ReadWrite<DataRole>, ReadWrite, ReadAssociate> {
 
         /**
          * @return access to the parent resource (if any) that contains the resource on the current position in the
@@ -91,7 +96,7 @@ public final class Resources {
      * {@link ReadInterface#get(Object)} method).
      */
     public interface Multiple
-            extends ResolvableToManyWithRelationships<Resource>, BrowserBase<Metrics.Read, Data.Read,
+            extends ResolvableToManyWithRelationships<Resource>, BrowserBase<Metrics.Read, Data.Read<DataRole>,
             ReadContained, Read> {}
 
     public interface ReadBase<Address> extends ReadInterface<Single, Multiple, Address> {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ValidationException.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ValidationException.java
@@ -68,7 +68,7 @@ public class ValidationException extends InventoryException {
         private final String severity;
         private final String message;
 
-        public ValidationMessage(String message, String severity) {
+        public ValidationMessage(String severity, String message) {
             this.message = message;
             this.severity = severity;
         }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ValidationException.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ValidationException.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.hawkular.inventory.api.model.CanonicalPath;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.3.0
+ */
+public class ValidationException extends InventoryException {
+
+    private final List<ValidationMessage> messages;
+    private final CanonicalPath dataPath;
+
+    public ValidationException(CanonicalPath dataPath, Iterable<ValidationMessage> messages, Throwable cause) {
+        super(cause);
+        this.dataPath = dataPath;
+
+        ArrayList<ValidationMessage> tmp = new ArrayList<>();
+
+        messages.forEach(tmp::add);
+
+        this.messages = Collections.unmodifiableList(tmp);
+    }
+
+    public CanonicalPath getDataPath() {
+        return dataPath;
+    }
+
+    public List<ValidationMessage> getMessages() {
+        return messages;
+    }
+
+    @Override
+    public String getMessage() {
+        StringBuilder bld = new StringBuilder("Validation of data entity at '").append(dataPath);
+
+        if (messages.isEmpty()) {
+            bld.append("' failed without any explicitly mentioned problems.");
+        } else {
+            bld.append("' failed with the following problems found:\n");
+            messages.forEach((m) -> bld.append(m.getSeverity()).append(": ").append(m.getMessage()).append("\n"));
+        }
+
+        return bld.toString();
+    }
+
+    public static final class ValidationMessage {
+        private final String severity;
+        private final String message;
+
+        public ValidationMessage(String message, String severity) {
+            this.message = message;
+            this.severity = severity;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public String getSeverity() {
+            return severity;
+        }
+    }
+}

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/CanonicalPath.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/CanonicalPath.java
@@ -68,6 +68,7 @@ public final class CanonicalPath extends Path implements Iterable<CanonicalPath>
         VALID_PROGRESSIONS.put(Environment.class, Arrays.asList(Metric.class, Resource.class, Feed.class));
         VALID_PROGRESSIONS.put(Feed.class, Arrays.asList(Metric.class, Resource.class, MetricType.class,
                 ResourceType.class));
+        VALID_PROGRESSIONS.put(ResourceType.class, Collections.singletonList(DataEntity.class));
         VALID_PROGRESSIONS.put(Resource.class, Arrays.asList(Resource.class, DataEntity.class));
         VALID_PROGRESSIONS.put(DataEntity.class, Collections.singletonList(StructuredData.class));
         VALID_PROGRESSIONS.put(StructuredData.class, Collections.singletonList(StructuredData.class));

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/CanonicalPath.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/CanonicalPath.java
@@ -326,7 +326,8 @@ public final class CanonicalPath extends Path implements Iterable<CanonicalPath>
             return idIfTypeCorrect(getRoot(), Relationship.class);
         }
 
-        public DataEntity.Role getDataRole() {
+        @SuppressWarnings("unchecked")
+        public <R extends DataEntity.Role> R getDataRole() {
             CanonicalPath currentPath = CanonicalPath.this;
 
             //move up from the potential data path segments
@@ -337,7 +338,7 @@ public final class CanonicalPath extends Path implements Iterable<CanonicalPath>
             //now we should be at the data entity, which should contain our role
             String roleStr = idIfTypeCorrect(currentPath, DataEntity.class);
 
-            return roleStr == null ? null : DataEntity.Role.valueOf(roleStr);
+            return roleStr == null ? null : (R) DataEntity.Role.valueOf(roleStr);
         }
 
         private String idIfTypeCorrect(CanonicalPath path, Class<? extends AbstractElement<?, ?>> desiredType) {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ElementBlueprintVisitor.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ElementBlueprintVisitor.java
@@ -37,7 +37,7 @@ public interface ElementBlueprintVisitor<R, P> {
 
     R visitRelationship(Relationship.Blueprint relationship, P parameter);
 
-    R visitData(DataEntity.Blueprint data, P parameter);
+    R visitData(DataEntity.Blueprint<?> data, P parameter);
 
     R visitUnknown(Object blueprint, P parameter);
 
@@ -97,7 +97,7 @@ public interface ElementBlueprintVisitor<R, P> {
         }
 
         @Override
-        public R visitData(DataEntity.Blueprint data, P parameter) {
+        public R visitData(DataEntity.Blueprint<?> data, P parameter) {
             return defaultAction();
         }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Path.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Path.java
@@ -31,6 +31,9 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
+import org.hawkular.inventory.api.ResourceTypes;
+import org.hawkular.inventory.api.Resources;
+
 /**
  * Represents a path in an inventory. The path is either {@link CanonicalPath} or {@link RelativePath}.
  *
@@ -956,6 +959,11 @@ public abstract class Path {
             super(segments, constructor);
         }
 
+        public StructuredDataBuilder<Impl> data(ResourceTypes.DataRole role) {
+            segments.add(new Segment(DataEntity.class, role.name()));
+            return new StructuredDataBuilder<>(segments, constructor);
+        }
+
         public Impl get() {
             return constructor.create(0, segments.size(), segments);
         }
@@ -1038,15 +1046,11 @@ public abstract class Path {
             return this;
         }
 
-        public StructuredDataBuilder<Impl> configuration() {
-            segments.add(new Segment(DataEntity.class, DataEntity.Role.configuration.name()));
+        public StructuredDataBuilder<Impl> data(Resources.DataRole role) {
+            segments.add(new Segment(DataEntity.class, role.name()));
             return new StructuredDataBuilder<>(segments, constructor);
         }
 
-        public StructuredDataBuilder<Impl> connectionConfiguration() {
-            segments.add(new Segment(DataEntity.class, DataEntity.Role.connectionConfiguration.name()));
-            return new StructuredDataBuilder<>(segments, constructor);
-        }
         public Impl get() {
             return constructor.create(0, segments.size(), segments);
         }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseData.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseData.java
@@ -16,27 +16,54 @@
  */
 package org.hawkular.inventory.base;
 
+import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
+import static org.hawkular.inventory.api.Relationships.WellKnown.defines;
 import static org.hawkular.inventory.api.Relationships.WellKnown.hasData;
 import static org.hawkular.inventory.api.filters.With.id;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.hawkular.inventory.api.Data;
 import org.hawkular.inventory.api.EntityNotFoundException;
 import org.hawkular.inventory.api.Log;
 import org.hawkular.inventory.api.Relationships;
+import org.hawkular.inventory.api.ResourceTypes;
+import org.hawkular.inventory.api.Resources;
+import org.hawkular.inventory.api.ValidationException;
+import org.hawkular.inventory.api.ValidationException.ValidationMessage;
 import org.hawkular.inventory.api.filters.Filter;
+import org.hawkular.inventory.api.filters.Related;
+import org.hawkular.inventory.api.filters.With;
 import org.hawkular.inventory.api.model.CanonicalPath;
 import org.hawkular.inventory.api.model.DataEntity;
 import org.hawkular.inventory.api.model.RelativePath;
+import org.hawkular.inventory.api.model.Resource;
+import org.hawkular.inventory.api.model.ResourceType;
 import org.hawkular.inventory.api.model.StructuredData;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
 import org.hawkular.inventory.base.spi.ShallowStructuredData;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.fge.jackson.JsonNodeReader;
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import com.github.fge.jsonschema.core.report.ListReportProvider;
+import com.github.fge.jsonschema.core.report.LogLevel;
+import com.github.fge.jsonschema.core.report.ProcessingReport;
+import com.github.fge.jsonschema.main.JsonSchemaFactory;
+import com.github.fge.jsonschema.main.JsonValidator;
+
 /**
- * Contains acccess interface implementations for accessing data entities.
+ * Contains access interface implementations for accessing data entities.
  *
  * @author Lukas Krejci
  * @since 0.3.0
@@ -47,7 +74,8 @@ public final class BaseData {
     }
 
 
-    public static final class Read<BE> extends Traversal<BE, DataEntity> implements Data.Read {
+    public static final class Read<BE, R extends DataEntity.Role> extends Traversal<BE, DataEntity>
+            implements Data.Read<R> {
         public Read(TraversalContext<BE, DataEntity> context) {
             super(context);
         }
@@ -58,16 +86,16 @@ public final class BaseData {
         }
 
         @Override
-        public Data.Single get(DataEntity.Role role) throws EntityNotFoundException {
+        public Data.Single get(R role) throws EntityNotFoundException {
             return new Single<>(context.proceed().where(id(role.name())).get());
         }
     }
 
-    public static final class ReadWrite<BE>
-            extends Mutator<BE, DataEntity, DataEntity.Blueprint, DataEntity.Update, DataEntity.Role>
-            implements Data.ReadWrite {
+    public static final class ReadWrite<BE, R extends DataEntity.Role>
+            extends Mutator<BE, DataEntity, DataEntity.Blueprint<R>, DataEntity.Update, R>
+            implements Data.ReadWrite<R> {
 
-        public ReadWrite(TraversalContext context) {
+        public ReadWrite(TraversalContext<BE, DataEntity> context) {
             super(context);
         }
 
@@ -78,9 +106,11 @@ public final class BaseData {
 
         @Override
         protected EntityAndPendingNotifications<DataEntity> wireUpNewEntity(BE entity,
-                DataEntity.Blueprint blueprint, CanonicalPath parentPath, BE parent) {
+                DataEntity.Blueprint<R> blueprint, CanonicalPath parentPath, BE parent) {
 
             DataEntity data = new DataEntity(parentPath, blueprint.getRole(), blueprint.getValue());
+
+            Validator.validate(context, blueprint.getValue(), entity);
 
             BE value = context.backend.persist(blueprint.getValue());
 
@@ -93,12 +123,31 @@ public final class BaseData {
         }
 
         @Override
-        public Data.Single create(DataEntity.Blueprint data) {
+        public Data.Single create(DataEntity.Blueprint<R> data) {
             return new Single<>(context.replacePath(doCreate(data)));
         }
 
         @Override
-        protected void cleanup(DataEntity.Role role, BE entityRepresentation) {
+        protected void cleanup(R role, BE entityRepresentation) {
+            cleanup(context, entityRepresentation);
+        }
+
+        @Override
+        protected void preUpdate(R r, BE entityRepresentation, DataEntity.Update update) {
+            preUpdate(context, entityRepresentation, update);
+        }
+
+        @Override
+        public Data.Multiple getAll(Filter[][] filters) {
+            return new Multiple<>(context.proceed().whereAll(filters).get());
+        }
+
+        @Override
+        public Data.Single get(R role) throws EntityNotFoundException {
+            return new Single<>(context.proceed().where(id(role.name())).get());
+        }
+
+        private static <BE> void cleanup(TraversalContext<BE, DataEntity> context, BE entityRepresentation) {
             Set<BE> rels = context.backend.getRelationships(entityRepresentation, Relationships.Direction.outgoing,
                     hasData.name());
 
@@ -115,14 +164,9 @@ public final class BaseData {
             context.backend.delete(dataRel);
         }
 
-        @Override
-        public Data.Multiple getAll(Filter[][] filters) {
-            return new Multiple<>(context.proceed().whereAll(filters).get());
-        }
-
-        @Override
-        public Data.Single get(DataEntity.Role role) throws EntityNotFoundException {
-            return new Single<>(context.proceed().where(id(role.name())).get());
+        private static <BE> void preUpdate(TraversalContext<BE, DataEntity> context, BE entityRepresentation,
+                DataEntity.Update update) {
+            Validator.validate(context, update.getValue(), entityRepresentation);
         }
     }
 
@@ -152,6 +196,16 @@ public final class BaseData {
                         .getData();
             });
         }
+
+        @Override
+        protected void cleanup(BE deletedEntity) {
+            ReadWrite.cleanup(context, deletedEntity);
+        }
+
+        @Override
+        protected void preUpdate(BE updatedEntity, DataEntity.Update update) {
+            ReadWrite.preUpdate(context, updatedEntity, update);
+        }
     }
 
     public static final class Multiple<BE>
@@ -177,5 +231,150 @@ public final class BaseData {
                 return context.backend.convert(dataEntity, ShallowStructuredData.class).getData();
             });
         }
+    }
+
+    public static final class Validator {
+
+        private static final JsonValidator VALIDATOR = JsonSchemaFactory.newBuilder()
+                .setReportProvider(new ListReportProvider(LogLevel.INFO, LogLevel.FATAL)).freeze().getValidator();
+
+        public static <BE> void validate(TraversalContext<BE, DataEntity> context, StructuredData data, BE dataEntity) {
+            CanonicalPath path = context.backend.extractCanonicalPath(dataEntity);
+
+            DataEntity.Role role = path.ids().getDataRole();
+
+            CanonicalPath ownerPath = path.up();
+
+            if (role == Resources.DataRole.configuration) {
+                throwIfInvalidOwnerType(role, ownerPath, Resource.class);
+
+                validateIfSchemaFound(context, dataEntity, Query.path().with(
+                        //up to the containing resource
+                        Related.asTargetBy(contains),
+                        //up to the defining resource type
+                        Related.asTargetBy(defines),
+                        //down to the contained data entity
+                        Related.by(contains), With.type(DataEntity.class),
+                        //with id of configuration schema
+                        With.id(ResourceTypes.DataRole.configurationSchema.name())).get());
+            } else if (role == Resources.DataRole.connectionConfiguration) {
+                throwIfInvalidOwnerType(role, ownerPath, Resource.class);
+
+                validateIfSchemaFound(context, dataEntity, Query.path().with(
+                        //up to the containing resource
+                        Related.asTargetBy(contains),
+                        //up to the defining resource type
+                        Related.asTargetBy(defines),
+                        //down to the contained data entity
+                        Related.by(contains), With.type(DataEntity.class),
+                        //with id of configuration schema
+                        With.id(ResourceTypes.DataRole.connectionConfigurationSchema.name())).get());
+            } else if (role == ResourceTypes.DataRole.configurationSchema
+                    || role == ResourceTypes.DataRole.connectionConfigurationSchema) {
+                throwIfInvalidOwnerType(role, ownerPath, ResourceType.class);
+
+                try {
+                    JsonNode schema = new JsonNodeReader(new ObjectMapper())
+                            .fromInputStream(BaseData.class.getClassLoader()
+                                    .getResourceAsStream("/json-meta-schema.json"));
+
+                    DataEntity dataEntityObject = context.backend.convert(dataEntity, DataEntity.class);
+
+                    validate(dataEntityObject.getPath(), convert(dataEntityObject.getValue()), schema);
+                } catch (IOException e) {
+                    throw new IllegalStateException("Could not load the embedded JSON Schema meta-schema.");
+                }
+            }
+        }
+
+        private static <BE> void validateIfSchemaFound(TraversalContext<BE, DataEntity> context, BE dataEntity,
+                Query query) {
+
+            Page<BE> possibleSchema = context.backend.traverse(dataEntity, query, Pager.single());
+            if (possibleSchema.isEmpty()) {
+                //no schema means anything is OK
+                return;
+            }
+
+            DataEntity schemaEntity = context.backend.convert(possibleSchema.get(0),
+                    DataEntity.class);
+
+            DataEntity dataEntityObject = context.backend.convert(dataEntity, DataEntity.class);
+
+            validate(dataEntityObject.getPath(), convert(dataEntityObject.getValue()),
+                    convert(schemaEntity.getValue()));
+        }
+
+        private static void validate(CanonicalPath dataPath, JsonNode dataNode, JsonNode schemaNode) {
+            try {
+                ProcessingReport report = VALIDATOR.validate(schemaNode, dataNode, true);
+                if (!report.isSuccess()) {
+                    List<ValidationMessage> messages = new ArrayList<>();
+                    report.forEach((m) ->
+                            messages.add(new ValidationMessage(m.getLogLevel().name(), m.getMessage())));
+
+                    throw new ValidationException(dataPath, messages, null);
+                }
+            } catch (ProcessingException e) {
+                throw new ValidationException(dataPath, Collections.emptyList(), e);
+            }
+        }
+
+        private static JsonNode convert(StructuredData data) {
+            return data.accept(new StructuredData.Visitor.Simple<JsonNode, Void>() {
+                @Override
+                public JsonNode visitBool(boolean value, Void ignored) {
+                    return JsonNodeFactory.instance.booleanNode(value);
+                }
+
+                @Override
+                public JsonNode visitFloatingPoint(double value, Void ignored) {
+                    return JsonNodeFactory.instance.numberNode(value);
+                }
+
+                @Override
+                public JsonNode visitIntegral(long value, Void ignored) {
+                    return JsonNodeFactory.instance.numberNode(value);
+                }
+
+                @Override
+                public JsonNode visitList(List<StructuredData> value, Void ignored) {
+                    ArrayNode list = JsonNodeFactory.instance.arrayNode();
+                    value.forEach((s) -> list.add(s.accept(this, null)));
+                    return list;
+                }
+
+                @Override
+                public JsonNode visitMap(Map<String, StructuredData> value, Void ignored) {
+                    ObjectNode object = JsonNodeFactory.instance.objectNode();
+                    value.forEach((k, v) -> object.set(k, v.accept(this, null)));
+                    return object;
+                }
+
+                @Override
+                public JsonNode visitString(String value, Void ignored) {
+                    return JsonNodeFactory.instance.textNode(value);
+                }
+
+                @Override
+                public JsonNode visitUndefined(Void ignored) {
+                    return JsonNodeFactory.instance.nullNode();
+                }
+            }, null);
+        }
+    }
+
+    private static void throwIfInvalidOwnerType(DataEntity.Role role, CanonicalPath ownerPath,
+            Class<?> expectedOwnerType) {
+
+        if (ownerPath.getSegment().getElementType() != expectedOwnerType) {
+            throw invalidOwnerType(role, ownerPath);
+        }
+    }
+
+    private static IllegalStateException invalidOwnerType(DataEntity.Role role, CanonicalPath ownerPath) {
+        return new IllegalStateException("Invalid owner of data entity with role '" + role.name() + "'."
+                + " Expected the owner to be a Resource but found: '"
+                + ownerPath.getSegment().getElementType().getSimpleName() + "'.");
     }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResourceTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResourceTypes.java
@@ -16,10 +16,12 @@
  */
 package org.hawkular.inventory.base;
 
+import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
 import static org.hawkular.inventory.api.Relationships.WellKnown.defines;
 import static org.hawkular.inventory.api.Relationships.WellKnown.incorporates;
 import static org.hawkular.inventory.api.filters.With.id;
 
+import org.hawkular.inventory.api.Data;
 import org.hawkular.inventory.api.EntityAlreadyExistsException;
 import org.hawkular.inventory.api.EntityNotFoundException;
 import org.hawkular.inventory.api.MetricTypes;
@@ -27,6 +29,7 @@ import org.hawkular.inventory.api.ResourceTypes;
 import org.hawkular.inventory.api.Resources;
 import org.hawkular.inventory.api.filters.Filter;
 import org.hawkular.inventory.api.model.CanonicalPath;
+import org.hawkular.inventory.api.model.DataEntity;
 import org.hawkular.inventory.api.model.MetricType;
 import org.hawkular.inventory.api.model.Path;
 import org.hawkular.inventory.api.model.Resource;
@@ -132,6 +135,11 @@ public final class BaseResourceTypes {
         public MetricTypes.ReadAssociate metricTypes() {
             return new BaseMetricTypes.ReadAssociate<>(context.proceedTo(incorporates, MetricType.class).get());
         }
+
+        @Override
+        public Data.ReadWrite<ResourceTypes.DataRole> data() {
+            return new BaseData.ReadWrite<>(context.proceedTo(contains, DataEntity.class).get());
+        }
     }
 
     public static class Multiple<BE> extends MultipleEntityFetcher<BE, ResourceType, ResourceType.Update>
@@ -149,6 +157,11 @@ public final class BaseResourceTypes {
         @Override
         public MetricTypes.ReadContained metricTypes() {
             return new BaseMetricTypes.ReadContained<>(context.proceedTo(incorporates, MetricType.class).get());
+        }
+
+        @Override
+        public Data.Read<ResourceTypes.DataRole> data() {
+            return new BaseData.Read<>(context.proceedTo(contains, DataEntity.class).get());
         }
     }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
@@ -239,7 +239,7 @@ public final class BaseResources {
         }
 
         @Override
-        public Data.ReadWrite data() {
+        public Data.ReadWrite<Resources.DataRole> data() {
             return new BaseData.ReadWrite<>(context.proceedTo(contains, DataEntity.class).get());
         }
 
@@ -273,7 +273,7 @@ public final class BaseResources {
         }
 
         @Override
-        public Data.Read data() {
+        public Data.Read<Resources.DataRole> data() {
             return new BaseData.Read<>(context.proceedTo(contains, DataEntity.class).get());
         }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Fetcher.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Fetcher.java
@@ -85,12 +85,36 @@ abstract class Fetcher<BE, E extends AbstractElement<?, U>, U extends AbstractEl
 
     @Override
     public void delete() {
-        Util.delete(context, context.select().get(), null);
+        Util.delete(context, context.select().get(), this::cleanup);
     }
 
     @Override
     public void update(U u) throws EntityNotFoundException, RelationNotFoundException {
-        Util.update(context, context.select().get(), u);
+        Util.update(context, context.select().get(), u, this::preUpdate);
+    }
+
+    /**
+     * Serves the same purpose as {@link Mutator#cleanup(Object, Object)} and is called during the {@link #delete()}
+     * method inside the transaction.
+     *
+     * @param deletedEntity the backend representation of the deleted entity
+     */
+    protected void cleanup(BE deletedEntity) {
+
+    }
+
+    /**
+     * Hook to be run prior to update. Serves the same purpose as
+     * {@link Mutator#preUpdate(Object, Object, AbstractElement.Update)} but is not supplied the id object that can be
+     * determined from the updated entity.
+     *
+     * <p>By default, this does nothing.
+     *
+     * @param updatedEntity the backend representation of the updated entity
+     * @param update        the update object
+     */
+    protected void preUpdate(BE updatedEntity, U update) {
+
     }
 
     @Override

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Mutator.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Mutator.java
@@ -117,7 +117,7 @@ abstract class Mutator<BE, E extends Entity<?, U>, B extends Blueprint, U extend
 
     public final void update(Id id, U update) throws EntityNotFoundException {
         Query q = id == null ? context.select().get() : context.select().with(id(id.toString())).get();
-        Util.update(context, q, update);
+        Util.update(context, q, update, (e, u) -> preUpdate(id, e, u));
     }
 
     public final void delete(Id id) throws EntityNotFoundException {
@@ -136,6 +136,20 @@ abstract class Mutator<BE, E extends Entity<?, U>, B extends Blueprint, U extend
      * @param entityRepresentation the backend specific representation of the entity
      */
     protected void cleanup(Id id, BE entityRepresentation) {
+
+    }
+
+    /**
+     * A hook that can run additional logic inside the update transaction before anything has been persisted to the
+     * backend database.
+     *
+     * <p>By default, this does nothing
+     *
+     * @param id                   the id of the entity being updated
+     * @param entityRepresentation the backend representation of the updated entity
+     * @param update               the update object
+     */
+    protected void preUpdate(Id id, BE entityRepresentation, U update) {
 
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Util.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Util.java
@@ -27,6 +27,7 @@ import static org.hawkular.inventory.api.Relationships.WellKnown.defines;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -209,7 +210,7 @@ final class Util {
 
     @SuppressWarnings("unchecked")
     public static <BE, E extends AbstractElement<?, U>, U extends AbstractElement.Update> void update(
-            TraversalContext<BE, E> context, Query entityQuery, U update) {
+            TraversalContext<BE, E> context, Query entityQuery, U update, BiConsumer<BE, U> preUpdateCheck) {
 
         BE updated = runInTransaction(context, false, (t) -> {
             Page<BE> entities = context.backend.query(entityQuery, Pager.single());
@@ -223,6 +224,10 @@ final class Util {
             }
 
             BE toUpdate = entities.get(0);
+
+            if (preUpdateCheck != null) {
+                preUpdateCheck.accept(toUpdate, update);
+            }
 
             context.backend.update(toUpdate, update);
             context.backend.commit(t);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InventoryBackend.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InventoryBackend.java
@@ -64,6 +64,20 @@ public interface InventoryBackend<E> extends AutoCloseable {
      * Translates the query to the backend-specific representation and runs it, returning a correct page of results
      * as prescribed by the provided pager object.
      *
+     * @param startingPoint the element which should be the starting point of the traversal
+     * @param query         the query to perform
+     * @param pager         pager to limit the number of results with
+     * @return the page of results, possibly empty, never null
+     */
+    Page<E> traverse(E startingPoint, Query query, Pager pager);
+
+    /**
+     * Translates the query to the backend-specific representation and runs it, returning a correct page of results
+     * as prescribed by the provided pager object.
+     *
+     * <p>The difference between this method and {@link #traverse(Object, Query, Pager)} is that this method performs
+     * a graph-wide query, while traverse starts from a single element.
+     *
      * @param query the query to execute
      * @param pager the page to return
      * @return a page of results corresponding to the parameters, possibly empty, never null.

--- a/hawkular-inventory-api/src/main/resources/json-meta-schema.json
+++ b/hawkular-inventory-api/src/main/resources/json-meta-schema.json
@@ -1,0 +1,221 @@
+{
+  "id": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Core schema meta-schema",
+  "definitions": {
+    "schemaArray": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#"
+      }
+    },
+    "positiveInteger": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "positiveIntegerDefault0": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/positiveInteger"
+        },
+        {
+          "default": 0
+        }
+      ]
+    },
+    "simpleTypes": {
+      "enum": [
+        "array",
+        "boolean",
+        "integer",
+        "null",
+        "number",
+        "object",
+        "string"
+      ]
+    },
+    "stringArray": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    }
+  },
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uri"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "default": {},
+    "multipleOf": {
+      "type": "number",
+      "minimum": 0,
+      "exclusiveMinimum": true
+    },
+    "maximum": {
+      "type": "number"
+    },
+    "exclusiveMaximum": {
+      "type": "boolean",
+      "default": false
+    },
+    "minimum": {
+      "type": "number"
+    },
+    "exclusiveMinimum": {
+      "type": "boolean",
+      "default": false
+    },
+    "maxLength": {
+      "$ref": "#/definitions/positiveInteger"
+    },
+    "minLength": {
+      "$ref": "#/definitions/positiveIntegerDefault0"
+    },
+    "pattern": {
+      "type": "string",
+      "format": "regex"
+    },
+    "additionalItems": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#"
+        }
+      ],
+      "default": {}
+    },
+    "items": {
+      "anyOf": [
+        {
+          "$ref": "#"
+        },
+        {
+          "$ref": "#/definitions/schemaArray"
+        }
+      ],
+      "default": {}
+    },
+    "maxItems": {
+      "$ref": "#/definitions/positiveInteger"
+    },
+    "minItems": {
+      "$ref": "#/definitions/positiveIntegerDefault0"
+    },
+    "uniqueItems": {
+      "type": "boolean",
+      "default": false
+    },
+    "maxProperties": {
+      "$ref": "#/definitions/positiveInteger"
+    },
+    "minProperties": {
+      "$ref": "#/definitions/positiveIntegerDefault0"
+    },
+    "required": {
+      "$ref": "#/definitions/stringArray"
+    },
+    "additionalProperties": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#"
+        }
+      ],
+      "default": {}
+    },
+    "definitions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#"
+      },
+      "default": {}
+    },
+    "properties": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#"
+      },
+      "default": {}
+    },
+    "patternProperties": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#"
+      },
+      "default": {}
+    },
+    "dependencies": {
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "$ref": "#"
+          },
+          {
+            "$ref": "#/definitions/stringArray"
+          }
+        ]
+      }
+    },
+    "enum": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "type": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/simpleTypes"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/simpleTypes"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      ]
+    },
+    "allOf": {
+      "$ref": "#/definitions/schemaArray"
+    },
+    "anyOf": {
+      "$ref": "#/definitions/schemaArray"
+    },
+    "oneOf": {
+      "$ref": "#/definitions/schemaArray"
+    },
+    "not": {
+      "$ref": "#"
+    }
+  },
+  "dependencies": {
+    "exclusiveMaximum": [
+      "maximum"
+    ],
+    "exclusiveMinimum": [
+      "minimum"
+    ]
+  },
+  "default": {}
+}

--- a/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryPersistenceCheck.java
+++ b/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryPersistenceCheck.java
@@ -30,12 +30,12 @@ import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
 import static org.hawkular.inventory.api.Relationships.WellKnown.hasData;
 import static org.hawkular.inventory.api.Relationships.WellKnown.incorporates;
 import static org.hawkular.inventory.api.Relationships.WellKnown.isParentOf;
+import static org.hawkular.inventory.api.Resources.DataRole.configuration;
+import static org.hawkular.inventory.api.Resources.DataRole.connectionConfiguration;
 import static org.hawkular.inventory.api.filters.Related.asTargetBy;
 import static org.hawkular.inventory.api.filters.Related.by;
 import static org.hawkular.inventory.api.filters.With.id;
 import static org.hawkular.inventory.api.filters.With.type;
-import static org.hawkular.inventory.api.model.DataEntity.Role.configuration;
-import static org.hawkular.inventory.api.model.DataEntity.Role.connectionConfiguration;
 
 import java.io.FileInputStream;
 import java.util.ArrayList;
@@ -319,7 +319,7 @@ public abstract class AbstractBaseInventoryPersistenceCheck<E> {
                 .build();
 
         assert inventory.tenants().get("com.example.tenant").environments().get("test")
-                .feedlessResources().get("playroom1").data().create(DataEntity.Blueprint.builder()
+                .feedlessResources().get("playroom1").data().create(DataEntity.Blueprint.<Resources.DataRole>builder()
                         .withRole(configuration).withValue(config).build()).entity().getValue().equals(config);
 
     }
@@ -1808,7 +1808,8 @@ public abstract class AbstractBaseInventoryPersistenceCheck<E> {
 
         StructuredData orig = StructuredData.get().map().putBool("yes", true).putBool("no", false).build();
 
-        res.data().create(DataEntity.Blueprint.builder().withRole(connectionConfiguration).withValue(orig).build());
+        res.data().create(DataEntity.Blueprint.<Resources.DataRole>builder().withRole(connectionConfiguration)
+                .withValue(orig).build());
 
         StructuredData retrieved = res.data().get(connectionConfiguration).entity().getValue();
 
@@ -1853,8 +1854,8 @@ public abstract class AbstractBaseInventoryPersistenceCheck<E> {
 
     @Test
     public void testFilteringByData() throws Exception {
-        Data.Read configs = inventory.tenants().getAll().environments().getAll().allResources().getAll()
-                .data();
+        Data.Read<Resources.DataRole> configs = inventory.tenants().getAll().environments().getAll().allResources()
+                .getAll().data();
 
         Assert.assertEquals(1, configs.getAll(With.dataAt(RelativePath.to().structuredData().key("primitives").index(0)
                 .get())).entities().size());

--- a/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/CanonicalPathTest.java
+++ b/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/CanonicalPathTest.java
@@ -16,6 +16,9 @@
  */
 package org.hawkular.inventory.api.test;
 
+import static org.hawkular.inventory.api.Resources.DataRole.configuration;
+import static org.hawkular.inventory.api.Resources.DataRole.connectionConfiguration;
+
 import java.util.Iterator;
 
 import org.hawkular.inventory.api.model.AbstractElement;
@@ -111,10 +114,10 @@ public class CanonicalPathTest {
         Assert.assertEquals("/rl;r", CanonicalPath.of().relationship("r").get().toString());
 
         Assert.assertEquals("/t;t/e;e/r;r/d;configuration/blah/1/key", CanonicalPath.of().tenant("t").environment("e")
-                .resource("r").configuration().key("blah").index(1).key("key").get().toString());
+                .resource("r").data(configuration).key("blah").index(1).key("key").get().toString());
 
         Assert.assertEquals("/t;t/e;e/r;r/d;connectionConfiguration/bl%2Fah", CanonicalPath.of().tenant("t")
-                .environment("e").resource("r").connectionConfiguration().key("bl/ah").get().toString());
+                .environment("e").resource("r").data(connectionConfiguration).key("bl/ah").get().toString());
 
         // escaped chars scenario
         Assert.assertEquals("/t;te%2Fnant/e;e;nv/r;r%25%2Fes;;", CanonicalPath.of().tenant("te/nant")

--- a/hawkular-inventory-json-helper/src/test/java/org/hawkular/inventory/json/SerializationTest.java
+++ b/hawkular-inventory-json-helper/src/test/java/org/hawkular/inventory/json/SerializationTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.HashMap;
 
+import org.hawkular.inventory.api.Resources;
 import org.hawkular.inventory.api.model.CanonicalPath;
 import org.hawkular.inventory.api.model.DataEntity;
 import org.hawkular.inventory.api.model.Environment;
@@ -269,7 +270,7 @@ public class SerializationTest {
     @Test
     public void testDataEntity() throws Exception {
         test(new DataEntity(CanonicalPath.of().tenant("t").environment("e").resource("r").get(),
-                DataEntity.Role.connectionConfiguration,
+                Resources.DataRole.connectionConfiguration,
                 StructuredData.get().list().addIntegral(1).addIntegral(2).build(), null));
     }
 

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesData.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesData.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.rest;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.hawkular.inventory.api.ResourceTypes;
+import org.hawkular.inventory.api.model.CanonicalPath;
+import org.hawkular.inventory.api.model.DataEntity;
+import org.hawkular.inventory.rest.json.ApiError;
+
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiParam;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.3.0
+ */
+@Path("/")
+@Produces(APPLICATION_JSON)
+@Consumes(APPLICATION_JSON)
+@Api(value = "/", description = "CRUD for resource type data")
+public class RestResourceTypesData extends RestBase {
+
+    @POST
+    @javax.ws.rs.Path("/resourceTypes/{resourceTypeId}/data")
+    @ApiOperation("Creates the configuration for pre-existing resource type")
+    @ApiResponses({
+            @ApiResponse(code = 204, message = "OK Created"),
+            @ApiResponse(code = 404, message = "Tenant or resource type doesn't exist",
+                    response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+    })
+    public Response createConfiguration(@PathParam("resourceTypeId") String resourceType,
+            @ApiParam(required = true) DataEntity.Blueprint<ResourceTypes.DataRole> configuration,
+            @Context UriInfo uriInfo) {
+
+        return doCreateData(null, null, resourceType, configuration, uriInfo);
+    }
+
+    @POST
+    @javax.ws.rs.Path("/{environmentId}/{feedId}/resourceTypes/{resourceTypeId}/data")
+    @ApiOperation("Creates the configuration for pre-existing resource type")
+    @ApiResponses({
+            @ApiResponse(code = 204, message = "OK Created"),
+            @ApiResponse(code = 404, message = "Tenant, environment, resource type or feed doesn't exist",
+                    response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+    })
+    public Response createConfiguration(@PathParam("environmentId") String environmentId,
+            @PathParam("feedId") String feedId, @PathParam("resourceTypeId") String resourceType,
+            @ApiParam(required = true) DataEntity.Blueprint<ResourceTypes.DataRole> configuration,
+            @Context UriInfo uriInfo) {
+
+        return doCreateData(environmentId, feedId, resourceType, configuration, uriInfo);
+    }
+
+    @PUT
+    @javax.ws.rs.Path("/resourceTypes/{resourceTypeId}/data")
+    @ApiOperation("Updates the configuration of a resource type")
+    @ApiResponses({
+            @ApiResponse(code = 204, message = "OK"),
+            @ApiResponse(code = 404, message = "Tenant, or resource type doesn't exist",
+                    response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+    })
+    public Response updateData(@PathParam("resourceTypeId") String resourceType,
+            @QueryParam("dataType") @DefaultValue("configurationSchema") ResourceTypes.DataRole dataType,
+            @ApiParam(required = true) DataEntity.Update data) {
+
+        return doUpdateData(null, null, resourceType, dataType, data);
+    }
+
+    @PUT
+    @javax.ws.rs.Path("/{environmentId}/{feedId}/resourceTypes/{resourceTypeId}/data")
+    @ApiOperation("Updates the configuration of a resource type")
+    @ApiResponses({
+            @ApiResponse(code = 204, message = "OK"),
+            @ApiResponse(code = 404, message = "Tenant, environment, feed or resource type doesn't exist",
+                    response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+    })
+    public Response updateData(@PathParam("environmentId") String environmentId, @PathParam("feedId") String feedId,
+            @PathParam("resourceTypeId") String resourceType,
+            @QueryParam("dataType") @DefaultValue("configurationSchema") ResourceTypes.DataRole dataType,
+            @ApiParam(required = true) DataEntity.Update data) {
+
+        return doUpdateData(environmentId, feedId, resourceType, dataType, data);
+    }
+
+    @DELETE
+    @javax.ws.rs.Path("/resourceTypes/{resourceTypeId}/data")
+    @ApiOperation("Updates the configuration of a resource type")
+    @ApiResponses({
+            @ApiResponse(code = 204, message = "OK"),
+            @ApiResponse(code = 404, message = "Tenant, or resource type doesn't exist",
+                    response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+    })
+    public Response deleteData(@PathParam("resourceTypeId") String resourceType,
+            @QueryParam("dataType") @DefaultValue("configurationSchema") ResourceTypes.DataRole dataType) {
+
+        return doDeleteData(null, null, resourceType, dataType);
+    }
+
+    @DELETE
+    @javax.ws.rs.Path("/{environmentId}/{feedId}/resourceTypes/{resourceTypeId}/data")
+    @ApiOperation("Updates the configuration of a resource type")
+    @ApiResponses({
+            @ApiResponse(code = 204, message = "OK"),
+            @ApiResponse(code = 404, message = "Tenant, environment, feed or resource type doesn't exist",
+                    response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+    })
+    public Response deleteData(@PathParam("environmentId") String environmentId, @PathParam("feedId") String feedId,
+            @PathParam("resourceTypeId") String resourceType,
+            @QueryParam("dataType") @DefaultValue("configurationSchema") ResourceTypes.DataRole dataType) {
+
+        return doDeleteData(environmentId, feedId, resourceType, dataType);
+    }
+
+    @GET
+    @Path("/resourceTypes/{resourceTypeId}/data")
+    @ApiOperation("Retrieves a single resource type")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "the resource type"),
+            @ApiResponse(code = 404, message = "Tenant or resource type doesn't exist", response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+    })
+    public DataEntity get(@PathParam("resourceTypeId") String resourceTypeId,
+            @QueryParam("dataType") @DefaultValue("configurationSchema") ResourceTypes.DataRole dataType) {
+        return doGetDataEntity(null, null, resourceTypeId, dataType);
+    }
+
+    @GET
+    @Path("/{environmentId}/{feedId}/resourceTypes/{resourceTypeId}/data")
+    @ApiOperation("Retrieves a single resource type")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "the resource type"),
+            @ApiResponse(code = 404, message = "Tenant or resource type doesn't exist", response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+    })
+    public DataEntity get(@PathParam("environmentId") String environmentId, @PathParam("feedId") String feedId,
+            @PathParam("resourceTypeId") String resourceTypeId,
+            @QueryParam("dataType") @DefaultValue("configurationSchema") ResourceTypes.DataRole dataType) {
+        return doGetDataEntity(environmentId, feedId, resourceTypeId, dataType);
+    }
+
+    private Response doCreateData(String environmentId, String feedId, String resourceTypeId,
+            DataEntity.Blueprint<ResourceTypes.DataRole> blueprint, UriInfo uriInfo) {
+
+        CanonicalPath resourceType = getResourceTypePath(environmentId, feedId, resourceTypeId);
+
+        if (!security.canUpdate(resourceType)) {
+            return Response.status(FORBIDDEN).build();
+        }
+        inventory.inspect(resourceType, ResourceTypes.Single.class).data().create(blueprint);
+
+        return ResponseUtil.created(uriInfo, blueprint.getRole().name()).build();
+
+    }
+
+    private Response doUpdateData(String environmentId, String feedId, String resourceTypeId,
+            ResourceTypes.DataRole dataType, DataEntity.Update update) {
+
+        CanonicalPath resourceType = getResourceTypePath(environmentId, feedId, resourceTypeId);
+
+        if (!security.canUpdate(resourceType)) {
+            return Response.status(FORBIDDEN).build();
+        }
+        inventory.inspect(resourceType, ResourceTypes.Single.class).data().update(dataType, update);
+
+        return Response.noContent().build();
+    }
+
+    private Response doDeleteData(String environmentId, String feedId, String resourceTypeId,
+            ResourceTypes.DataRole dataType) {
+        CanonicalPath resourceType = getResourceTypePath(environmentId, feedId, resourceTypeId);
+
+        if (!security.canUpdate(resourceType)) {
+            return Response.status(FORBIDDEN).build();
+        }
+        inventory.inspect(resourceType, ResourceTypes.Single.class).data().delete(dataType);
+
+        return Response.noContent().build();
+    }
+
+    private DataEntity doGetDataEntity(String environmentId, String feedId, String resourceTypeId,
+            ResourceTypes.DataRole dataType) {
+
+        return inventory.inspect(getResourceTypePath(environmentId, feedId, resourceTypeId), ResourceTypes.Single.class)
+                .data().get(dataType).entity();
+    }
+
+    private CanonicalPath getResourceTypePath(String environmentId, String feedId, String resourceTypeId) {
+        if (environmentId == null) {
+            return CanonicalPath.of().tenant(getTenantId()).resourceType(resourceTypeId).get();
+        } else {
+            return CanonicalPath.of().tenant(getTenantId()).environment(environmentId).feed(feedId)
+                    .resourceType(resourceTypeId).get();
+        }
+    }
+}

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourcesData.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourcesData.java
@@ -64,10 +64,9 @@ public class RestResourcesData extends RestResources {
                           @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
                   })
     public Response createConfiguration(@PathParam("environmentId") String environmentId,
-                                        @PathParam("feedId") String feedId,
-                                        @PathParam("resourcePath") String resourcePath,
-                                        @ApiParam(required = true) DataEntity.Blueprint configuration,
-                                        @Context UriInfo uriInfo) {
+            @PathParam("feedId") String feedId, @PathParam("resourcePath") String resourcePath,
+            @ApiParam(required = true) DataEntity.Blueprint<Resources.DataRole> configuration,
+            @Context UriInfo uriInfo) {
 
         return createConfigurationHelper(environmentId, feedId, resourcePath, configuration, uriInfo);
     }
@@ -82,15 +81,15 @@ public class RestResourcesData extends RestResources {
                           @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
                   })
     public Response createConfiguration(@PathParam("environmentId") String environmentId,
-                                        @PathParam("resourcePath") String resourcePath,
-                                        @ApiParam(required = true) DataEntity.Blueprint configuration,
-                                        @Context UriInfo uriInfo) {
+            @PathParam("resourcePath") String resourcePath,
+            @ApiParam(required = true) DataEntity.Blueprint<Resources.DataRole> configuration,
+            @Context UriInfo uriInfo) {
 
         return createConfigurationHelper(environmentId, null, resourcePath, configuration, uriInfo);
     }
 
     private Response createConfigurationHelper(String environmentId, String feedId, String resourcePath,
-                                               DataEntity.Blueprint configuration, UriInfo uriInfo) {
+            DataEntity.Blueprint<Resources.DataRole> configuration, UriInfo uriInfo) {
         String tenantId = getTenantId();
         CanonicalPath resource = composeCanonicalPath(tenantId, environmentId, feedId, resourcePath);
 
@@ -114,7 +113,7 @@ public class RestResourcesData extends RestResources {
     public Response getConfiguration(@PathParam("environmentId") String environmentId,
                                      @PathParam("feedId") String feedId,
                                      @PathParam("resourcePath") String resourcePath,
-                                     @DefaultValue("configuration") @QueryParam("dataType") DataEntity.Role dataType) {
+            @DefaultValue("configuration") @QueryParam("dataType") Resources.DataRole dataType) {
 
         return getConfigurationHelper(environmentId, feedId, resourcePath, dataType);
     }
@@ -130,13 +129,13 @@ public class RestResourcesData extends RestResources {
                   })
     public Response getConfiguration(@PathParam("environmentId") String environmentId,
                                      @PathParam("resourcePath") String resourcePath,
-                                     @DefaultValue("configuration") @QueryParam("dataType") DataEntity.Role dataType) {
+            @DefaultValue("configuration") @QueryParam("dataType") Resources.DataRole dataType) {
 
         return getConfigurationHelper(environmentId, null, resourcePath, dataType);
     }
 
     private Response getConfigurationHelper(String environmentId, String feedId, String resourcePath,
-                                            DataEntity.Role dataType) {
+            Resources.DataRole dataType) {
         String tenantId = getTenantId();
         CanonicalPath resource = composeCanonicalPath(tenantId, environmentId, feedId, resourcePath);
 
@@ -155,10 +154,9 @@ public class RestResourcesData extends RestResources {
                           @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
                   })
     public Response updateConfiguration(@PathParam("environmentId") String environmentId,
-                                        @PathParam("feedId") String feedId,
-                                        @PathParam("resourcePath") String resourcePath,
-                                        @DefaultValue("configuration") @QueryParam("dataType") DataEntity.Role dataType,
-                                        @ApiParam(required = true) DataEntity.Update configuration) {
+            @PathParam("feedId") String feedId, @PathParam("resourcePath") String resourcePath,
+            @DefaultValue("configuration") @QueryParam("dataType") Resources.DataRole dataType,
+            @ApiParam(required = true) DataEntity.Update configuration) {
 
         return updateConfigurationHelper(environmentId, feedId, resourcePath, dataType, configuration);
     }
@@ -173,15 +171,15 @@ public class RestResourcesData extends RestResources {
                           @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
                   })
     public Response updateConfiguration(@PathParam("environmentId") String environmentId,
-                                        @PathParam("resourcePath") String resourcePath,
-                                        @DefaultValue("configuration") @QueryParam("dataType") DataEntity.Role dataType,
-                                        @ApiParam(required = true) DataEntity.Update configuration) {
+            @PathParam("resourcePath") String resourcePath,
+            @DefaultValue("configuration") @QueryParam("dataType") Resources.DataRole dataType,
+            @ApiParam(required = true) DataEntity.Update configuration) {
 
         return updateConfigurationHelper(environmentId, null, resourcePath, dataType, configuration);
     }
 
     private Response updateConfigurationHelper(String environmentId, String feedId, String resourcePath,
-                                               DataEntity.Role dataType, DataEntity.Update configuration) {
+            Resources.DataRole dataType, DataEntity.Update configuration) {
         String tenantId = getTenantId();
         CanonicalPath resource = composeCanonicalPath(tenantId, environmentId, feedId, resourcePath);
 
@@ -203,7 +201,7 @@ public class RestResourcesData extends RestResources {
                                         @PathParam("feedId") String feedId,
                                         @PathParam("resourcePath") String resourcePath,
                                         @DefaultValue("configuration") @QueryParam("dataType")
-                                        DataEntity.Role dataType) {
+                                        Resources.DataRole dataType) {
 
         return deleteConfigurationHelper(environmentId, feedId, resourcePath, dataType);
     }
@@ -220,13 +218,13 @@ public class RestResourcesData extends RestResources {
     public Response deleteConfiguration(@PathParam("environmentId") String environmentId,
                                         @PathParam("resourcePath") String resourcePath,
                                         @DefaultValue("configuration") @QueryParam("dataType")
-                                        DataEntity.Role dataType) {
+                                        Resources.DataRole dataType) {
 
         return deleteConfigurationHelper(environmentId, null, resourcePath, dataType);
     }
 
     private Response deleteConfigurationHelper(String environmentId, String feedId, String resourcePath,
-                                               DataEntity.Role dataType) {
+            Resources.DataRole dataType) {
         String tenantId = getTenantId();
         CanonicalPath resource = composeCanonicalPath(tenantId, environmentId, feedId, resourcePath);
 


### PR DESCRIPTION
The definitions are modelled using JSON schema.
- Split up DataEntity.Role so that its use in different scenarios can be
  type-checked.
- Added ResourceTypes.*.data() to access the data associated with the
  resource type which can be either config or connection config schema.
- Added validation logic for resource data against schemas on the resource
  types
- Added validation logic of the resource type data against json schema
  meta-schema (i.e. if they are well-formed json-schema documents).
- Properly call cleanup and preUpdate checks both in ReadWrite and Single
  impls.
- Added ability to set a starting element for a traversal query to the
  InventoryBackend interface.
