### PR TITLE
[HWKINVENT-130] Add some wait time between transaction retries

### DIFF
--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Log.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Log.java
@@ -41,4 +41,8 @@ public interface Log extends BasicLogger {
     @LogMessage(level = Logger.Level.WARN)
     @Message(id = 2, value = "No data associated with data entity on path %s that is being deleted.")
     void wNoDataAssociatedWithEntity(CanonicalPath dataEntityPath);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 3, value = "Thread interrupted while waiting for a next retry of a previously failed transaction.")
+    void wInterruptedWhileWaitingForTransactionRetry();
 }


### PR DESCRIPTION
Add some wait time between transaction retries in an attempt to reduce lock contention on the titan indexes during insertion bursts.
