### PR TITLE
[HWKINVENT-161] Make all inventory path fragments correctly annotated with @Encoded @PathParam.

### DIFF
--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestPath.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestPath.java
@@ -23,6 +23,7 @@ import static org.hawkular.inventory.rest.RequestUtil.extractPaging;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
+import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -76,7 +77,7 @@ public class RestPath extends RestBase {
             @ApiResponse(code = 404, message = "The entity doesn't exist", response = ApiError.class),
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })
-    public Response get(@PathParam("entityPath") String entityPath, @Context UriInfo uriInfo) {
+    public Response get(@Encoded @PathParam("entityPath") String entityPath, @Context UriInfo uriInfo) {
         String tenantId = getTenantId();
         CanonicalPath tenant = CanonicalPath.of().tenant(tenantId).get();
 
@@ -97,7 +98,7 @@ public class RestPath extends RestBase {
                           @ApiResponse(code = 404, message = "The entity doesn't exist", response = ApiError.class),
                           @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
                   })
-    public Response getRelationships(@PathParam("entityPath") String entityPath,
+    public Response getRelationships(@Encoded @PathParam("entityPath") String entityPath,
                                      @DefaultValue("both") @QueryParam("direction") String direction,
                                      @DefaultValue("") @QueryParam("property") String propertyName,
                                      @DefaultValue("") @QueryParam("propertyValue") String propertyValue,

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesMetricTypes.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesMetricTypes.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
+import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -120,7 +121,7 @@ public class RestResourceTypesMetricTypes extends RestBase {
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })
     public MetricType getAssociatedMetricType(@PathParam("resourceTypeId") String resourceTypeId,
-                                              @PathParam("metricTypePath") String metricTypePath,
+                                              @Encoded @PathParam("metricTypePath") String metricTypePath,
                                               @QueryParam("canonical") @DefaultValue("false")
                                               @ApiParam("True if metric type path should be considered canonical," +
                                                       " false by default.")
@@ -165,7 +166,7 @@ public class RestResourceTypesMetricTypes extends RestBase {
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })
     public Response disassociateMetricType(@PathParam("resourceTypeId") String resourceTypeId,
-                                           @PathParam("metricTypePath") String metricTypePath,
+                                           @Encoded @PathParam("metricTypePath") String metricTypePath,
                                            @QueryParam("canonical") @DefaultValue("false")
                                            @ApiParam("True if metric path should be considered canonical, false by" +
                                                    " default.")
@@ -252,7 +253,7 @@ public class RestResourceTypesMetricTypes extends RestBase {
     })
     public MetricType getAssociatedMetricType(@PathParam("feedId") String feedId,
                                               @PathParam("resourceTypeId") String resourceTypeId,
-                                              @PathParam("metricTypePath") String metricTypePath,
+                                              @Encoded @PathParam("metricTypePath") String metricTypePath,
                                               @QueryParam("canonical") @DefaultValue("false")
                                               @ApiParam("True if metric type path should be considered canonical," +
                                                       " false by default.")
@@ -299,7 +300,7 @@ public class RestResourceTypesMetricTypes extends RestBase {
     })
     public Response disassociateMetricType(@PathParam("feedId") String feedId,
                                            @PathParam("resourceTypeId") String resourceTypeId,
-                                           @PathParam("metricTypePath") String metricTypePath,
+                                           @Encoded @PathParam("metricTypePath") String metricTypePath,
                                            @QueryParam("canonical") @DefaultValue("false")
                                            @ApiParam("True if metric path should be considered canonical, false by" +
                                                    " default.")

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourcesData.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourcesData.java
@@ -23,6 +23,7 @@ import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
+import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -63,8 +64,8 @@ public class RestResourcesData extends RestResources {
                                        response = ApiError.class),
                           @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
                   })
-    public Response createConfigurationF(@PathParam("feedId") String feedId, @PathParam
-            ("resourcePath") String resourcePath,
+    public Response createConfigurationF(@PathParam("feedId") String feedId,
+                                         @Encoded @PathParam("resourcePath") String resourcePath,
                                          @ApiParam(required = true)
                                          DataEntity.Blueprint<Resources.DataRole> configuration,
                                          @Context UriInfo uriInfo) {
@@ -82,7 +83,7 @@ public class RestResourcesData extends RestResources {
                           @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
                   })
     public Response createConfiguration(@PathParam("environmentId") String environmentId,
-            @PathParam("resourcePath") String resourcePath,
+            @Encoded @PathParam("resourcePath") String resourcePath,
             @ApiParam(required = true) DataEntity.Blueprint<Resources.DataRole> configuration,
             @Context UriInfo uriInfo) {
 
@@ -112,7 +113,7 @@ public class RestResourcesData extends RestResources {
                           @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
                   })
     public Response getConfigurationF(@PathParam("feedId") String feedId,
-                                      @PathParam("resourcePath") String resourcePath,
+                                      @Encoded @PathParam("resourcePath") String resourcePath,
                                       @DefaultValue("configuration") @QueryParam("dataType")
                                       Resources.DataRole dataType) {
 
@@ -129,8 +130,9 @@ public class RestResourcesData extends RestResources {
                           @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
                   })
     public Response getConfiguration(@PathParam("environmentId") String environmentId,
-                                     @PathParam("resourcePath") String resourcePath,
-            @DefaultValue("configuration") @QueryParam("dataType") Resources.DataRole dataType) {
+                                     @Encoded @PathParam("resourcePath") String resourcePath,
+                                     @DefaultValue("configuration") @QueryParam("dataType") Resources.DataRole dataType)
+    {
 
         return getConfigurationHelper(environmentId, null, resourcePath, dataType);
     }
@@ -155,7 +157,7 @@ public class RestResourcesData extends RestResources {
                           @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
                   })
     public Response updateConfigurationF(@PathParam("feedId") String feedId,
-                                         @PathParam("resourcePath") String resourcePath,
+                                         @Encoded @PathParam("resourcePath") String resourcePath,
                                          @DefaultValue("configuration") @QueryParam("dataType")
                                          Resources.DataRole dataType,
                                          @ApiParam(required = true) DataEntity.Update configuration) {
@@ -173,9 +175,10 @@ public class RestResourcesData extends RestResources {
                           @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
                   })
     public Response updateConfiguration(@PathParam("environmentId") String environmentId,
-            @PathParam("resourcePath") String resourcePath,
-            @DefaultValue("configuration") @QueryParam("dataType") Resources.DataRole dataType,
-            @ApiParam(required = true) DataEntity.Update configuration) {
+                                        @Encoded @PathParam("resourcePath") String resourcePath,
+                                        @DefaultValue("configuration") @QueryParam("dataType")
+                                            Resources.DataRole dataType,
+                                        @ApiParam(required = true) DataEntity.Update configuration) {
 
         return updateConfigurationHelper(environmentId, null, resourcePath, dataType, configuration);
     }
@@ -191,7 +194,7 @@ public class RestResourcesData extends RestResources {
     }
 
     @DELETE
-    @javax.ws.rs.Path("/feeds/{feedId}/resources/{resourcrcePath:.+}/data")
+    @javax.ws.rs.Path("/feeds/{feedId}/resources/{resourcePath:.+}/data")
     @ApiOperation("Deletes the configuration of a resource")
     @ApiResponses({
                           @ApiResponse(code = 204, message = "OK"),
@@ -200,7 +203,7 @@ public class RestResourcesData extends RestResources {
                           @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
                   })
     public Response deleteConfigurationF(@PathParam("feedId") String feedId,
-                                         @PathParam("resourcePath") String resourcePath,
+                                         @Encoded @PathParam("resourcePath") String resourcePath,
                                          @DefaultValue("configuration") @QueryParam("dataType")
                                          Resources.DataRole dataType) {
 
@@ -217,7 +220,7 @@ public class RestResourcesData extends RestResources {
                           @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
                   })
     public Response deleteConfiguration(@PathParam("environmentId") String environmentId,
-                                        @PathParam("resourcePath") String resourcePath,
+                                        @Encoded @PathParam("resourcePath") String resourcePath,
                                         @DefaultValue("configuration") @QueryParam("dataType")
                                         Resources.DataRole dataType) {
 


### PR DESCRIPTION
This makes sure clients don't need to double URL-encode the path fragments
that contain slashes (single url-encoding should suffice now across the
REST API).
