### PR TITLE
HWKINVENT-132 - Rest endpoint for retrieving arbitrary entity by path is broken

### DIFF
--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestPath.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestPath.java
@@ -57,7 +57,7 @@ public class RestPath extends RestBase {
         String tenantId = getTenantId();
         CanonicalPath tenant = CanonicalPath.of().tenant(tenantId).get();
 
-        CanonicalPath path = CanonicalPath.fromPartiallyUntypedString(entityPath, tenant, Entity.class);
+        CanonicalPath path = CanonicalPath.fromPartiallyUntypedString('/' + entityPath, tenant, Entity.class);
 
         return Response.ok(inventory.inspect(path, ResolvableToSingle.class).entity()).build();
     }


### PR DESCRIPTION
fix: Prepending the / to the entity path string, because it's 'deleted/ignored' by the resteasy.
