### PR TITLE
Log the stacktrace on debug when inventory init fails.

### DIFF
--- a/hawkular-inventory-cdi/src/main/java/org/hawkular/inventory/cdi/Log.java
+++ b/hawkular-inventory-cdi/src/main/java/org/hawkular/inventory/cdi/Log.java
@@ -39,8 +39,8 @@ public interface Log extends BasicLogger {
     void wCannotReadConfigurationFile(String fileName, @Cause Throwable cause);
 
     @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 3501, value = "Inventory backend failed to initialize in an attempt %d of %d.")
-    void wInitializationFailure(int attempt, int maxAttempts);
+    @Message(id = 3501, value = "Inventory backend failed to initialize in an attempt %d of %d with message: %s.")
+    void wInitializationFailure(int attempt, int maxAttempts, String message);
 
     @LogMessage(level = Logger.Level.INFO)
     @Message(id = 3502, value = "Using inventory implementation: %s")

--- a/hawkular-inventory-cdi/src/main/java/org/hawkular/inventory/cdi/OfficialInventoryProducer.java
+++ b/hawkular-inventory-cdi/src/main/java/org/hawkular/inventory/cdi/OfficialInventoryProducer.java
@@ -105,8 +105,8 @@ public class OfficialInventoryProducer {
 
                 initialized = true;
             } catch (Exception e) {
-                LOG.debugf("Unable to initialize inventory, exception thrown: ", e);
-                LOG.wInitializationFailure(failures, maxFailures);
+                LOG.debug("Unable to initialize inventory, exception thrown: ", e);
+                LOG.wInitializationFailure(failures, maxFailures, e.getMessage());
                 Thread.sleep(1000);
             }
         }


### PR DESCRIPTION
The `debugf()` call made previously didn't do what we thought it'd do.
