### PR TITLE
Query performance 2

### DIFF
--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/Constants.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/Constants.java
@@ -17,13 +17,20 @@
 package org.hawkular.inventory.impl.tinkerpop;
 
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__metric_data_type;
+import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__sourceCp;
+import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__sourceEid;
+import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__sourceType;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__structuredDataIndex;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__structuredDataKey;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__structuredDataType;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__structuredDataValue;
+import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__targetCp;
+import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__targetEid;
+import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__targetType;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__unit;
 
 import java.util.Arrays;
+import java.util.HashSet;
 
 import org.hawkular.inventory.api.model.AbstractElement;
 import org.hawkular.inventory.api.model.DataEntity;
@@ -97,8 +104,23 @@ final class Constants {
          * The name of the property on the structured data vertex that holds the primitive value of that vertex.
          * List and maps don't hold the value directly but instead have edges going out to the child vertices.
          */
-        __structuredDataValue;
+        __structuredDataValue,
 
+        __sourceType,
+
+        __targetType,
+
+        __sourceCp,
+
+        __targetCp,
+
+        __sourceEid,
+
+        __targetEid;
+
+
+        private static final HashSet<String> MIRRORED_PROPERTIES = new HashSet<>(Arrays.asList(__type.name(),
+                __eid.name(), __cp.name()));
 
         public static String mapUserDefined(String property) {
             if (AbstractElement.ID_PROPERTY.equals(property)) {
@@ -106,6 +128,10 @@ final class Constants {
             } else {
                 return property;
             }
+        }
+
+        public static boolean isMirroredInEdges(String property) {
+            return MIRRORED_PROPERTIES.contains(property);
         }
     }
 
@@ -116,9 +142,9 @@ final class Constants {
         tenant(Tenant.class), environment(Environment.class), feed(Feed.class),
         resourceType(ResourceType.class), metricType(MetricType.class, __unit, __metric_data_type),
         operationType(OperationType.class), resource(Resource.class), metric(Metric.class),
-        relationship(Relationship.class), dataEntity(DataEntity.class),
-        structuredData(StructuredData.class, __structuredDataType, __structuredDataValue, __structuredDataIndex,
-                __structuredDataKey);
+        relationship(Relationship.class, __sourceType, __targetType, __sourceCp, __targetCp, __sourceEid, __targetEid),
+        dataEntity(DataEntity.class), structuredData(StructuredData.class, __structuredDataType,
+                __structuredDataValue, __structuredDataIndex, __structuredDataKey);
 
         private final String[] mappedProperties;
         private final Class<?> entityType;

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/QueryTranslationState.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/QueryTranslationState.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.impl.tinkerpop;
+
+import com.tinkerpop.blueprints.Direction;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.6.0
+ */
+final class QueryTranslationState implements Cloneable {
+    private boolean inEdges;
+    private Direction comingFrom;
+
+    public boolean isInEdges() {
+        return inEdges;
+    }
+
+    public void setInEdges(boolean inEdges) {
+        this.inEdges = inEdges;
+    }
+
+    public Direction getComingFrom() {
+        return comingFrom;
+    }
+
+    public void setComingFrom(Direction comingFrom) {
+        this.comingFrom = comingFrom;
+    }
+
+    @Override
+    public QueryTranslationState clone() {
+        try {
+            return (QueryTranslationState) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new AssertionError("CloneNotSupportedException on a Cloneable class. What?");
+        }
+    }
+}

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopInventory.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopInventory.java
@@ -106,7 +106,6 @@ public final class TinkerpopInventory extends BaseInventory<Element> {
                         .withProperty(IndexSpec.Property.builder()
                                 .withName(Constants.Property.__metric_data_type.name())
                                 .withType(String.class)
-//                                .withUnique(true)
                                 .build())
                         .build(),
                 IndexSpec.builder()
@@ -115,6 +114,48 @@ public final class TinkerpopInventory extends BaseInventory<Element> {
                                 .withName(Constants.Property.__eid.name())
                                 .withType(String.class)
                                 .withUnique(true)
+                                .build())
+                        .build(),
+                IndexSpec.builder()
+                        .withElementType(Edge.class)
+                        .withProperty(IndexSpec.Property.builder()
+                                .withName(Constants.Property.__sourceCp.name())
+                                .withType(String.class)
+                                .build())
+                        .build(),
+                IndexSpec.builder()
+                        .withElementType(Edge.class)
+                        .withProperty(IndexSpec.Property.builder()
+                                .withName(Constants.Property.__sourceEid.name())
+                                .withType(String.class)
+                                .build())
+                        .build(),
+                IndexSpec.builder()
+                        .withElementType(Edge.class)
+                        .withProperty(IndexSpec.Property.builder()
+                                .withName(Constants.Property.__sourceType.name())
+                                .withType(String.class)
+                                .build())
+                        .build(),
+                IndexSpec.builder()
+                        .withElementType(Edge.class)
+                        .withProperty(IndexSpec.Property.builder()
+                                .withName(Constants.Property.__targetCp.name())
+                                .withType(String.class)
+                                .build())
+                        .build(),
+                IndexSpec.builder()
+                        .withElementType(Edge.class)
+                        .withProperty(IndexSpec.Property.builder()
+                                .withName(Constants.Property.__targetEid.name())
+                                .withType(String.class)
+                                .build())
+                        .build(),
+                IndexSpec.builder()
+                        .withElementType(Edge.class)
+                        .withProperty(IndexSpec.Property.builder()
+                                .withName(Constants.Property.__targetType.name())
+                                .withType(String.class)
                                 .build())
                         .build());
         return graph;


### PR DESCRIPTION
mirror immutable vertex properties on edges and query on them directly on the edges instead of hopping to vertices.

This extends https://github.com/hawkular/hawkular-inventory/pull/177
