### PR TITLE
HWKINVENT-150 Broken on Windows

### DIFF
--- a/hawkular-inventory-cdi/src/main/java/org/hawkular/inventory/cdi/TokenReplacingReader.java
+++ b/hawkular-inventory-cdi/src/main/java/org/hawkular/inventory/cdi/TokenReplacingReader.java
@@ -176,6 +176,9 @@ public final class TokenReplacingReader extends Reader {
                             cont = false;
                             break;
                         default:
+                            if (skipUntilExpressionEnd) {
+                                break;
+                            }
                             this.tokenNameBuffer.append((char) data);
                     }
                     break;

--- a/hawkular-inventory-cdi/src/test/java/org/hawkular/inventory/cdi/TokenReplacingReaderTest.java
+++ b/hawkular-inventory-cdi/src/test/java/org/hawkular/inventory/cdi/TokenReplacingReaderTest.java
@@ -56,8 +56,18 @@ public class TokenReplacingReaderTest {
     }
 
     @Test
+    public void testMultipleChoice2() throws Exception {
+        testExpression("Hello, ${who,blah}!").with("who", "world").matches("Hello, world!");
+    }
+
+    @Test
+    public void testMultipleChoice3() throws Exception {
+        testExpression("Hello, ${splat,who,blah}!").with("who", "world").matches("Hello, world!");
+    }
+
+    @Test
     public void testMultipleChoiceWithDefaultValue() throws Exception {
-        testExpression("Hello, ${blah,who:world}!").matches("Hello, world!");
+        testExpression("Hello, ${splat,blah,who:world}!").matches("Hello, world!");
     }
 
     @Test

--- a/hawkular-inventory-dist/src/main/resources/hawkular-inventory.properties
+++ b/hawkular-inventory-dist/src/main/resources/hawkular-inventory.properties
@@ -22,7 +22,7 @@ storage.hostname=127.0.0.1
 storage.cassandra.keyspace=hawkular_inventory
 
 index.es.backend=elasticsearch
-index.es.directory=${jboss.server.data.dir}/hawkular-inventory/es-index
+index.es.directory=${org.hawkular.data.dir,jboss.server.data.dir:MISSING_PROPERTY}/hawkular-inventory/es-index
 index.es.elasticsearch.client-only=false
 index.es.elasticsearch.local-mode=true
 


### PR DESCRIPTION
The token replacement ${jboss.server.data.dir} in hawkular-inventory.properties
results in a windows path, and backslashes are not escaped, resulting
in an invalid value. Instead, use the new org.hawkular.data.dir,
defaulting back to the jboss property.  This allows windows users to set
the new property on the command line to bypass the issue (or to use a
directory not under the jboss server, if desired).

Unfortunately, the TokenReplacer had a bug in its support for multiple
properties, so this commit also includes a fix for the token replacer.
