### PR TITLE
Fixing the wrong path in .travis.swagger.sh. 

### DIFF
--- a/.travis.swagger.sh
+++ b/.travis.swagger.sh
@@ -22,7 +22,7 @@ set -x
 mvn clean compile -Pdocgen -DskipTests -Dcheckstyle.skip -Dlicense.skip
 
 FILE_NAME="rest-inventory.adoc"
-FILE_PATH="rest-servlet/target/generated/$FILE_NAME"
+FILE_PATH="hawkular-inventory-rest-api/target/generated/$FILE_NAME"
 
 # don't push the empty docs
 [[ -s $FILE_PATH ]] || {


### PR DESCRIPTION
Module was renamed quite some time ago.
btw. currently the change is published only for the non-snapshot versions, which is good, I guess.
