### PR TITLE
Redeclare BytesToken in org.apache.cassandra.dht on a place it used to be

### DIFF
--- a/hawkular-inventory-dist/checkstyle-suppressions.xml
+++ b/hawkular-inventory-dist/checkstyle-suppressions.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+  <suppress checks="PackageName" files="src/main/java/org/apache/cassandra/dht/BytesToken.java"/>
+</suppressions>

--- a/hawkular-inventory-dist/pom.xml
+++ b/hawkular-inventory-dist/pom.xml
@@ -42,6 +42,10 @@
     <tag>HEAD</tag>
   </scm>
 
+  <properties>
+    <checkstyle.suppressions.file>checkstyle-suppressions.xml</checkstyle.suppressions.file>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.hawkular.inventory</groupId>
@@ -105,6 +109,11 @@
           <artifactId>netty</artifactId>
         </exclusion>
         <exclusion>
+          <!-- we use our own -->
+          <groupId>org.apache.cassandra</groupId>
+          <artifactId>cassandra-all</artifactId>
+        </exclusion>
+        <exclusion>
           <!-- TODO HACK ALERT: We're coupling pinger here... -->
           <!-- We need to depend on another version that is also used in Pinger. This should disappear once pinger
           becomes a proper remote client of inventory. -->
@@ -112,6 +121,11 @@
           <artifactId>httpclient</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.cassandra</groupId>
+      <artifactId>cassandra-all</artifactId>
     </dependency>
 
     <!-- TODO HACK ALERT: We're coupling pinger here... -->

--- a/hawkular-inventory-dist/src/main/java/org/apache/cassandra/dht/BytesToken.java
+++ b/hawkular-inventory-dist/src/main/java/org/apache/cassandra/dht/BytesToken.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.dht;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Hawkular upgraded to Cassandra 2.2.0 which moved this class to ByteOrderedPartitioner. Titan requires this class
+ * so let's provide it to it the way it wants it.
+ *
+ * @author Lukas Krejci
+ * @since 0.4.0
+ */
+public class BytesToken extends ByteOrderedPartitioner.BytesToken {
+    public BytesToken(byte[] token) {
+        super(token);
+    }
+
+    public BytesToken(ByteBuffer token) {
+        super(token);
+    }
+}


### PR DESCRIPTION
prior to C\* 2.2.0. This works around Titan's incompatibility with that
release.
