### PR TITLE
 [HWKINVENT-104] Expose data entity events on the bus

### DIFF
--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/DataEntity.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/DataEntity.java
@@ -32,7 +32,7 @@ import org.hawkular.inventory.api.Resources;
  * @author Lukas Krejci
  * @since 0.3.0
  */
-public class DataEntity extends Entity<DataEntity.Blueprint<?>, DataEntity.Update> {
+public final class DataEntity extends Entity<DataEntity.Blueprint<?>, DataEntity.Update> {
 
     private final StructuredData value;
 
@@ -68,7 +68,7 @@ public class DataEntity extends Entity<DataEntity.Blueprint<?>, DataEntity.Updat
     }
 
     @Override
-    public Updater<Update, ? extends AbstractElement<?, Update>> update() {
+    public Updater<Update, DataEntity> update() {
         return new Updater<>((u) -> new DataEntity(this.getPath().up(), this.getRole(),
                 valueOrDefault(u.getValue(), getValue()), u.getProperties()));
     }
@@ -122,6 +122,9 @@ public class DataEntity extends Entity<DataEntity.Blueprint<?>, DataEntity.Updat
 
         public Blueprint(DataRole role, StructuredData value, Map<String, Object> properties) {
             super(properties);
+            if (value == null) {
+                value = StructuredData.get().undefined();
+            }
             this.role = role;
             this.value = value;
         }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ResourceType.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ResourceType.java
@@ -59,7 +59,8 @@ public final class ResourceType extends FeedBasedEntity<ResourceType.Blueprint, 
      * Data required to create a resource type.
      *
      * <p>Note that tenantId, etc., are not needed here because they are provided by the context in which the
-     * {@link org.hawkular.inventory.api.WriteInterface#create(Entity.Blueprint)} method is called.
+     * {@link org.hawkular.inventory.api.WriteInterface#create(org.hawkular.inventory.api.model.Blueprint)} method is
+     * called.
      */
     @XmlRootElement
     public static final class Blueprint extends Entity.Blueprint {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseData.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseData.java
@@ -304,6 +304,11 @@ public final class BaseData {
         }
 
         private static void validate(CanonicalPath dataPath, JsonNode dataNode, JsonNode schemaNode) {
+            //explicitly allow null schemas
+            if (dataNode == null || dataNode.isNull()) {
+                return;
+            }
+
             try {
                 ProcessingReport report = VALIDATOR.validate(schemaNode, dataNode, true);
                 if (!report.isSuccess()) {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetrics.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetrics.java
@@ -33,7 +33,6 @@ import org.hawkular.inventory.api.model.MetricType;
 import org.hawkular.inventory.api.model.Path;
 import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.Resource;
-import org.hawkular.inventory.base.EntityAndPendingNotifications.Notification;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
 
 /**

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
@@ -43,7 +43,6 @@ import org.hawkular.inventory.api.model.Path;
 import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.api.model.ResourceType;
-import org.hawkular.inventory.base.EntityAndPendingNotifications.Notification;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
 
 /**

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/EntityAndPendingNotifications.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/EntityAndPendingNotifications.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.hawkular.inventory.api.Action;
 import org.hawkular.inventory.api.model.AbstractElement;
 
 /**
@@ -60,52 +59,5 @@ public final class EntityAndPendingNotifications<E extends AbstractElement<?, ?>
 
     public List<Notification<?, ?>> getNotifications() {
         return notifications;
-    }
-
-    /**
-     * Represents a notification to be sent out. I.e. this wraps together the data necessary to sending a new inventory
-     * event.
-     *
-     * @param <C> the type of the action context - i.e. the data describing the action
-     * @param <V> the type of the value that the action has been performed upon
-     */
-    public static final class Notification<C, V> {
-        private final C actionContext;
-        private final V value;
-        private final Action<C, V> action;
-
-        /**
-         * Constructs a new instance.
-         *
-         * @param actionContext the data describing the results of the action
-         * @param value         the value that the action has been performed upon
-         * @param action        the action itself
-         */
-        public Notification(C actionContext, V value, Action<C, V> action) {
-            this.actionContext = actionContext;
-            this.value = value;
-            this.action = action;
-        }
-
-        /**
-         * @return the action to be notified about
-         */
-        public Action<C, V> getAction() {
-            return action;
-        }
-
-        /**
-         * @return the data describing the action performed
-         */
-        public C getActionContext() {
-            return actionContext;
-        }
-
-        /**
-         * @return the value the action has been performed upon
-         */
-        public V getValue() {
-            return value;
-        }
     }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Mutator.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Mutator.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 
 import org.hawkular.inventory.api.EntityAlreadyExistsException;
 import org.hawkular.inventory.api.EntityNotFoundException;
-import org.hawkular.inventory.api.PartiallyApplied;
 import org.hawkular.inventory.api.model.AbstractElement;
 import org.hawkular.inventory.api.model.Blueprint;
 import org.hawkular.inventory.api.model.CanonicalPath;
@@ -122,7 +121,7 @@ abstract class Mutator<BE, E extends Entity<?, U>, B extends Blueprint, U extend
 
     public final void delete(Id id) throws EntityNotFoundException {
         Query q = id == null ? context.select().get() : context.select().with(id(id.toString())).get();
-        Util.delete(context, q, PartiallyApplied.procedure(this::cleanup).first(id).asConsumer());
+        Util.delete(context, q, (e) -> cleanup(id, e));
     }
 
     /**

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Notification.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Notification.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.base;
+
+import org.hawkular.inventory.api.Action;
+
+/**
+ * Represents a notification to be sent out. I.e. this wraps together the data necessary to sending a new inventory
+ * event.
+ *
+ * @param <C> the type of the action context - i.e. the data describing the action
+ * @param <V> the type of the value that the action has been performed upon
+ */
+public final class Notification<C, V> {
+    private final C actionContext;
+    private final V value;
+    private final Action<C, V> action;
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param actionContext the data describing the results of the action
+     * @param value         the value that the action has been performed upon
+     * @param action        the action itself
+     */
+    public Notification(C actionContext, V value, Action<C, V> action) {
+        this.actionContext = actionContext;
+        this.value = value;
+        this.action = action;
+    }
+
+    /**
+     * @return the action to be notified about
+     */
+    public Action<C, V> getAction() {
+        return action;
+    }
+
+    /**
+     * @return the data describing the action performed
+     */
+    public C getActionContext() {
+        return actionContext;
+    }
+
+    /**
+     * @return the value the action has been performed upon
+     */
+    public V getValue() {
+        return value;
+    }
+}

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TraversalContext.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TraversalContext.java
@@ -29,7 +29,6 @@ import org.hawkular.inventory.api.model.AbstractElement;
 import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.model.Path;
 import org.hawkular.inventory.api.model.Relationship;
-import org.hawkular.inventory.base.EntityAndPendingNotifications.Notification;
 import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.base.spi.SwitchElementType;
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Util.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Util.java
@@ -49,7 +49,6 @@ import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.RelativePath;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
-import org.hawkular.inventory.base.EntityAndPendingNotifications.Notification;
 import org.hawkular.inventory.base.spi.CommitFailureException;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
 import org.hawkular.inventory.base.spi.InventoryBackend;

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InventoryBackend.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InventoryBackend.java
@@ -228,7 +228,7 @@ public interface InventoryBackend<E> extends AutoCloseable {
      * @param dataEntityRepresentation the representation of the {@link org.hawkular.inventory.api.model.DataEntity}
      *                                 instance
      * @param dataPath                 the path in the data to descend to.
-     * @see org.hawkular.inventory.api.Datas.Single#data(RelativePath)
+     * @see org.hawkular.inventory.api.Data.Single#data(RelativePath)
      */
     E descendToData(E dataEntityRepresentation, RelativePath dataPath);
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/ShallowStructuredData.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/ShallowStructuredData.java
@@ -22,7 +22,7 @@ import org.hawkular.inventory.api.model.StructuredData;
 /**
  * This is essentially a marker class to distinguish a fully loaded structured data from the "bare" shallow variant that
  * doesn't contain the potential children (see for example
- * {@link org.hawkular.inventory.api.Datas.Single#flatData(RelativePath)}).
+ * {@link org.hawkular.inventory.api.Data.Single#flatData(RelativePath)}).
  *
  * <p>When calling {@link InventoryBackend#convert(Object, Class)}, with {@link StructuredData}, the whole structured
  * data is loaded. On the other hand calling it with {@code ShallowStructuredData} will make the convert method not load

--- a/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/DataEntityEvent.java
+++ b/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/DataEntityEvent.java
@@ -16,19 +16,27 @@
  */
 package org.hawkular.inventory.bus.api;
 
+import java.util.Map;
+
 import org.hawkular.inventory.api.Action;
-import org.hawkular.inventory.api.model.Relationship;
+import org.hawkular.inventory.api.model.DataEntity;
 
 /**
  * @author Lukas Krejci
- * @since 0.0.1
+ * @since 0.3.2
  */
-public final class RelationshipEvent extends InventoryEvent<Relationship> {
-
-    public RelationshipEvent() {
+public final class DataEntityEvent extends InventoryEvent<DataEntity> {
+    public DataEntityEvent() {
     }
 
-    public RelationshipEvent(Action.Enumerated action, Relationship object) {
+    public DataEntityEvent(Action.Enumerated action, DataEntity object) {
         super(action, object);
+    }
+
+    @Override
+    public Map<String, String> createMessageHeaders() {
+        Map<String, String> ret = super.createMessageHeaders();
+        ret.put("dataRole", getObject().getRole().name());
+        return ret;
     }
 }

--- a/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/EnvironmentEvent.java
+++ b/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/EnvironmentEvent.java
@@ -25,23 +25,10 @@ import org.hawkular.inventory.api.model.Environment;
  */
 public final class EnvironmentEvent extends InventoryEvent<Environment> {
 
-    private Environment object;
-
     public EnvironmentEvent() {
     }
 
     public EnvironmentEvent(Action.Enumerated action, Environment object) {
-        super(action);
-        this.object = object;
-    }
-
-    @Override
-    public Environment getObject() {
-        return object;
-    }
-
-    @Override
-    public void setObject(Environment object) {
-        this.object = object;
+        super(action, object);
     }
 }

--- a/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/FeedEvent.java
+++ b/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/FeedEvent.java
@@ -25,23 +25,10 @@ import org.hawkular.inventory.api.model.Feed;
  */
 public final class FeedEvent extends InventoryEvent<Feed> {
 
-    private Feed object;
-
     public FeedEvent() {
     }
 
     public FeedEvent(Action.Enumerated action, Feed object) {
-        super(action);
-        this.object = object;
-    }
-
-    @Override
-    public Feed getObject() {
-        return object;
-    }
-
-    @Override
-    public void setObject(Feed object) {
-        this.object = object;
+        super(action, object);
     }
 }

--- a/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/InventoryEventMessageListener.java
+++ b/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/InventoryEventMessageListener.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.bus.api;
+
+import javax.jms.Message;
+
+import org.hawkular.bus.common.BasicMessage;
+import org.hawkular.bus.common.consumer.BasicMessageListener;
+import org.hawkular.inventory.api.model.Tenant;
+
+/**
+ * This can be used as a base class for receiving inventory events. This class takes care of automatically determining
+ * the correct type of the inventory message received and deserializing it appropriately.
+ *
+ * <p>The users are supposed to implement the {@link #onBasicMessage(BasicMessage)} method where they receive an
+ * instance of one of the concrete subclasses of the {@link InventoryEvent} (i.e. {@link TenantEvent}, {@link FeedEvent}
+ * and the like).
+ *
+ * @author Lukas Krejci
+ * @since 0.3.2
+ */
+public abstract class InventoryEventMessageListener extends BasicMessageListener<InventoryEvent<?>> {
+
+    private ThreadLocal<Class<? extends InventoryEvent<?>>> currentEventType = new ThreadLocal<>();
+
+    @SuppressWarnings("unchecked")
+    public InventoryEventMessageListener() {
+        super((Class<InventoryEvent<?>>) (Class) DummyEvent.class);
+    }
+
+    @Override
+    protected InventoryEvent<?> getBasicMessageFromMessage(Message message) {
+        try {
+            currentEventType.set(InventoryEvent.determineEventType(message));
+            return super.getBasicMessageFromMessage(message);
+        } finally {
+            currentEventType.set(null);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Class<InventoryEvent<?>> getBasicMessageClass() {
+        Class<? extends InventoryEvent<?>> cls = currentEventType.get();
+
+        if (cls == null) {
+            return super.getBasicMessageClass();
+        } else {
+            return (Class<InventoryEvent<?>>) cls;
+        }
+    }
+
+    private static final class DummyEvent extends InventoryEvent<Tenant> {
+    }
+}

--- a/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/MetricEvent.java
+++ b/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/MetricEvent.java
@@ -25,23 +25,10 @@ import org.hawkular.inventory.api.model.Metric;
  */
 public final class MetricEvent extends InventoryEvent<Metric> {
 
-    private Metric object;
-
     public MetricEvent() {
     }
 
     public MetricEvent(Action.Enumerated action, Metric object) {
-        super(action);
-        this.object = object;
-    }
-
-    @Override
-    public Metric getObject() {
-        return object;
-    }
-
-    @Override
-    public void setObject(Metric object) {
-        this.object = object;
+        super(action, object);
     }
 }

--- a/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/MetricTypeEvent.java
+++ b/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/MetricTypeEvent.java
@@ -25,23 +25,10 @@ import org.hawkular.inventory.api.model.MetricType;
  */
 public final class MetricTypeEvent extends InventoryEvent<MetricType> {
 
-    private MetricType object;
-
     public MetricTypeEvent() {
     }
 
     public MetricTypeEvent(Action.Enumerated action, MetricType object) {
-        super(action);
-        this.object = object;
-    }
-
-    @Override
-    public MetricType getObject() {
-        return object;
-    }
-
-    @Override
-    public void setObject(MetricType object) {
-        this.object = object;
+        super(action, object);
     }
 }

--- a/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/ResourceEvent.java
+++ b/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/ResourceEvent.java
@@ -25,23 +25,10 @@ import org.hawkular.inventory.api.model.Resource;
  */
 public final class ResourceEvent extends InventoryEvent<Resource> {
 
-    private Resource object;
-
     public ResourceEvent() {
     }
 
     public ResourceEvent(Action.Enumerated action, Resource object) {
-        super(action);
-        this.object = object;
-    }
-
-    @Override
-    public Resource getObject() {
-        return object;
-    }
-
-    @Override
-    public void setObject(Resource object) {
-        this.object = object;
+        super(action, object);
     }
 }

--- a/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/ResourceTypeEvent.java
+++ b/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/ResourceTypeEvent.java
@@ -25,23 +25,10 @@ import org.hawkular.inventory.api.model.ResourceType;
  */
 public final class ResourceTypeEvent extends InventoryEvent<ResourceType> {
 
-    private ResourceType object;
-
     public ResourceTypeEvent() {
     }
 
     public ResourceTypeEvent(Action.Enumerated action, ResourceType object) {
-        super(action);
-        this.object = object;
-    }
-
-    @Override
-    public ResourceType getObject() {
-        return object;
-    }
-
-    @Override
-    public void setObject(ResourceType object) {
-        this.object = object;
+        super(action, object);
     }
 }

--- a/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/TenantEvent.java
+++ b/hawkular-inventory-bus-api/src/main/java/org/hawkular/inventory/bus/api/TenantEvent.java
@@ -25,23 +25,10 @@ import org.hawkular.inventory.api.model.Tenant;
  */
 public final class TenantEvent extends InventoryEvent<Tenant> {
 
-    private Tenant object;
-
     public TenantEvent() {
     }
 
     public TenantEvent(Action.Enumerated action, Tenant object) {
-        super(action);
-        this.object = object;
-    }
-
-    @Override
-    public Tenant getObject() {
-        return object;
-    }
-
-    @Override
-    public void setObject(Tenant object) {
-        this.object = object;
+        super(action, object);
     }
 }

--- a/hawkular-inventory-bus/pom.xml
+++ b/hawkular-inventory-bus/pom.xml
@@ -67,6 +67,12 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>org.hawkular.bus</groupId>
@@ -74,15 +80,25 @@
       <version>${version.org.hawkular.bus}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-jackson2-provider</artifactId>
-      <scope>provided</scope>
+      <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-impl-tinkerpop</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-impl-tinkerpop-tinkergraph-provider</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/hawkular-inventory-bus/src/main/java/org/hawkular/inventory/bus/BusIntegration.java
+++ b/hawkular-inventory-bus/src/main/java/org/hawkular/inventory/bus/BusIntegration.java
@@ -27,8 +27,8 @@ import javax.naming.NamingException;
 import org.hawkular.inventory.api.Action;
 import org.hawkular.inventory.api.Interest;
 import org.hawkular.inventory.api.Inventory;
-import org.hawkular.inventory.api.PartiallyApplied;
 import org.hawkular.inventory.api.model.AbstractElement;
+import org.hawkular.inventory.api.model.DataEntity;
 import org.hawkular.inventory.api.model.Environment;
 import org.hawkular.inventory.api.model.Feed;
 import org.hawkular.inventory.api.model.Metric;
@@ -89,6 +89,7 @@ public final class BusIntegration {
         install(inventory, subscriptions, Resource.class, messageSender);
         install(inventory, subscriptions, Metric.class, messageSender);
         install(inventory, subscriptions, Relationship.class, messageSender);
+        install(inventory, subscriptions, DataEntity.class, messageSender);
     }
 
     private void uninstall() {
@@ -112,8 +113,7 @@ public final class BusIntegration {
 
         Interest<C, T> interest = Interest.in(entityClass).being(action);
 
-        Subscription s = inventory.observable(interest).subscribe(PartiallyApplied.procedure(sender::send)
-                .first(interest));
+        Subscription s = inventory.observable(interest).subscribe((c) -> sender.send(interest, c));
         subscriptions.add(s);
     }
 }

--- a/hawkular-inventory-bus/src/main/java/org/hawkular/inventory/bus/MessageSender.java
+++ b/hawkular-inventory-bus/src/main/java/org/hawkular/inventory/bus/MessageSender.java
@@ -18,7 +18,6 @@ package org.hawkular.inventory.bus;
 
 import static org.hawkular.inventory.bus.Log.LOG;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.jms.JMSException;
@@ -49,7 +48,7 @@ final class MessageSender {
 
     public void send(Interest<?, ?> interest, Object inventoryEvent) {
         InventoryEvent<?> message = InventoryEvent.from(interest.getAction(), inventoryEvent);
-        Map<String, String> headers = toHeaders(interest);
+        Map<String, String> headers = message.createMessageHeaders();
 
         try (ConnectionContextFactory ccf = new ConnectionContextFactory(topicConnectionFactory)) {
 
@@ -62,18 +61,5 @@ final class MessageSender {
         } catch (JMSException e) {
             LOG.failedToSendMessage(message.toString());
         }
-    }
-
-    private Map<String, String> toHeaders(Interest<?, ?> interest) {
-        HashMap<String, String> ret = new HashMap<>();
-
-        ret.put("action", interest.getAction().asEnum().name().toLowerCase());
-        ret.put("entityType", firstLetterLowercased(interest.getEntityType().getSimpleName()));
-
-        return ret;
-    }
-
-    private String firstLetterLowercased(String source) {
-        return Character.toLowerCase(source.charAt(0)) + source.substring(1);
     }
 }

--- a/hawkular-inventory-bus/src/test/java/org/hawkular/inventory/bus/BusTest.java
+++ b/hawkular-inventory-bus/src/test/java/org/hawkular/inventory/bus/BusTest.java
@@ -22,8 +22,28 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
 import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.function.Consumer;
+
+import javax.jms.Connection;
+import javax.jms.JMSException;
+import javax.jms.TopicConnection;
+import javax.jms.TopicConnectionFactory;
+import javax.naming.Binding;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.Name;
+import javax.naming.NameClassPair;
+import javax.naming.NameParser;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.spi.InitialContextFactory;
 
 import org.hawkular.bus.common.ConnectionContextFactory;
 import org.hawkular.bus.common.Endpoint;
@@ -33,7 +53,12 @@ import org.hawkular.bus.common.producer.ProducerConnectionContext;
 import org.hawkular.bus.common.test.SimpleTestListener;
 import org.hawkular.bus.common.test.VMEmbeddedBrokerWrapper;
 import org.hawkular.inventory.api.Action;
+import org.hawkular.inventory.api.Configuration;
+import org.hawkular.inventory.api.Inventory;
+import org.hawkular.inventory.api.ResourceTypes;
+import org.hawkular.inventory.api.feeds.RandomUUIDFeedIdStrategy;
 import org.hawkular.inventory.api.model.CanonicalPath;
+import org.hawkular.inventory.api.model.DataEntity;
 import org.hawkular.inventory.api.model.Environment;
 import org.hawkular.inventory.api.model.Feed;
 import org.hawkular.inventory.api.model.Metric;
@@ -43,15 +68,20 @@ import org.hawkular.inventory.api.model.MetricUnit;
 import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.api.model.ResourceType;
+import org.hawkular.inventory.api.model.StructuredData;
 import org.hawkular.inventory.api.model.Tenant;
+import org.hawkular.inventory.bus.api.DataEntityEvent;
 import org.hawkular.inventory.bus.api.EnvironmentEvent;
 import org.hawkular.inventory.bus.api.FeedEvent;
+import org.hawkular.inventory.bus.api.InventoryEvent;
+import org.hawkular.inventory.bus.api.InventoryEventMessageListener;
 import org.hawkular.inventory.bus.api.MetricEvent;
 import org.hawkular.inventory.bus.api.MetricTypeEvent;
 import org.hawkular.inventory.bus.api.RelationshipEvent;
 import org.hawkular.inventory.bus.api.ResourceEvent;
 import org.hawkular.inventory.bus.api.ResourceTypeEvent;
 import org.hawkular.inventory.bus.api.TenantEvent;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -93,6 +123,9 @@ public class BusTest {
         ResourceEvent resourceEvent = new ResourceEvent(Action.Enumerated.UPDATED,
                 new Resource(CanonicalPath.fromString("/t;t/e;e/r;r"), resourceType));
         ResourceTypeEvent resourceTypeEvent = new ResourceTypeEvent(Action.Enumerated.COPIED, resourceType);
+        DataEntityEvent dataEntityEvent = new DataEntityEvent(Action.Enumerated.DELETED,
+                new DataEntity(resourceType.getPath(), ResourceTypes.DataRole.configurationSchema,
+                        StructuredData.get().undefined()));
 
         String tenantJSON = tenantEvent.toJSON();
         String envJSON = environmentEvent.toJSON();
@@ -102,6 +135,7 @@ public class BusTest {
         String relationshipJSON = relationshipEvent.toJSON();
         String resourceJSON = resourceEvent.toJSON();
         String resourceTypeJSON = resourceTypeEvent.toJSON();
+        String dataEntityJSON = dataEntityEvent.toJSON();
 
         assertThat(tenantEvent.getObject(),
                    is(equalTo(TenantEvent.fromJSON(tenantJSON, TenantEvent.class).getObject())));
@@ -119,6 +153,8 @@ public class BusTest {
                    is(equalTo(ResourceEvent.fromJSON(resourceJSON, ResourceEvent.class).getObject())));
         assertThat(resourceTypeEvent.getObject(),
                    is(equalTo(ResourceTypeEvent.fromJSON(resourceTypeJSON, ResourceTypeEvent.class).getObject())));
+        assertThat(dataEntityEvent.getObject(), is(equalTo(DataEntityEvent.fromJSON(dataEntityJSON,
+                DataEntityEvent.class).getObject())));
     }
 
     @Test
@@ -184,7 +220,7 @@ public class BusTest {
             tenantListener.waitForMessage(3);
             TenantEvent tenantReceivedMsg = tenantListener.getReceivedMessage();
             assertEquals("Should have received the message",
-                         tenantReceivedMsg.getObject().getProperties().get(PROP_KEY), PROP_VALUE);
+                    tenantReceivedMsg.getObject().getProperties().get(PROP_KEY), PROP_VALUE);
             assertNotNull(tenantReceivedMsg.getHeaders());
             assertEquals(1, tenantReceivedMsg.getHeaders().size());
             assertEquals(PROP_VALUE, tenantReceivedMsg.getHeaders().get(PROP_KEY));
@@ -237,7 +273,7 @@ public class BusTest {
             MetricEvent metricReceivedMsg = metricListener.getReceivedMessage();
 
             assertEquals("Should have received the message",
-                         metricReceivedMsg.getObject().getProperties().get(PROP_KEY), PROP_VALUE);
+                    metricReceivedMsg.getObject().getProperties().get(PROP_KEY), PROP_VALUE);
             assertNotNull(metricReceivedMsg.getHeaders());
             assertEquals(1, metricReceivedMsg.getHeaders().size());
             assertEquals(metricType.getType(), metricReceivedMsg.getObject().getType().getType());
@@ -247,6 +283,290 @@ public class BusTest {
             producerFactory.close();
             consumerFactory.close();
             broker.stop();
+        }
+    }
+
+    @Test
+    public void testBusIntegrationHeaderInjection() throws Exception {
+        VMEmbeddedBrokerWrapper broker = new VMEmbeddedBrokerWrapper();
+
+        System.setProperty(Context.INITIAL_CONTEXT_FACTORY, ContextFactory.class.getName());
+
+        InitialContext namingContext = new InitialContext();
+
+        Inventory inventory = ServiceLoader.load(Inventory.class).iterator().next();
+        inventory.initialize(new Configuration(new RandomUUIDFeedIdStrategy(), null, Collections.emptyMap()));
+
+        try (ConnectionContextFactory producerFactory = new ConnectionContextFactory(broker.getBrokerURL());
+             ConnectionContextFactory consumerFactory = new ConnectionContextFactory(broker.getBrokerURL())) {
+
+            broker.start();
+
+            String topicName =
+                    org.hawkular.inventory.bus.Configuration.Property.INVENTORY_CHANGES_TOPIC_NAME.getDefaultValue();
+            Endpoint topic = new Endpoint(Endpoint.Type.TOPIC, topicName);
+
+            namingContext.bind(
+                    org.hawkular.inventory.bus.Configuration.Property.CONNECTION_FACTORY_JNDI_NAME.getDefaultValue(),
+                    new TopicConnectionFactory() {
+                        @Override
+                        public TopicConnection createTopicConnection() throws JMSException {
+                            return (TopicConnection) producerFactory.createProducerConnectionContext(topic)
+                                    .getConnection();
+                        }
+
+                        @Override
+                        public TopicConnection createTopicConnection(String userName,
+                                String password) throws JMSException {
+                            return createTopicConnection();
+                        }
+
+                        @Override
+                        public Connection createConnection() throws JMSException {
+                            return createTopicConnection();
+                        }
+
+                        @Override
+                        public Connection createConnection(String userName, String password) throws JMSException {
+                            return createTopicConnection(userName, password);
+                        }
+                    });
+
+            BusIntegration busIntegration = new BusIntegration(inventory);
+            busIntegration.configure(org.hawkular.inventory.bus.Configuration.builder().build());
+            busIntegration.start();
+
+
+            ConsumerConnectionContext consumerContext = consumerFactory.createConsumerConnectionContext(topic);
+
+            testHeaders(consumerContext, TenantEvent.class,
+                    () -> inventory.tenants().create(Tenant.Blueprint.builder().withId("t").build()),
+                    (headers) -> {
+                        assertThat(headers.size(), is(equalTo(3)));
+                        assertThat(headers.get("path"), is(equalTo(CanonicalPath.of().tenant("t").get().toString())));
+                        assertThat(headers.get("action"), is(equalTo(Action.Enumerated.CREATED.name())));
+                        assertThat(headers.get("entityType"), is(equalTo("tenant")));
+                    });
+
+            testHeaders(consumerContext, ResourceTypeEvent.class,
+                    () -> inventory.tenants().get("t").feedlessResourceTypes().create(ResourceType.Blueprint.builder()
+                            .withId("rt").build()),
+                    (headers) -> {
+                        assertThat(headers.size(), is(equalTo(3)));
+                        assertThat(headers.get("path"), is(equalTo(CanonicalPath.of().tenant("t")
+                                .resourceType("rt").get().toString())));
+                        assertThat(headers.get("action"), is(equalTo(Action.Enumerated.CREATED.name())));
+                        assertThat(headers.get("entityType"), is(equalTo("resourceType")));
+                    });
+
+            //data entity events declare one more header, so we need to check for that, too
+            testHeaders(consumerContext, DataEntityEvent.class,
+                    () -> inventory.tenants().get("t").feedlessResourceTypes().get("rt").data()
+                            .create(DataEntity.Blueprint.<ResourceTypes.DataRole>builder()
+                                    .withRole(ResourceTypes.DataRole.configurationSchema).build()),
+                    (headers) -> {
+                        assertThat(headers.size(), is(equalTo(4)));
+                        assertThat(headers.get("path"), is(equalTo(CanonicalPath.of().tenant("t")
+                                .resourceType("rt").data(ResourceTypes.DataRole.configurationSchema).get()
+                                .toString())));
+                        assertThat(headers.get("action"), is(equalTo(Action.Enumerated.CREATED.name())));
+                        assertThat(headers.get("entityType"), is(equalTo("dataEntity")));
+                        assertThat(headers.get("dataRole"),
+                                is(equalTo(ResourceTypes.DataRole.configurationSchema.name())));
+                    });
+        } finally {
+            broker.stop();
+            namingContext.close();
+            inventory.close();
+        }
+    }
+
+    private void testHeaders(ConsumerConnectionContext consumerContext, Class<? extends InventoryEvent<?>> eventClass,
+            Runnable inventoryAction, Consumer<Map<String, String>> assertions)
+            throws JMSException, InterruptedException {
+
+        List<InventoryEvent<?>> receivedMessages = new ArrayList<>();
+
+        InventoryEventMessageListener listener = new InventoryEventMessageListener() {
+            @Override
+            protected void onBasicMessage(InventoryEvent<?> inventoryEvent) {
+                receivedMessages.add(inventoryEvent);
+            }
+        };
+
+        MessageProcessor receiver = new MessageProcessor();
+        receiver.listen(consumerContext, listener);
+
+        inventoryAction.run();
+
+        Thread.sleep(3000);
+
+        boolean checked = false;
+        for (InventoryEvent<?> e : receivedMessages) {
+            if (eventClass.isAssignableFrom(e.getClass())) {
+                assertions.accept(e.getHeaders());
+                checked = true;
+            }
+        }
+
+        if (!checked) {
+            Assert.fail("No event of type " + eventClass + " received. We obtained: " + receivedMessages);
+        }
+    }
+
+    public static class ContextFactory implements InitialContextFactory {
+
+        @Override
+        public Context getInitialContext(Hashtable<?, ?> environment) throws NamingException {
+            return new MapContext();
+        }
+    }
+
+    public static class MapContext implements Context {
+        private static final Map<String, Object> objects = new Hashtable<>();
+
+        @Override
+        public Object lookup(Name name) throws NamingException {
+            return lookup(name.toString());
+        }
+
+        @Override
+        public Object lookup(String name) throws NamingException {
+            return objects.get(name);
+        }
+
+        @Override
+        public void bind(Name name, Object obj) throws NamingException {
+            bind(name.toString(), obj);
+        }
+
+        @Override
+        public void bind(String name, Object obj) throws NamingException {
+            objects.put(name, obj);
+        }
+
+        @Override
+        public void rebind(Name name, Object obj) throws NamingException {
+            rebind(name.toString(), obj);
+        }
+
+        @Override
+        public void rebind(String name, Object obj) throws NamingException {
+            objects.put(name, obj);
+        }
+
+        @Override
+        public void unbind(Name name) throws NamingException {
+            unbind(name.toString());
+        }
+
+        @Override
+        public void unbind(String name) throws NamingException {
+            objects.remove(name);
+        }
+
+        @Override
+        public void rename(Name oldName, Name newName) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void rename(String oldName, String newName) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public NamingEnumeration<NameClassPair> list(Name name) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public NamingEnumeration<NameClassPair> list(String name) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public NamingEnumeration<Binding> listBindings(Name name) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public NamingEnumeration<Binding> listBindings(String name) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void destroySubcontext(Name name) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void destroySubcontext(String name) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Context createSubcontext(Name name) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Context createSubcontext(String name) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object lookupLink(Name name) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object lookupLink(String name) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public NameParser getNameParser(Name name) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public NameParser getNameParser(String name) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Name composeName(Name name, Name prefix) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String composeName(String name, String prefix) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object addToEnvironment(String propName, Object propVal) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object removeFromEnvironment(String propName) throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Hashtable<?, ?> getEnvironment() throws NamingException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() throws NamingException {
+        }
+
+        @Override
+        public String getNameInNamespace() throws NamingException {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
@@ -745,7 +745,11 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
                 }
                 context.getGraph().removeVertex(dataVertex);
 
-                Element newData = persist(data.getValue());
+                StructuredData dataValue = data.getValue();
+                if (dataValue == null) {
+                    dataValue = StructuredData.get().undefined();
+                }
+                Element newData = persist(dataValue);
 
                 relate(v, newData, Relationships.WellKnown.hasData.name(), null);
                 return null;


### PR DESCRIPTION
Apart from the simple unrelated changes, this PR mainly makes sure that the `DataEntity` events flow to the bus, too.

Also a utility base class was added for easier work with inventory events on the receiving side of the bus - the `InventoryEventMessageListener`.

The creation of message headers was moved from the bus to the bus-api classes and 2 new headers were added - all inventory events now have the `path` header that determines the entity on which the event was raised and data entity events in addition have the `dataRole` header so that data entities of different roles are easily filtered on the receiving side.
