### PR TITLE
Query performance 1

### DIFF
--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Path.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Path.java
@@ -690,7 +690,9 @@ public abstract class Path {
          * @return true if the path can be extended with the provided segment, false otherwise.
          */
         public boolean canExtendTo(Segment segment) {
-            switch (checkCanProgress(segment.elementType, Objects.equals(segment, segments.get(checkIndex)))) {
+            boolean idMatches = checkIndex >= 0 && checkIndex < segments.size() &&
+                    Objects.equals(segment, segments.get(checkIndex));
+            switch (checkCanProgress(segment.elementType, idMatches)) {
                 case PROCEED:
                 case CLEAR_SEGMENTS_AND_JUMP_TO_END:
                 case JUMP_TO_END:

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/paging/Page.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/paging/Page.java
@@ -24,6 +24,8 @@ import java.util.Spliterators;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import org.hawkular.inventory.api.Log;
+
 /**
  * A read-only list representing a single page of some results.
  *
@@ -83,6 +85,7 @@ public class Page<T> implements Iterator<T>, AutoCloseable, Iterable<T> {
         if (wrapped == null) {
             throw new IllegalStateException("the iterator has been already closed");
         }
+        Log.LOGGER.trace("Page: Obtaining next element from the wrapped iterator.");
         return wrapped.next();
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Query.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Query.java
@@ -16,25 +16,15 @@
  */
 package org.hawkular.inventory.base;
 
-import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
-import static org.hawkular.inventory.api.filters.With.id;
-import static org.hawkular.inventory.api.filters.With.type;
-
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.hawkular.inventory.api.filters.Filter;
-import org.hawkular.inventory.api.filters.Related;
-import org.hawkular.inventory.api.filters.RelationWith;
+import org.hawkular.inventory.api.filters.With;
 import org.hawkular.inventory.api.model.CanonicalPath;
-import org.hawkular.inventory.api.model.Entity;
-import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.base.spi.NoopFilter;
 
 /**
@@ -120,28 +110,7 @@ public final class Query {
 
     @SuppressWarnings({"ConstantConditions", "unchecked"})
     public static Query to(CanonicalPath entity) {
-        SymmetricExtender bld = Query.path();
-
-        Iterator<CanonicalPath.Segment> it = entity.getPath().iterator();
-
-        if (it.hasNext()) {
-            CanonicalPath.Segment s = it.next();
-            if (Relationship.class.equals(s.getElementType())) {
-                bld.with(RelationWith.id(s.getElementId()));
-                //early return - no further querying needed for relationships
-                return bld.get();
-            } else {
-                bld.with(type((Class<? extends Entity<?, ?>>) s.getElementType()), id(s.getElementId()));
-            }
-        }
-
-        while (it.hasNext()) {
-            CanonicalPath.Segment s = it.next();
-            bld.with(Related.by(contains), type((Class<? extends Entity<?, ?>>) s.getElementType()),
-                    id(s.getElementId()));
-        }
-
-        return bld.get();
+        return Query.path().with(With.path(entity)).get();
     }
 
     /**
@@ -277,18 +246,24 @@ public final class Query {
 
         /**
          * Sets the filters to be used on the current node in the tree.
+         * <p>
+         * This method tries to optimize the query by checking if the provided fragments (appended to the current query)
+         * form a canonical traversal and if so, replaces the query so far with a simple filter on the canonical path
+         * instead of a traversal with more steps.
          *
          * @param filters the list of filters to apply to the query at this position in the tree.
          * @return this builder
          */
         public Builder with(QueryFragment... filters) {
-            Collections.addAll(this.fragments, filters);
+            QueryOptimizer.appendOptimized(fragments, filters);
             return this;
         }
 
         public Builder with(Function<Filter, QueryFragment> converter, QueryFragment... filters) {
-            this.fragments.addAll(Arrays.asList(filters).stream().map(QueryFragment::getFilter).map(converter)
-                    .collect(Collectors.toList()));
+            QueryFragment[] converted = Arrays.asList(filters).stream().map(QueryFragment::getFilter).map(converter)
+                    .toArray(QueryFragment[]::new);
+
+            QueryOptimizer.appendOptimized(fragments, converted);
             return this;
         }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Query.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Query.java
@@ -204,6 +204,31 @@ public final class Query {
         return new SymmetricExtender(asBuilder());
     }
 
+    @Override
+    public String toString() {
+        StringBuilder bld = new StringBuilder();
+        addToString(bld, 0);
+        return bld.toString();
+    }
+
+    private void addToString(StringBuilder bld, int indentation) {
+        indent(bld, indentation);
+        bld.append("Query[fragments=").append(Arrays.toString(fragments));
+        if (!subTrees.isEmpty()) {
+            bld.append("\n");
+            subTrees.forEach((s) -> s.indent(bld, indentation + 1));
+        }
+        bld.append("\n");
+        indent(bld, indentation);
+        bld.append("]");
+    }
+
+    private void indent(StringBuilder bld, int indentation) {
+        for (int i = 0; i < indentation; ++i) {
+            bld.append("  ");
+        }
+    }
+
     /**
      * A low-level builder able to create new branches in the query tree.
      */

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/QueryOptimizer.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/QueryOptimizer.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.base;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.hawkular.inventory.api.filters.Filter;
+import org.hawkular.inventory.api.filters.Related;
+import org.hawkular.inventory.api.filters.With;
+import org.hawkular.inventory.api.model.CanonicalPath;
+import org.hawkular.inventory.api.model.Path;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.6.0
+ */
+final class QueryOptimizer {
+    private QueryOptimizer() {
+
+    }
+
+    public static void appendOptimized(List<QueryFragment> fragments, QueryFragment... filters) {
+        //remove duplicates
+        List<QueryFragment> applicableNewFilters;
+
+        if (fragments.isEmpty()) {
+            applicableNewFilters = new ArrayList<>(Arrays.asList(filters));
+        } else {
+            applicableNewFilters = removeDuplicates(fragments.get(fragments.size() - 1).getFilter(),
+                    new ArrayList<>(Arrays.asList(filters)));
+        }
+
+        cleanUnnecessaryNoops(applicableNewFilters);
+
+        QueryFragment cpFilter = findLastCanonicalFilterAndPrepareNewFilters(fragments, applicableNewFilters);
+
+        List<CanonicalPath.Extender> checkers;
+        if (cpFilter == null) {
+            checkers = Collections.singletonList(CanonicalPath.empty());
+        } else {
+            With.CanonicalPaths cps = (With.CanonicalPaths) cpFilter.getFilter();
+            checkers = Arrays.asList(cps.getPaths()).stream().map(CanonicalPath::modified).collect(toList());
+        }
+
+        while (!applicableNewFilters.isEmpty()) {
+            boolean isPath = applicableNewFilters.get(0) instanceof PathFragment;
+
+            QueryFragment first, second, third;
+
+            if ((first = removeOrReadd(applicableNewFilters, null, null)) == null) {
+                break;
+            }
+            if ((second = removeOrReadd(applicableNewFilters, first, null)) == null) {
+                break;
+            }
+            third = applicableNewFilters.isEmpty() ? null : applicableNewFilters.remove(0);
+
+            //check that the query is not transitioning from a path to a filter or vice versa
+            //we do this check only on the positions of the contains filter, because only that can actually influence
+            //the results
+            if (cpFilter != null && first.getClass() != cpFilter.getClass()) {
+                //we were trying to continue a classpath filter. move the contains to the processed fragments
+                //and try with the type/id as if this was a new start of the cp filter.
+                reAddNonNull(false, fragments, first);
+                reAddNonNull(true, applicableNewFilters, second, third);
+                checkers = Collections.singletonList(CanonicalPath.empty());
+                cpFilter = null;
+                continue;
+            }
+
+            With.Types typeFilter;
+            With.Ids idFilter;
+
+            if (cpFilter == null) {
+                //there is no prior canonical path filter, so we're starting a new one potentially
+                //this means that first and second are type+id
+                //additionally, the contains query fragment, if it is present, must be of the same type as the type/id
+                //filters.
+                //this is so that they all are either path segs or filter segs - we must not mix them together.
+                typeFilter = choose(With.Types.class, first, second);
+                idFilter = choose(With.Ids.class, first, second);
+                if (third != null && (!isOutgoingContains(third.getFilter()) || second.getClass() != third
+                        .getClass())) {
+                    reAddNonNull(true, applicableNewFilters, third);
+                }
+            } else {
+                //there is a prior canonical path filter, so we're trying to continue it.
+                //this means that first must be a contains filter, and second and third are type+id
+                //again we must check for the change in the query fragment type
+                if (!isOutgoingContains(first.getFilter())) {
+                    reAddNonNull(false, fragments, first);
+                    reAddNonNull(true, applicableNewFilters, second, third);
+                    checkers = Collections.singletonList(CanonicalPath.empty());
+                    cpFilter = null;
+                    continue;
+                }
+
+                typeFilter = choose(With.Types.class, second, third);
+                idFilter = choose(With.Ids.class, second, third);
+            }
+
+            if (typeFilter == null || idFilter == null) {
+                //hmm... not sure what to do with filters invalid for cp extension.. so just add them back to
+                //fragments and try to continue
+                reAddNonNull(false, fragments, first, second, third);
+                checkers = Collections.singletonList(CanonicalPath.empty());
+                cpFilter = null;
+                continue;
+            }
+
+            if (typeFilter.getTypes().length != idFilter.getIds().length) {
+                //the canonical path filter wouldn't be able to completely match the type+id filters, so
+                //bail
+                reAddNonNull(false, fragments, first, second, third);
+                checkers = Collections.singletonList(CanonicalPath.empty());
+                cpFilter = null;
+                continue;
+            }
+
+            // if we should be able to use the canonical path filter, everything must match - all the
+            // checkers must be able to extend to all types
+            boolean checkFailed = false;
+            CHECK:
+            for (CanonicalPath.Extender checker : checkers) {
+                for (int n = 0; n < typeFilter.getTypes().length; ++n) {
+                    Path.Segment seg = new Path.Segment(typeFilter.getTypes()[n], idFilter.getIds()[n]);
+                    if (!checker.canExtendTo(seg)) {
+                        if (cpFilter == null) {
+                            //k we tried to start a new cp filter, but failed
+                            reAddNonNull(false, fragments, first, second, third);
+                        } else {
+                            //move the contains to "processed" fragments and try again as if this was a new path
+                            reAddNonNull(false, fragments, first);
+                            reAddNonNull(true, applicableNewFilters, second, third);
+                            checkers = Collections.singletonList(CanonicalPath.empty());
+                            cpFilter = null;
+                        }
+                        checkFailed = true;
+                        break CHECK;
+                    } else {
+                        checker.extend(seg);
+                    }
+                }
+            }
+
+            if (!checkFailed) {
+                //k, so now we can transform the checkers into a new canonical path filter, because they contain
+                //our new canonical positions
+                if (!fragments.isEmpty()
+                        && fragments.get(fragments.size() - 1).getFilter() instanceof With.CanonicalPaths) {
+                    //remove the last filter from our fragments
+                    fragments.remove(fragments.size() - 1);
+                }
+
+                CanonicalPath[] newPaths = checkers.stream().map(CanonicalPath.Extender::get)
+                        .toArray(CanonicalPath[]::new);
+
+                QueryFragment related = cpFilter == null ? third : null;
+
+                cpFilter = isPath ? new PathFragment(With.paths(newPaths))
+                        : new FilterFragment(With.paths(newPaths));
+
+                fragments.add(cpFilter);
+
+                if (related != null) {
+                    reAddNonNull(true, applicableNewFilters, related);
+                }
+            }
+        }
+
+        //add the rest of the filters from the input
+        fragments.addAll(applicableNewFilters);
+    }
+
+    private static void cleanUnnecessaryNoops(List<QueryFragment> filters) {
+
+    }
+
+    private static <T> void reAddNonNull(boolean atBeginning, List<T> list, T... objs) {
+        int pos = atBeginning ? 0 : list.size();
+        for (int i = objs.length - 1; i >= 0; --i) {
+            T o = objs[i];
+            if (o != null) {
+                list.add(pos, o);
+            }
+        }
+    }
+
+    private static QueryFragment removeOrReadd(List<QueryFragment> fragments, QueryFragment first,
+                                               QueryFragment second) {
+
+        if (fragments.isEmpty()) {
+            addIfNotNull(fragments, first);
+            addIfNotNull(fragments, second);
+            return null;
+        } else {
+            return fragments.remove(0);
+        }
+    }
+
+    private static <T> void addIfNotNull(Collection<T> col, T el) {
+        if (el != null) {
+            col.add(el);
+        }
+    }
+
+    private static <T extends Filter> T choose(Class<T> type, QueryFragment... objects) {
+        for (QueryFragment o : objects) {
+            if (o != null && type.equals(o.getFilter().getClass())) {
+                return type.cast(o.getFilter());
+            }
+        }
+
+        return null;
+    }
+
+    private static boolean isOutgoingContains(Filter f) {
+        if (!(f instanceof Related)) {
+            return false;
+        }
+
+        Related rel = (Related) f;
+
+        return rel.getEntityRole() == Related.EntityRole.SOURCE &&
+                contains.name().equals(rel.getRelationshipName());
+    }
+
+    private static QueryFragment findLastCanonicalFilterAndPrepareNewFilters(List<QueryFragment> fragments,
+                                                                             List<QueryFragment> newFilters) {
+
+        if (fragments.isEmpty()) {
+            return null;
+        }
+
+        Filter last = fragments.get(fragments.size() - 1).getFilter();
+
+        QueryFragment ret = null;
+
+        if (last instanceof With.CanonicalPaths) {
+            ret = fragments.get(fragments.size() - 1);
+            CanonicalPath[] sources = ((With.CanonicalPaths) last).getPaths();
+
+            //remove anything from newFilters that is also matched by the canonical path filter
+            Set<Class<?>> expectedClasses = Arrays.asList(sources).stream()
+                    .map((s) -> s.getSegment().getElementType()).collect(toSet());
+            Set<String> expectedIds = Arrays.asList(sources).stream().map((s) -> s.getSegment().getElementId())
+                    .collect(toSet());
+
+            for (Iterator<QueryFragment> it = newFilters.iterator(); it.hasNext(); ) {
+                QueryFragment f = it.next();
+                if (f.getFilter() instanceof With.Types) {
+                    Set<Class<?>> filterTypes = new HashSet<>(Arrays.asList(((With.Types) f.getFilter()).getTypes()));
+                    if (!expectedClasses.equals(filterTypes)) {
+                        break;
+                    }
+                } else if (f.getFilter() instanceof With.Ids) {
+                    Set<String> filterIds = new HashSet<>(Arrays.asList(((With.Ids) f.getFilter()).getIds()));
+                    if (!expectedIds.equals(filterIds)) {
+                        break;
+                    }
+                } else {
+                    break;
+                }
+
+                it.remove();
+            }
+        } else if (fragments.size() > 1) {
+            //check if the second last isn't a canonical filter and the last + the current filter cannot be
+            //made into continuation of that canonical path filter
+            Filter secondLast = fragments.get(fragments.size() - 2).getFilter();
+            Filter thirdLast = fragments.size() > 2 ? fragments.get(fragments.size() - 3).getFilter() : null;
+
+            if (secondLast instanceof With.CanonicalPaths && last instanceof Related) {
+                Related rel = (Related) last;
+                if (contains.name().equals(rel.getRelationshipName())) {
+                    ret = fragments.get(fragments.size() - 2);
+                    //prepend the filters with the last
+                    newFilters.add(0, fragments.remove(fragments.size() - 1));
+                }
+            } else if (thirdLast instanceof With.CanonicalPaths && secondLast instanceof Related
+                    && (last instanceof With.Types || last instanceof With.Ids)) {
+                Related rel = (Related) secondLast;
+                if (contains.name().equals(rel.getRelationshipName())) {
+                    ret = fragments.get(fragments.size() - 3);
+                    //prepend the filters with the last and second last
+                    newFilters.add(0, fragments.remove(fragments.size() - 1));
+                    newFilters.add(0, fragments.remove(fragments.size() - 1));
+                } else {
+                    //k, so the Related filter is not what we want... but the last element still might offer something
+                    //to base the cp filter on, so let's provide it
+                    newFilters.add(0, fragments.remove(fragments.size() - 1));
+                }
+            } else if (!newFilters.isEmpty() && ((last instanceof With.Types
+                    && newFilters.get(0).getFilter() instanceof With.Ids)
+                    || (last instanceof With.Ids
+                    && newFilters.get(0).getFilter() instanceof With.Types))) {
+
+                //we've not seen any canonical path filter, but we might be starting a new one because the end
+                //of the fragments list lends itself to it
+                newFilters.add(0, fragments.remove(fragments.size() - 1));
+            }
+        } else if (!newFilters.isEmpty() && ((last instanceof With.Types
+                && newFilters.get(0).getFilter() instanceof With.Ids)
+                || (last instanceof With.Ids
+                && newFilters.get(0).getFilter() instanceof With.Types))) {
+
+            //we've not seen any canonical path filter, but we might be starting a new one because the end
+            //of the fragments list lends itself to it
+            newFilters.add(0, fragments.remove(fragments.size() - 1));
+        }
+
+        return ret;
+    }
+
+    private static List<QueryFragment> removeDuplicates(Filter original, List<QueryFragment> filters) {
+        List<QueryFragment> ret = filters;
+        int i = 0;
+        while (i < filters.size() && original.equals(filters.get(i).getFilter())) {
+            i++;
+        }
+        if (i > 0) {
+            ret = ret.subList(i, ret.size());
+        }
+
+        return ret;
+    }
+}

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TraversalContext.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TraversalContext.java
@@ -83,18 +83,8 @@ public final class TraversalContext<BE, E extends AbstractElement<?, ?>> {
     TraversalContext(BaseInventory<BE> inventory, Query sourcePath, Query selectCandidates,
                      InventoryBackend<BE> backend, Class<E> entityClass, Configuration configuration,
                      ObservableContext observableContext) {
-        this.inventory = inventory;
-        this.sourcePath = sourcePath;
-        this.selectCandidates = selectCandidates;
-        this.backend = backend;
-        this.entityClass = entityClass;
-        this.configuration = configuration;
-        this.observableContext = observableContext;
-        this.previous = null;
-
-        String retries = configuration.getProperty(BaseInventory.TRANSACTION_RETRIES, "5");
-
-        transactionRetries = Integer.parseInt(retries);
+        this(inventory, sourcePath, selectCandidates, backend, entityClass, configuration, observableContext,
+                getTransactionRetries(configuration), null);
     }
 
     private TraversalContext(BaseInventory<BE> inventory, Query sourcePath, Query selectCandidates,
@@ -111,6 +101,11 @@ public final class TraversalContext<BE, E extends AbstractElement<?, ?>> {
         this.observableContext = observableContext;
         this.transactionRetries = transactionRetries;
         this.previous = previous;
+    }
+
+    private static int getTransactionRetries(Configuration configuration) {
+        String retries = configuration.getProperty(BaseInventory.TRANSACTION_RETRIES, "5");
+        return Integer.parseInt(retries);
     }
 
     /**

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Util.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Util.java
@@ -72,6 +72,7 @@ final class Util {
     public static <R> R runInTransaction(TraversalContext<?, ?> context, boolean readOnly,
                                          PotentiallyCommittingPayload<R> payload) {
         InventoryBackend.Transaction transaction = context.backend.startTransaction(!readOnly);
+        Log.LOGGER.trace("Starting transaction: " + transaction);
         int maxFailures = context.getTransactionRetriesCount();
         return commitOrRetry(transaction, context.backend, payload, payload, maxFailures, true);
     }

--- a/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/QueryTest.java
+++ b/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/QueryTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.test;
+
+import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
+import static org.hawkular.inventory.api.filters.Related.by;
+import static org.hawkular.inventory.api.filters.With.id;
+import static org.hawkular.inventory.api.filters.With.type;
+
+import org.hawkular.inventory.api.filters.Related;
+import org.hawkular.inventory.api.filters.With;
+import org.hawkular.inventory.api.model.CanonicalPath;
+import org.hawkular.inventory.api.model.Environment;
+import org.hawkular.inventory.api.model.Resource;
+import org.hawkular.inventory.api.model.Tenant;
+import org.hawkular.inventory.base.FilterFragment;
+import org.hawkular.inventory.base.PathFragment;
+import org.hawkular.inventory.base.Query;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.6.0
+ */
+public class QueryTest {
+
+    @Test
+    public void testCanonicalPathFilterUsed() throws Exception {
+        Query q = Query.to(CanonicalPath.of().tenant("t").environment("e").get());
+        Assert.assertEquals(1, q.getFragments().length);
+        Assert.assertTrue(q.getFragments()[0].getFilter() instanceof With.CanonicalPaths);
+    }
+
+    @Test
+    public void testCanonicalPathOptimizationOnJustTenant() throws Exception {
+        Query q = Query.path().with(type(Tenant.class), id("id")).get();
+
+        Assert.assertEquals(1, q.getFragments().length);
+        Assert.assertTrue(q.getFragments()[0].getFilter() instanceof With.CanonicalPaths);
+
+        CanonicalPath[] cps = ((With.CanonicalPaths) q.getFragments()[0].getFilter()).getPaths();
+        Assert.assertEquals(1, cps.length);
+        Assert.assertEquals(Tenant.class, cps[0].getSegment().getElementType());
+        Assert.assertEquals("id", cps[0].getSegment().getElementId());
+    }
+
+    @Test
+    public void testCanonicalPathOnLongPath() throws Exception {
+        Query q = Query.path().with(type(Tenant.class)).with(id("t")).with(by(contains)).with(type(Environment.class))
+                .with(id("e")).with(by(contains)).with(type(Resource.class)).with(id("r")).get();
+
+        Assert.assertEquals(1, q.getFragments().length);
+        Assert.assertTrue(q.getFragments()[0].getFilter() instanceof With.CanonicalPaths);
+
+        CanonicalPath[] cps = ((With.CanonicalPaths) q.getFragments()[0].getFilter()).getPaths();
+        Assert.assertEquals(1, cps.length);
+        Assert.assertEquals(CanonicalPath.of().tenant("t").environment("e").resource("r").get(), cps[0]);
+    }
+
+    @Test
+    public void testCanonicalPathRobustAgainstInvalidPaths() throws Exception {
+        Query q = Query.path().with(type(Tenant.class)).with(id("t")).with(by(contains)).with(type(Environment.class))
+                .with(id("e")).with(by(contains)).with(type(Tenant.class)).with(id("t2")).get();
+
+        Assert.assertEquals(3, q.getFragments().length);
+        Assert.assertTrue(q.getFragments()[0].getFilter() instanceof With.CanonicalPaths);
+        Assert.assertTrue(q.getFragments()[1].getFilter() instanceof Related);
+        Assert.assertTrue(q.getFragments()[2].getFilter() instanceof With.CanonicalPaths);
+    }
+
+    @Test
+    public void testQueryFragmentTypeChangeInterruptsOptimization() throws Exception {
+        Query q = Query.path().with(type(Tenant.class)).with(id("t")).filter().with(by(contains)).with(type
+                (Environment.class)).with(id("e")).with(by(contains)).with(type(Tenant.class)).with(id("t2")).get();
+
+        Assert.assertEquals(6, q.getFragments().length);
+        Assert.assertTrue(q.getFragments()[0].getFilter() instanceof With.CanonicalPaths);
+        Assert.assertTrue(q.getFragments()[1].getFilter() instanceof Related);
+        Assert.assertTrue(q.getFragments()[2].getFilter() instanceof With.Types);
+        Assert.assertTrue(q.getFragments()[3].getFilter() instanceof With.Ids);
+        Assert.assertTrue(q.getFragments()[4].getFilter() instanceof Related);
+        Assert.assertTrue(q.getFragments()[5].getFilter() instanceof With.CanonicalPaths);
+        Assert.assertTrue(q.getFragments()[0] instanceof PathFragment);
+        Assert.assertTrue(q.getFragments()[1] instanceof FilterFragment);
+        Assert.assertTrue(q.getFragments()[2] instanceof FilterFragment);
+        Assert.assertTrue(q.getFragments()[3] instanceof FilterFragment);
+        Assert.assertTrue(q.getFragments()[4] instanceof FilterFragment);
+        Assert.assertTrue(q.getFragments()[5] instanceof FilterFragment);
+    }
+
+    @Test
+    public void testOptimizationRessurectsAfterNonCanonicalSection() throws Exception {
+        Query q = Query.path().with(type(Tenant.class)).with(id("t")).with(by(contains)).with(type
+                (Environment.class)).with(id("e")).with(by("kachna")).with(type(Tenant.class)).with(id("t2")).get();
+
+        Assert.assertEquals(3, q.getFragments().length);
+        Assert.assertTrue(q.getFragments()[0].getFilter() instanceof With.CanonicalPaths);
+        Assert.assertTrue(q.getFragments()[1].getFilter() instanceof Related);
+        Assert.assertTrue(q.getFragments()[2].getFilter() instanceof With.CanonicalPaths);
+    }
+}

--- a/hawkular-inventory-cdi/src/main/java/org/hawkular/inventory/cdi/OfficialInventoryProducer.java
+++ b/hawkular-inventory-cdi/src/main/java/org/hawkular/inventory/cdi/OfficialInventoryProducer.java
@@ -99,20 +99,24 @@ public class OfficialInventoryProducer {
         int failures = 0;
         int maxFailures = 5;
         boolean initialized = false;
+        Throwable lastError = null;
         while (!initialized && failures++ < maxFailures) {
             try {
                 inventory.initialize(cfg);
 
                 initialized = true;
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 LOG.debug("Unable to initialize inventory, exception thrown: ", e);
                 LOG.wInitializationFailure(failures, maxFailures, e.getMessage());
+                lastError = e;
                 Thread.sleep(1000);
             }
         }
 
         if (!initialized) {
-            throw new IllegalStateException("Could not initialize inventory.");
+            //noinspection ConstantConditions
+            throw new IllegalStateException("Could not initialize inventory. Last error message was: "
+                    + lastError.getMessage(), lastError);
         }
 
         LOG.iInitialized();

--- a/hawkular-inventory-dist/src/main/resources/hawkular-inventory.properties
+++ b/hawkular-inventory-dist/src/main/resources/hawkular-inventory.properties
@@ -30,10 +30,10 @@ index.es.elasticsearch.local-mode=true
 query.fast-property=true
 
 #aggressive caching to improve performance
-cache.db-cache=true
-cache.db-cache-size=0.1
-cache.db-cache-time=30000
-cache.tx-dirty-size=32
+#cache.db-cache=true
+#cache.db-cache-size=0.1
+#cache.db-cache-time=30000
+#cache.tx-dirty-size=32
 
 # http://git.io/vYcTb
 # round robin should be faster with embedded C*, but shouldn't be used in production

--- a/hawkular-inventory-dist/src/main/resources/hawkular-inventory.properties
+++ b/hawkular-inventory-dist/src/main/resources/hawkular-inventory.properties
@@ -30,9 +30,9 @@ index.es.elasticsearch.local-mode=true
 query.fast-property=true
 
 #aggressive caching to improve performance
-cache.db-cache=true
-cache.db-cache-size=0.1
-cache.db-cache-time=30000
+#cache.db-cache=true
+#cache.db-cache-size=0.1
+#cache.db-cache-time=30000
 #ironically, this seems to hurt insert performance of agents (with any value ranging up to 512)
 #cache.tx-dirty-size=32
 

--- a/hawkular-inventory-dist/src/main/resources/hawkular-inventory.properties
+++ b/hawkular-inventory-dist/src/main/resources/hawkular-inventory.properties
@@ -29,6 +29,12 @@ index.es.elasticsearch.local-mode=true
 #we use all the properties of the vertex most of the time, so this helps reduce DB traffic
 query.fast-property=true
 
+#aggressive caching to improve performance
+cache.db-cache=true
+cache.db-cache-size=0.1
+cache.db-cache-time=30000
+cache.tx-dirty-size=32
+
 # http://git.io/vYcTb
 # round robin should be faster with embedded C*, but shouldn't be used in production
 #storage.cassandra.astyanax.connection-pool-type=ROUND_ROBIN

--- a/hawkular-inventory-dist/src/main/resources/hawkular-inventory.properties
+++ b/hawkular-inventory-dist/src/main/resources/hawkular-inventory.properties
@@ -26,6 +26,9 @@ index.es.directory=${jboss.server.data.dir}/hawkular-inventory/es-index
 index.es.elasticsearch.client-only=false
 index.es.elasticsearch.local-mode=true
 
+#we use all the properties of the vertex most of the time, so this helps reduce DB traffic
+query.fast-property=true
+
 # http://git.io/vYcTb
 # round robin should be faster with embedded C*, but shouldn't be used in production
 #storage.cassandra.astyanax.connection-pool-type=ROUND_ROBIN

--- a/hawkular-inventory-dist/src/main/resources/hawkular-inventory.properties
+++ b/hawkular-inventory-dist/src/main/resources/hawkular-inventory.properties
@@ -30,9 +30,10 @@ index.es.elasticsearch.local-mode=true
 query.fast-property=true
 
 #aggressive caching to improve performance
-#cache.db-cache=true
-#cache.db-cache-size=0.1
-#cache.db-cache-time=30000
+cache.db-cache=true
+cache.db-cache-size=0.1
+cache.db-cache-time=30000
+#ironically, this seems to hurt insert performance of agents (with any value ranging up to 512)
 #cache.tx-dirty-size=32
 
 # http://git.io/vYcTb

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/HawkularPipeline.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/HawkularPipeline.java
@@ -55,7 +55,7 @@ import com.tinkerpop.pipes.util.structures.Tree;
  * @author Lukas Krejci
  * @since 0.0.1
  */
-final class HawkularPipeline<S, E> extends GremlinPipeline<S, E> implements Cloneable {
+class HawkularPipeline<S, E> extends GremlinPipeline<S, E> implements Cloneable {
 
     private int asLabelCount;
     private final Deque<String> labelStack = new ArrayDeque<>(2);

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/Log.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/Log.java
@@ -16,6 +16,7 @@
  */
 package org.hawkular.inventory.impl.tinkerpop;
 
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -30,8 +31,7 @@ import org.jboss.logging.annotations.ValidIdRange;
  * @author Heiko W. Rupp
  */
 @MessageLogger(projectCode = "HAWKINV")
-@ValidIdRange(min = 1000, max = 1999)
-interface Log {
+@ValidIdRange(min = 1000, max = 1999) interface Log extends BasicLogger {
 
     Log LOG = Logger.getMessageLogger(Log.class, "org.hawkular.inventory.impl.tinkerpop");
 

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
@@ -147,26 +147,7 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
 
         Object start = startingPoint == null ? context.getGraph() : startingPoint;
 
-        q = new HawkularPipeline<Object, Element>(start) {
-            @Override
-            public Iterator<Element> iterator() {
-                boolean tracing = Log.LOG.isTraceEnabled();
-
-                long now = 0;
-
-                if (tracing) {
-                    now = System.currentTimeMillis();
-                }
-
-                List<Element> res = toList();
-
-                if (tracing) {
-                    now = System.currentTimeMillis() - now;
-                    Log.LOG.trace("Eager query evaluation to measure effective time querying: " + now + "ms.");
-                }
-                return res.iterator();
-            }
-        };
+        q = new HawkularPipeline<Object, Element>(start);
 
         if (startingPoint == null) {
             if (query.getFragments()[0].getFilter() instanceof RelationFilter) {

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
@@ -119,12 +119,14 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
 
         q.counter("total").page(pager);
 
-        Log.LOG.trace("Converted query: " + query + " to pipeline: " + q);
+        Log.LOG.debugf("Query execution (starting at %s):\nquery:\n%s\n\npipeline:\n%s", startingPoint, query, q);
+
         return new SizeAwarePage<>(q.cast(Element.class).iterator(), pager, () -> q.getCount("total"));
     }
 
     @Override public Element traverseToSingle(Element startingPoint, Query query) {
         HawkularPipeline<?, ? extends Element> q = translate(startingPoint, query);
+        Log.LOG.debugf("Query execution (starting at %s):\nquery:\n%s\n\npipeline:\n%s", startingPoint, query, q);
         if (q.hasNext()) {
             return q.cast(Element.class).next();
         }
@@ -211,6 +213,8 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
                         }
                     });
         }
+
+        Log.LOG.debugf("Query execution:\nquery:\n%s\n\npipeline:\n%s", query, q2);
 
         return new SizeAwarePage<>(q2.iterator(), pager, () -> q.getCount("total"));
     }

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
@@ -119,6 +119,7 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
 
         q.counter("total").page(pager);
 
+        Log.LOG.trace("Converted query: " + query + " to pipeline: " + q);
         return new SizeAwarePage<>(q.cast(Element.class).iterator(), pager, () -> q.getCount("total"));
     }
 
@@ -142,12 +143,35 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
     private HawkularPipeline<?, ? extends Element> translate(Element startingPoint, Query query) {
         HawkularPipeline<?, ? extends Element> q;
 
-        if (startingPoint != null) {
-            q = new HawkularPipeline<>(startingPoint);
-        } else if (query.getFragments()[0].getFilter() instanceof RelationFilter) {
-            q = new HawkularPipeline<>(context.getGraph()).E();
-        } else {
-            q = new HawkularPipeline<>(context.getGraph()).V();
+        Object start = startingPoint == null ? context.getGraph() : startingPoint;
+
+        q = new HawkularPipeline<Object, Element>(start) {
+            @Override
+            public Iterator<Element> iterator() {
+                boolean tracing = Log.LOG.isTraceEnabled();
+
+                long now = 0;
+
+                if (tracing) {
+                    now = System.currentTimeMillis();
+                }
+
+                List<Element> res = toList();
+
+                if (tracing) {
+                    now = System.currentTimeMillis() - now;
+                    Log.LOG.trace("Eager query evaluation to measure effective time querying: " + now + "ms.");
+                }
+                return res.iterator();
+            }
+        };
+
+        if (startingPoint == null) {
+            if (query.getFragments()[0].getFilter() instanceof RelationFilter) {
+                q = q.E();
+            } else {
+                q = q.V();
+            }
         }
 
         FilterApplicator.applyAll(query, q);
@@ -159,15 +183,7 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
     public <T> Page<T> query(Query query, Pager pager,
             Function<Element, T> conversion, Function<T, Boolean> filter) {
 
-        HawkularPipeline<?, ? extends Element> q;
-
-        if (query.getFragments()[0].getFilter() instanceof RelationFilter) {
-            q = new HawkularPipeline<>(context.getGraph()).E();
-        } else {
-            q = new HawkularPipeline<>(context.getGraph()).V();
-        }
-
-        FilterApplicator.applyAll(query, q);
+        HawkularPipeline<?, ? extends Element> q = translate(null, query);
 
         HawkularPipeline<?, T> q2;
         if (filter == null) {
@@ -196,7 +212,7 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
                     });
         }
 
-        return new SizeAwarePage<>(q2, pager, () -> q.getCount("total"));
+        return new SizeAwarePage<>(q2.iterator(), pager, () -> q.getCount("total"));
     }
 
     @Override
@@ -833,6 +849,7 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
     public void commit(Transaction t) throws CommitFailureException {
         try {
             context.commit(t);
+            Log.LOG.trace("Transaction committed: " + t);
         } catch (Exception e) {
             throw new CommitFailureException(e);
         }

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopInventory.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopInventory.java
@@ -24,6 +24,7 @@ import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.impl.tinkerpop.spi.GraphProvider;
 import org.hawkular.inventory.impl.tinkerpop.spi.IndexSpec;
 
+import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Element;
 import com.tinkerpop.blueprints.TransactionalGraph;
 import com.tinkerpop.blueprints.Vertex;
@@ -74,7 +75,7 @@ public final class TinkerpopInventory extends BaseInventory<Element> {
                         .withProperty(IndexSpec.Property.builder()
                                 .withName(Constants.Property.__eid.name())
                                 .withType(String.class)
-                                .withUnique(true)
+//                                .withUnique(true)
                                 .build())
                         .build(),
                 IndexSpec.builder()
@@ -106,6 +107,14 @@ public final class TinkerpopInventory extends BaseInventory<Element> {
                                 .withName(Constants.Property.__metric_data_type.name())
                                 .withType(String.class)
 //                                .withUnique(true)
+                                .build())
+                        .build(),
+                IndexSpec.builder()
+                        .withElementType(Edge.class)
+                        .withProperty(IndexSpec.Property.builder()
+                                .withName(Constants.Property.__eid.name())
+                                .withType(String.class)
+                                .withUnique(true)
                                 .build())
                         .build());
         return graph;


### PR DESCRIPTION
First run is still quite slow.

```
$ curl -u jdoe:password http://localhost:8080/hawkular/inventory/test/localhost/resourceTypes/WildFly%20Server/resources  -w "\\n CN: %{time_connect}\\n ST: %{time_starttransfer}\\n TT: %{time_total}"
...
 CN: 0.005
 ST: 2.065
 TT: 2.065
```

But after that it gets better...

```
$ curl -u jdoe:password http://localhost:8080/hawkular/inventory/test/localhost/resourceTypes/WildFly%20Server/resources  -w "\\n CN: %{time_connect}\\n ST: %{time_starttransfer}\\n TT: %{time_total}"
...
 CN: 0.005
 ST: 0.229
 TT: 0.229
```

And better...

```
$ curl -u jdoe:password http://localhost:8080/hawkular/inventory/test/localhost/resourceTypes/WildFly%20Server/resources  -w "\\n CN: %{time_connect}\\n ST: %{time_starttransfer}\\n TT: %{time_total}"
...
 CN: 0.004
 ST: 0.130
 TT: 0.130
```

I've got still some work to do on this WRT eliminating `NoopFilter`s where possible but wanted to show this off. We're slowly getting faster :wink: 
