### PR TITLE
Swagger docs update

### DIFF
--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResources.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResources.java
@@ -502,7 +502,7 @@ public class RestResources extends RestBase {
 
     @PUT
     @javax.ws.rs.Path("/{environmentId}/resources/{resourcePath:.+}")
-    @ApiOperation("Update a resource type")
+    @ApiOperation("Update a resource")
     @ApiResponses({
             @ApiResponse(code = 204, message = "OK"),
             @ApiResponse(code = 400, message = "Invalid input data", response = ApiError.class),
@@ -528,7 +528,7 @@ public class RestResources extends RestBase {
 
     @PUT
     @javax.ws.rs.Path("/feeds/{feedId}/resources/{resourcePath:.+}")
-    @ApiOperation("Update a resource type")
+    @ApiOperation("Update a resource")
     @ApiResponses({
             @ApiResponse(code = 204, message = "OK"),
             @ApiResponse(code = 400, message = "Invalid input data", response = ApiError.class),


### PR DESCRIPTION
The swagger bash script currently doesn't upload the newest rest docs because of this issue https://travis-ci.org/hawkular/hawkular-inventory/builds/92368235#L6867

It says  curl: "Argument list too long".. it's because we are passing the encoded doc file as env param that is expanded in bash and curl is complaining about the length of the command. So this PR puts everything into /tmp/restDoc file and use the file refferrencing when calling the curl call.

Also fixing some typos - this is totally unrelated to the swagger part.
