### PR TITLE
[HWKINVENT-153] Detection of identical resource and metric types across feeds and tenant.

### DIFF
--- a/hawkular-inventory-api/api-changes.json
+++ b/hawkular-inventory-api/api-changes.json
@@ -994,8 +994,267 @@
         "old": "method FB org.hawkular.inventory.api.model.Path.TenantBuilder<Impl extends org.hawkular.inventory.api.model.Path, EB extends org.hawkular.inventory.api.model.Path.EnvironmentBuilder<Impl extends org.hawkular.inventory.api.model.Path, RB extends org.hawkular.inventory.api.model.Path.ResourceBuilder<Impl, RB, SDB extends org.hawkular.inventory.api.model.Path.StructuredDataBuilder<Impl, SDB>>, MB extends org.hawkular.inventory.api.model.Path.MetricBuilder<Impl>, RTB extends org.hawkular.inventory.api.model.Path.ResourceTypeBuilder<Impl, OTB extends org.hawkular.inventory.api.model.Path.OperationTypeBuilder<Impl, SDB>, SDB>, MTB extends org.hawkular.inventory.api.model.Path.MetricTypeBuilder<Impl>, OTB, SDB>, RTB extends org.hawkular.inventory.api.model.Path.ResourceTypeBuilder<Impl extends org.hawkular.inventory.api.model.Path, OTB extends org.hawkular.inventory.api.model.Path.OperationTypeBuilder<Impl, SDB extends org.hawkular.inventory.api.model.Path.StructuredDataBuilder<Impl, SDB>>, SDB>, MTB extends org.hawkular.inventory.api.model.Path.MetricTypeBuilder<Impl extends org.hawkular.inventory.api.model.Path>, OTB extends org.hawkular.inventory.api.model.Path.OperationTypeBuilder<Impl extends org.hawkular.inventory.api.model.Path, SDB extends org.hawkular.inventory.api.model.Path.StructuredDataBuilder<Impl, SDB>>, SDB extends org.hawkular.inventory.api.model.Path.StructuredDataBuilder<Impl extends org.hawkular.inventory.api.model.Path, SDB extends org.hawkular.inventory.api.model.Path.StructuredDataBuilder<Impl, SDB>>, MPB extends org.hawkular.inventory.api.model.Path.MetadataPackBuilder<Impl extends org.hawkular.inventory.api.model.Path>, FB extends org.hawkular.inventory.api.model.Path.FeedBuilder<Impl extends org.hawkular.inventory.api.model.Path, RTB extends org.hawkular.inventory.api.model.Path.ResourceTypeBuilder<Impl, OTB extends org.hawkular.inventory.api.model.Path.OperationTypeBuilder<Impl, SDB extends org.hawkular.inventory.api.model.Path.StructuredDataBuilder<Impl, SDB>>, SDB>, MTB extends org.hawkular.inventory.api.model.Path.MetricTypeBuilder<Impl>, RB extends org.hawkular.inventory.api.model.Path.ResourceBuilder<Impl, RB, SDB>, MB extends org.hawkular.inventory.api.model.Path.MetricBuilder<Impl>, OTB, SDB>, RB extends org.hawkular.inventory.api.model.Path.ResourceBuilder<Impl extends org.hawkular.inventory.api.model.Path, RB extends org.hawkular.inventory.api.model.Path.ResourceBuilder<Impl, RB, SDB extends org.hawkular.inventory.api.model.Path.StructuredDataBuilder<Impl, SDB>>, SDB>, MB extends org.hawkular.inventory.api.model.Path.MetricBuilder<Impl extends org.hawkular.inventory.api.model.Path>>::feedBuilder(java.util.List<org.hawkular.inventory.api.model.Path.Segment>)",
         "new": "method FB org.hawkular.inventory.api.model.Path.TenantBuilder<Impl extends org.hawkular.inventory.api.model.Path, EB extends org.hawkular.inventory.api.model.Path.EnvironmentBuilder<Impl extends org.hawkular.inventory.api.model.Path, RB extends org.hawkular.inventory.api.model.Path.ResourceBuilder<Impl, RB, MB extends org.hawkular.inventory.api.model.Path.MetricBuilder<Impl>, SDB extends org.hawkular.inventory.api.model.Path.StructuredDataBuilder<Impl, SDB>>, MB, RTB extends org.hawkular.inventory.api.model.Path.ResourceTypeBuilder<Impl, OTB extends org.hawkular.inventory.api.model.Path.OperationTypeBuilder<Impl, SDB>, SDB>, MTB extends org.hawkular.inventory.api.model.Path.MetricTypeBuilder<Impl>, OTB, SDB>, RTB extends org.hawkular.inventory.api.model.Path.ResourceTypeBuilder<Impl extends org.hawkular.inventory.api.model.Path, OTB extends org.hawkular.inventory.api.model.Path.OperationTypeBuilder<Impl, SDB extends org.hawkular.inventory.api.model.Path.StructuredDataBuilder<Impl, SDB>>, SDB>, MTB extends org.hawkular.inventory.api.model.Path.MetricTypeBuilder<Impl extends org.hawkular.inventory.api.model.Path>, OTB extends org.hawkular.inventory.api.model.Path.OperationTypeBuilder<Impl extends org.hawkular.inventory.api.model.Path, SDB extends org.hawkular.inventory.api.model.Path.StructuredDataBuilder<Impl, SDB>>, SDB extends org.hawkular.inventory.api.model.Path.StructuredDataBuilder<Impl extends org.hawkular.inventory.api.model.Path, SDB extends org.hawkular.inventory.api.model.Path.StructuredDataBuilder<Impl, SDB>>, MPB extends org.hawkular.inventory.api.model.Path.MetadataPackBuilder<Impl extends org.hawkular.inventory.api.model.Path>, FB extends org.hawkular.inventory.api.model.Path.FeedBuilder<Impl extends org.hawkular.inventory.api.model.Path, RTB extends org.hawkular.inventory.api.model.Path.ResourceTypeBuilder<Impl, OTB extends org.hawkular.inventory.api.model.Path.OperationTypeBuilder<Impl, SDB extends org.hawkular.inventory.api.model.Path.StructuredDataBuilder<Impl, SDB>>, SDB>, MTB extends org.hawkular.inventory.api.model.Path.MetricTypeBuilder<Impl>, RB extends org.hawkular.inventory.api.model.Path.ResourceBuilder<Impl, RB, MB extends org.hawkular.inventory.api.model.Path.MetricBuilder<Impl>, SDB>, MB, OTB, SDB>, RB extends org.hawkular.inventory.api.model.Path.ResourceBuilder<Impl extends org.hawkular.inventory.api.model.Path, RB extends org.hawkular.inventory.api.model.Path.ResourceBuilder<Impl, RB, MB extends org.hawkular.inventory.api.model.Path.MetricBuilder<Impl>, SDB extends org.hawkular.inventory.api.model.Path.StructuredDataBuilder<Impl, SDB>>, MB, SDB>, MB extends org.hawkular.inventory.api.model.Path.MetricBuilder<Impl extends org.hawkular.inventory.api.model.Path>>::feedBuilder(java.util.List<org.hawkular.inventory.api.model.Path.Segment>)",
         "justification": "Metrics can now be owned by resources"
-        }        
+        }
       ]
+    }
+  },
+  "0.11.1.Final": {
+    "revapi": {
+      "ignore": [
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method org.hawkular.inventory.api.MetricTypes.Read org.hawkular.inventory.api.MetricTypes.BrowserBase::identical()",
+          "justification": "New feature - identical metric and resource types detection across feeds"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.lang.String org.hawkular.inventory.api.MetricTypes.Single::identityHash() throws org.hawkular.inventory.api.EntityNotFoundException",
+          "justification": "New feature - identical metric and resource types detection across feeds"
+        },      
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method org.hawkular.inventory.api.ResourceTypes.Read org.hawkular.inventory.api.ResourceTypes.BrowserBase<Resources, MetricTypes, OperationTypes, Data>::identical()",
+          "justification": "New feature - identical metric and resource types detection across feeds"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.lang.String org.hawkular.inventory.api.ResourceTypes.Single::identityHash() throws org.hawkular.inventory.api.EntityNotFoundException",
+          "justification": "New feature - identical metric and resource types detection across feeds"
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.hawkular.inventory.base.BaseData.DataModificationChecks<BE>::preCreate(org.hawkular.inventory.api.model.DataEntity.Blueprint)",
+          "new": "method void org.hawkular.inventory.base.BaseData.DataModificationChecks<BE>::preCreate(org.hawkular.inventory.api.model.DataEntity.Blueprint, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.hawkular.inventory.base.BaseData.DataModificationChecks<BE>::preDelete(BE)",
+          "new": "method void org.hawkular.inventory.base.BaseData.DataModificationChecks<BE>::preDelete(BE, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.hawkular.inventory.base.BaseData.DataModificationChecks<BE>::preUpdate(BE, org.hawkular.inventory.api.model.DataEntity.Update)",
+          "new": "method void org.hawkular.inventory.base.BaseData.DataModificationChecks<BE>::preUpdate(BE, org.hawkular.inventory.api.model.DataEntity.Update, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.hawkular.inventory.base.BaseData.ReadWrite<BE, R extends org.hawkular.inventory.api.model.DataEntity.Role>::preUpdate(R, BE, org.hawkular.inventory.api.model.DataEntity.Update)",
+          "new": "method void org.hawkular.inventory.base.BaseData.ReadWrite<BE, R extends org.hawkular.inventory.api.model.DataEntity.Role>::preUpdate(R, BE, org.hawkular.inventory.api.model.DataEntity.Update, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.DataEntity> org.hawkular.inventory.base.BaseData.ReadWrite<BE, R extends org.hawkular.inventory.api.model.DataEntity.Role>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.DataEntity.Blueprint<R>, org.hawkular.inventory.api.model.CanonicalPath, BE)",
+          "new": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.DataEntity> org.hawkular.inventory.base.BaseData.ReadWrite<BE, R extends org.hawkular.inventory.api.model.DataEntity.Role>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.DataEntity.Blueprint<R>, org.hawkular.inventory.api.model.CanonicalPath, BE, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method void org.hawkular.inventory.base.BaseData.Single<BE>::cleanup(BE)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.hawkular.inventory.base.BaseData.Single<BE>::preUpdate(BE, org.hawkular.inventory.api.model.DataEntity.Update)",
+          "new": "method void org.hawkular.inventory.base.BaseData.Single<BE>::preUpdate(BE, org.hawkular.inventory.api.model.DataEntity.Update, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.Environment> org.hawkular.inventory.base.BaseEnvironments.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.Environment.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE)",
+          "new": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.Environment> org.hawkular.inventory.base.BaseEnvironments.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.Environment.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.Feed> org.hawkular.inventory.base.BaseFeeds.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.Feed.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE)",
+          "new": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.Feed> org.hawkular.inventory.base.BaseFeeds.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.Feed.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.MetadataPack> org.hawkular.inventory.base.BaseMetadataPacks.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.MetadataPack.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE)",
+          "new": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.MetadataPack> org.hawkular.inventory.base.BaseMetadataPacks.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.MetadataPack.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method void org.hawkular.inventory.base.BaseMetricTypes.ReadWrite<BE>::cleanup(java.lang.String, BE)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.hawkular.inventory.base.BaseMetricTypes.ReadWrite<BE>::preUpdate(java.lang.String, BE, org.hawkular.inventory.api.model.MetricType.Update)",
+          "new": "method void org.hawkular.inventory.base.BaseMetricTypes.ReadWrite<BE>::preUpdate(java.lang.String, BE, org.hawkular.inventory.api.model.MetricType.Update, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.MetricType> org.hawkular.inventory.base.BaseMetricTypes.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.MetricType.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE)",
+          "new": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.MetricType> org.hawkular.inventory.base.BaseMetricTypes.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.MetricType.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method void org.hawkular.inventory.base.BaseMetricTypes.Single<BE>::cleanup(BE)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.hawkular.inventory.base.BaseMetricTypes.Single<BE>::preUpdate(BE, org.hawkular.inventory.api.model.MetricType.Update)",
+          "new": "method void org.hawkular.inventory.base.BaseMetricTypes.Single<BE>::preUpdate(BE, org.hawkular.inventory.api.model.MetricType.Update, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.Metric> org.hawkular.inventory.base.BaseMetrics.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.Metric.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE)",
+          "new": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.Metric> org.hawkular.inventory.base.BaseMetrics.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.Metric.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.hawkular.inventory.base.BaseOperationTypes.OperationTypeDataModificationChecks<BE>::preCreate(org.hawkular.inventory.api.model.DataEntity.Blueprint)",
+          "new": "method void org.hawkular.inventory.base.BaseOperationTypes.OperationTypeDataModificationChecks<BE>::preCreate(org.hawkular.inventory.api.model.DataEntity.Blueprint, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.hawkular.inventory.base.BaseOperationTypes.OperationTypeDataModificationChecks<BE>::preDelete(BE)",
+          "new": "method void org.hawkular.inventory.base.BaseOperationTypes.OperationTypeDataModificationChecks<BE>::preDelete(BE, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.hawkular.inventory.base.BaseOperationTypes.OperationTypeDataModificationChecks<BE>::preUpdate(BE, org.hawkular.inventory.api.model.DataEntity.Update)",
+          "new": "method void org.hawkular.inventory.base.BaseOperationTypes.OperationTypeDataModificationChecks<BE>::preUpdate(BE, org.hawkular.inventory.api.model.DataEntity.Update, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method void org.hawkular.inventory.base.BaseOperationTypes.ReadWrite<BE>::cleanup(java.lang.String, BE)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.OperationType> org.hawkular.inventory.base.BaseOperationTypes.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.OperationType.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE)",
+          "new": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.OperationType> org.hawkular.inventory.base.BaseOperationTypes.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.OperationType.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method void org.hawkular.inventory.base.BaseOperationTypes.Single<BE>::cleanup(BE)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method void org.hawkular.inventory.base.BaseResourceTypes.ReadWrite<BE>::cleanup(java.lang.String, BE)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.hawkular.inventory.base.BaseResourceTypes.ReadWrite<BE>::preUpdate(java.lang.String, BE, org.hawkular.inventory.api.model.ResourceType.Update)",
+          "new": "method void org.hawkular.inventory.base.BaseResourceTypes.ReadWrite<BE>::preUpdate(java.lang.String, BE, org.hawkular.inventory.api.model.ResourceType.Update, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.ResourceType> org.hawkular.inventory.base.BaseResourceTypes.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.ResourceType.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE)",
+          "new": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.ResourceType> org.hawkular.inventory.base.BaseResourceTypes.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.ResourceType.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.hawkular.inventory.base.BaseResourceTypes.ResourceTypeDataModificationChecks<BE>::preCreate(org.hawkular.inventory.api.model.DataEntity.Blueprint)",
+          "new": "method void org.hawkular.inventory.base.BaseResourceTypes.ResourceTypeDataModificationChecks<BE>::preCreate(org.hawkular.inventory.api.model.DataEntity.Blueprint, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.hawkular.inventory.base.BaseResourceTypes.ResourceTypeDataModificationChecks<BE>::preDelete(BE)",
+          "new": "method void org.hawkular.inventory.base.BaseResourceTypes.ResourceTypeDataModificationChecks<BE>::preDelete(BE, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.hawkular.inventory.base.BaseResourceTypes.ResourceTypeDataModificationChecks<BE>::preUpdate(BE, org.hawkular.inventory.api.model.DataEntity.Update)",
+          "new": "method void org.hawkular.inventory.base.BaseResourceTypes.ResourceTypeDataModificationChecks<BE>::preUpdate(BE, org.hawkular.inventory.api.model.DataEntity.Update, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method void org.hawkular.inventory.base.BaseResourceTypes.Single<BE>::cleanup(BE)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.hawkular.inventory.base.BaseResourceTypes.Single<BE>::preUpdate(BE, org.hawkular.inventory.api.model.ResourceType.Update)",
+          "new": "method void org.hawkular.inventory.base.BaseResourceTypes.Single<BE>::preUpdate(BE, org.hawkular.inventory.api.model.ResourceType.Update, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.Resource> org.hawkular.inventory.base.BaseResources.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.Resource.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE)",
+          "new": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.Resource> org.hawkular.inventory.base.BaseResources.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.Resource.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.Tenant> org.hawkular.inventory.base.BaseTenants.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.Tenant.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE)",
+          "new": "method org.hawkular.inventory.base.EntityAndPendingNotifications<org.hawkular.inventory.api.model.Tenant> org.hawkular.inventory.base.BaseTenants.ReadWrite<BE>::wireUpNewEntity(BE, org.hawkular.inventory.api.model.Tenant.Blueprint, org.hawkular.inventory.api.model.CanonicalPath, BE, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method void org.hawkular.inventory.base.Fetcher<BE, E extends org.hawkular.inventory.api.model.AbstractElement<?, U extends org.hawkular.inventory.api.model.AbstractElement.Update>, U extends org.hawkular.inventory.api.model.AbstractElement.Update>::cleanup(BE)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.hawkular.inventory.base.Fetcher<BE, E extends org.hawkular.inventory.api.model.AbstractElement<?, U extends org.hawkular.inventory.api.model.AbstractElement.Update>, U extends org.hawkular.inventory.api.model.AbstractElement.Update>::preUpdate(BE, U)",
+          "new": "method void org.hawkular.inventory.base.Fetcher<BE, E extends org.hawkular.inventory.api.model.AbstractElement<?, U extends org.hawkular.inventory.api.model.AbstractElement.Update>, U extends org.hawkular.inventory.api.model.AbstractElement.Update>::preUpdate(BE, U, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method void org.hawkular.inventory.base.Mutator<BE, E extends org.hawkular.inventory.api.model.Entity<?, U extends org.hawkular.inventory.api.model.Entity.Update>, B extends org.hawkular.inventory.api.model.Blueprint, U extends org.hawkular.inventory.api.model.Entity.Update, Id>::cleanup(Id, BE)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.hawkular.inventory.base.Mutator<BE, E extends org.hawkular.inventory.api.model.Entity<?, U extends org.hawkular.inventory.api.model.Entity.Update>, B extends org.hawkular.inventory.api.model.Blueprint, U extends org.hawkular.inventory.api.model.Entity.Update, Id>::preUpdate(Id, BE, U)",
+          "new": "method void org.hawkular.inventory.base.Mutator<BE, E extends org.hawkular.inventory.api.model.Entity<?, U extends org.hawkular.inventory.api.model.Entity.Update>, B extends org.hawkular.inventory.api.model.Blueprint, U extends org.hawkular.inventory.api.model.Entity.Update, Id>::preUpdate(Id, BE, U, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method org.hawkular.inventory.base.EntityAndPendingNotifications<E> org.hawkular.inventory.base.Mutator<BE, E extends org.hawkular.inventory.api.model.Entity<?, U extends org.hawkular.inventory.api.model.Entity.Update>, B extends org.hawkular.inventory.api.model.Blueprint, U extends org.hawkular.inventory.api.model.Entity.Update, Id>::wireUpNewEntity(BE, B, org.hawkular.inventory.api.model.CanonicalPath, BE)",
+          "new": "method org.hawkular.inventory.base.EntityAndPendingNotifications<E> org.hawkular.inventory.base.Mutator<BE, E extends org.hawkular.inventory.api.model.Entity<?, U extends org.hawkular.inventory.api.model.Entity.Update>, B extends org.hawkular.inventory.api.model.Blueprint, U extends org.hawkular.inventory.api.model.Entity.Update, Id>::wireUpNewEntity(BE, B, org.hawkular.inventory.api.model.CanonicalPath, BE, org.hawkular.inventory.base.spi.InventoryBackend.Transaction)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.lang.String org.hawkular.inventory.base.spi.InventoryBackend<E>::extractIdentityHash(E)",
+          "justification": "New feature - identical metric and resource types detection across feeds"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method boolean org.hawkular.inventory.base.spi.InventoryBackend<E>::isBackendInternal(E)",
+          "justification": "New feature - identical metric and resource types detection across feeds"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.hawkular.inventory.base.spi.InventoryBackend<E>::updateIdentityHash(E, java.lang.String)",
+          "justification": "New feature - identical metric and resource types detection across feeds"
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method void org.hawkular.inventory.base.BaseData.ReadWrite<BE, R extends org.hawkular.inventory.api.model.DataEntity.Role>::cleanup(R, BE)",
+          "justification": "More comprehensive way of adding custom preCreate, postCreate, preUpdate, postUpdate, preDelete and postDelete logic in base.Fetcher and base.Mutator subclasses."
+        }
+     ]
     }
   }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -385,6 +385,16 @@ public class EmptyInventory implements Inventory {
         public Relationships.ReadWrite relationships(Relationships.Direction direction) {
             return new RelationshipsReadWrite();
         }
+
+        @Override
+        public String identityHash() throws EntityNotFoundException {
+            return "";
+        }
+
+        @Override
+        public ResourceTypes.Read identical() {
+            return new ResourceTypesRead();
+        }
     }
 
     public static class ResourceTypesMultiple implements ResourceTypes.Multiple {
@@ -422,6 +432,11 @@ public class EmptyInventory implements Inventory {
         @Override
         public Page<ResourceType> entities(Pager pager) {
             return emptyPage(pager);
+        }
+
+        @Override
+        public ResourceTypes.Read identical() {
+            return new ResourceTypesRead();
         }
     }
 
@@ -529,6 +544,11 @@ public class EmptyInventory implements Inventory {
         public Page<MetricType> entities(Pager pager) {
             return emptyPage(pager);
         }
+
+        @Override
+        public MetricTypes.Read identical() {
+            return new MetricTypesRead();
+        }
     }
 
     public static class MetricTypesSingle extends SingleBase<MetricType, MetricType.Update>
@@ -551,6 +571,16 @@ public class EmptyInventory implements Inventory {
         @Override
         public Relationships.ReadWrite relationships(Relationships.Direction direction) {
             return new RelationshipsReadWrite();
+        }
+
+        @Override
+        public String identityHash() throws EntityNotFoundException {
+            return "";
+        }
+
+        @Override
+        public MetricTypes.Read identical() {
+            return new MetricTypesRead();
         }
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Inventory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Inventory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -378,7 +378,10 @@ public interface Inventory extends AutoCloseable {
 
             @Override
             public Single visitMetricType(Void parameter) {
-                return accessInterface.cast(tenants().get(ids.getTenantId()).metricTypes()
+                Tenants.Single ten = tenants().get(ids.getTenantId());
+                return accessInterface.cast(ids.getFeedId() == null
+                        ? ten.metricTypes().get(ids.getMetricTypeId())
+                        : ten.feeds().get(ids.getFeedId()).metricTypes()
                         .get(ids.getMetricTypeId()));
             }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/MetricTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/MetricTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,12 +37,19 @@ public final class MetricTypes {
          * @return metrics defined by the metric type(s)
          */
         Metrics.Read metrics();
+
+        /**
+         * @return metric types that are identical to this metric type
+         */
+        MetricTypes.Read identical();
     }
 
     /**
      * Interface for accessing a single metric type in a writable manner.
      */
     public interface Single extends ResolvableToSingleWithRelationships<MetricType, MetricType.Update>, BrowserBase {
+
+        String identityHash() throws EntityNotFoundException;
     }
 
     /**
@@ -59,8 +66,7 @@ public final class MetricTypes {
      * Provides read-write access to metric types.
      */
     public interface ReadWrite
-            extends ReadWriteInterface<MetricType.Update, MetricType.Blueprint, Single, Multiple, String
-            > {}
+            extends ReadWriteInterface<MetricType.Update, MetricType.Blueprint, Single, Multiple, String> {}
 
     /**
      * Provides read-only access to metric types.

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResourceTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResourceTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -78,6 +78,11 @@ public final class ResourceTypes {
          * @return access to the data associated with the resource type.
          */
         Data data();
+
+        /**
+         * @return resource types that are equivalent to this resource type based on the {@link IdentityHash} rules.
+         */
+        Read identical();
     }
 
     /**
@@ -85,6 +90,8 @@ public final class ResourceTypes {
      */
     public interface Single extends ResolvableToSingleWithRelationships<ResourceType, ResourceType.Update>,
             BrowserBase<Resources.Read, MetricTypes.ReadAssociate, OperationTypes.ReadWrite, Data.ReadWrite<DataRole>> {
+
+        String identityHash() throws EntityNotFoundException;
     }
 
     /**

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/filters/With.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/filters/With.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -153,6 +153,16 @@ public final class With {
      */
     public static DataOfTypes dataOfTypes(StructuredData.Type... types) {
         return new DataOfTypes(types);
+    }
+
+    /**
+     * Looks for resource or metric types that have the same identity hash as the entity/ies on the current position
+     * in the filter chain.
+     *
+     * @return the filter
+     */
+    public static SameIdentityHash sameIdentityHash() {
+        return SameIdentityHash.INSTANCE;
     }
 
     public static final class Ids extends Filter {
@@ -435,6 +445,28 @@ public final class With {
         @Override
         public int hashCode() {
             return Arrays.hashCode(types);
+        }
+    }
+
+    public static final class SameIdentityHash extends Filter {
+        public static final SameIdentityHash INSTANCE = new SameIdentityHash();
+
+        public SameIdentityHash() {
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return this == obj || (obj instanceof SameIdentityHash);
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+
+        @Override
+        public String toString() {
+            return "SameIdentityHash";
         }
     }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseEnvironments.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseEnvironments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,6 +36,7 @@ import org.hawkular.inventory.api.model.Feed;
 import org.hawkular.inventory.api.model.Metric;
 import org.hawkular.inventory.api.model.Path;
 import org.hawkular.inventory.api.model.Resource;
+import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.base.spi.RecurseFilter;
 
 /**
@@ -123,7 +124,8 @@ public final class BaseEnvironments {
 
         @Override
         protected EntityAndPendingNotifications<Environment> wireUpNewEntity(BE entity, Environment.Blueprint blueprint,
-                                                                             CanonicalPath parentPath, BE parent) {
+                                                                             CanonicalPath parentPath, BE parent,
+                                                                             InventoryBackend.Transaction transaction) {
             return new EntityAndPendingNotifications<>(new Environment(blueprint.getName(),
                     parentPath.extend(Environment.class, context.backend.extractId(entity)).get(),
                     blueprint.getProperties()));

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseFeeds.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseFeeds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,6 +38,7 @@ import org.hawkular.inventory.api.model.Path;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.api.model.ResourceType;
 import org.hawkular.inventory.api.model.Tenant;
+import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.base.spi.RecurseFilter;
 
 /**
@@ -74,7 +75,8 @@ public final class BaseFeeds {
 
         @Override
         protected EntityAndPendingNotifications<Feed> wireUpNewEntity(BE entity, Feed.Blueprint blueprint,
-                CanonicalPath parentPath, BE parent) {
+                                                                      CanonicalPath parentPath, BE parent,
+                                                                      InventoryBackend.Transaction transaction) {
             return new EntityAndPendingNotifications<>(new Feed(blueprint.getName(), parentPath.extend(Feed.class,
                     context.backend.extractId(entity)).get(), blueprint.getProperties()));
         }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseInventory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseInventory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -96,6 +96,9 @@ public abstract class BaseInventory<E> implements Inventory {
         return new BaseTransactionFrame<>(backend, observableContext, tenantContext);
     }
 
+    Initialized<E> keepTransaction(InventoryBackend.Transaction transaction) {
+        return new Initialized<>(new TransactionFixedBackend<>(backend, transaction), observableContext, configuration);
+    }
     /**
      * This method is called during {@link #initialize(Configuration)} and provides the instance of the backend
      * initialized from the configuration.

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetadataPacks.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetadataPacks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,6 +39,7 @@ import org.hawkular.inventory.api.model.Path;
 import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.ResourceType;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
+import org.hawkular.inventory.base.spi.InventoryBackend;
 
 /**
  * @author Lukas Krejci
@@ -74,7 +75,8 @@ public final class BaseMetadataPacks {
 
         @Override
         protected EntityAndPendingNotifications<MetadataPack>
-        wireUpNewEntity(BE entity, MetadataPack.Blueprint blueprint, CanonicalPath parentPath, BE parent) {
+        wireUpNewEntity(BE entity, MetadataPack.Blueprint blueprint, CanonicalPath parentPath, BE parent,
+                        InventoryBackend.Transaction transaction) {
             Set<Notification<?, ?>> newRels = new HashSet<>();
 
             blueprint.getMembers().forEach((p) -> {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetrics.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,6 +35,7 @@ import org.hawkular.inventory.api.model.Path;
 import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
+import org.hawkular.inventory.base.spi.InventoryBackend;
 
 /**
  * @author Lukas Krejci
@@ -61,7 +62,8 @@ public final class BaseMetrics {
 
         @Override
         protected EntityAndPendingNotifications<Metric> wireUpNewEntity(BE entity, Metric.Blueprint blueprint,
-                CanonicalPath parentPath, BE parent) {
+                                                                        CanonicalPath parentPath, BE parent,
+                                                                        InventoryBackend.Transaction transaction) {
 
             BE metricTypeObject;
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,6 +44,7 @@ import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.api.model.ResourceType;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
+import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.base.spi.RecurseFilter;
 
 /**
@@ -70,7 +71,9 @@ public final class BaseResources {
 
         @Override
         protected EntityAndPendingNotifications<Resource> wireUpNewEntity(BE entity,
-                Resource.Blueprint blueprint, CanonicalPath parentPath, BE parent) {
+                                                                          Resource.Blueprint blueprint,
+                                                                          CanonicalPath parentPath, BE parent,
+                                                                          InventoryBackend.Transaction transaction) {
 
             BE resourceTypeObject;
             CanonicalPath resourceTypePath = null;

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseTenants.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseTenants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,6 +38,7 @@ import org.hawkular.inventory.api.model.MetricType;
 import org.hawkular.inventory.api.model.Path;
 import org.hawkular.inventory.api.model.ResourceType;
 import org.hawkular.inventory.api.model.Tenant;
+import org.hawkular.inventory.base.spi.InventoryBackend;
 
 /**
  * @author Lukas Krejci
@@ -63,7 +64,8 @@ public final class BaseTenants {
 
         @Override
         protected EntityAndPendingNotifications<Tenant> wireUpNewEntity(BE entity, Tenant.Blueprint blueprint,
-                CanonicalPath parentPath, BE parent) {
+                                                                        CanonicalPath parentPath, BE parent,
+                                                                        InventoryBackend.Transaction transaction) {
 
             return new EntityAndPendingNotifications<>(new Tenant(blueprint.getName(), CanonicalPath.of()
                     .tenant(context.backend.extractId(entity)).get(), blueprint.getProperties()));

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingInventoryBackend.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingInventoryBackend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -78,6 +78,11 @@ public class DelegatingInventoryBackend<E> implements InventoryBackend<E> {
     @Override
     public CanonicalPath extractCanonicalPath(E entityRepresentation) {
         return backend.extractCanonicalPath(entityRepresentation);
+    }
+
+    @Override
+    public String extractIdentityHash(E entityRepresentation) {
+        return backend.extractIdentityHash(entityRepresentation);
     }
 
     @Override
@@ -197,6 +202,11 @@ public class DelegatingInventoryBackend<E> implements InventoryBackend<E> {
     }
 
     @Override
+    public boolean isBackendInternal(E element) {
+        return backend.isBackendInternal(element);
+    }
+
+    @Override
     public Transaction startTransaction(boolean mutating) {
         return backend.startTransaction(mutating);
     }
@@ -210,6 +220,11 @@ public class DelegatingInventoryBackend<E> implements InventoryBackend<E> {
     @Override
     public void update(E entity, AbstractElement.Update update) {
         backend.update(entity, update);
+    }
+
+    @Override
+    public void updateIdentityHash(E entity, String identityHash) {
+        backend.updateIdentityHash(entity, identityHash);
     }
 
     @Override

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TransactionFixedBackend.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TransactionFixedBackend.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.base;
+
+import org.hawkular.inventory.base.spi.CommitFailureException;
+import org.hawkular.inventory.base.spi.InventoryBackend;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.10.0
+ */
+final class TransactionFixedBackend<E> extends DelegatingInventoryBackend<E> {
+
+    private final Transaction transaction;
+
+    public TransactionFixedBackend(InventoryBackend<E> backend, Transaction transaction) {
+        super(backend);
+        this.transaction = transaction;
+    }
+
+    @Override
+    public Transaction startTransaction(boolean mutating) {
+        return transaction;
+    }
+
+    @Override
+    public void commit(Transaction transaction) throws CommitFailureException {
+    }
+
+    @Override
+    public void rollback(Transaction transaction) {
+    }
+}

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TransactionRecordingBackend.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TransactionRecordingBackend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,11 +29,11 @@ import org.hawkular.inventory.base.spi.InventoryBackend;
  * @author Lukas Krejci
  * @since 0.4.0
  */
-final class NoncommittingBackend<E> extends DelegatingInventoryBackend<E> {
+final class TransactionRecordingBackend<E> extends DelegatingInventoryBackend<E> {
 
     private final PayloadRememberingTransaction transaction;
 
-    public NoncommittingBackend(InventoryBackend<E> backend, boolean mutating) {
+    public TransactionRecordingBackend(InventoryBackend<E> backend, boolean mutating) {
         super(backend);
         this.transaction = new PayloadRememberingTransaction(mutating);
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InventoryBackend.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InventoryBackend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -213,6 +213,14 @@ public interface InventoryBackend<E> extends AutoCloseable {
     CanonicalPath extractCanonicalPath(E entityRepresentation);
 
     /**
+     * Extracts the identity hash from the provided entity.
+     *
+     * @param entityRepresentation the representation object
+     * @return the identity hash of the entity or null if not supported for that type of entity
+     */
+    String extractIdentityHash(E entityRepresentation);
+
+    /**
      * Converts the provided representation object to an inventory element of provided type.
      *
      * <p>This must support all the concrete subclasses of {@link AbstractElement}, {@link StructuredData} <b>and</b>
@@ -277,6 +285,14 @@ public interface InventoryBackend<E> extends AutoCloseable {
     void update(E entity, AbstractElement.Update update);
 
     /**
+     * Updates the identity hash of the entity.
+     *
+     * @param entity the entity to update
+     * @param identityHash the identity hash to set
+     */
+    void updateIdentityHash(E entity, String identityHash);
+
+    /**
      * Simply deletes the entity from the storage.
      *
      * @param entity the entity to delete
@@ -303,6 +319,14 @@ public interface InventoryBackend<E> extends AutoCloseable {
     void rollback(Transaction transaction);
 
     /**
+     * The query results might sometimes return elements that are not representable in the inventory API because they
+     * are an implementation detail of the backend. This will tell the API.
+     *
+     * @param element the element to check
+     */
+    boolean isBackendInternal(E element);
+
+    /**
      * See the javadoc in {@link org.hawkular.inventory.api.Inventory#getGraphSON(String)}
      */
     InputStream getGraphSON(String tenantId);
@@ -310,6 +334,7 @@ public interface InventoryBackend<E> extends AutoCloseable {
     <T extends Entity<?, ?>> Iterator<T> getTransitiveClosureOver(CanonicalPath startingPoint,
                                                                   Relationships.Direction direction, Class<T> clazz,
                                                                   String... relationshipNames);
+
     /**
      * Represents a transaction being performed. Implementations of the {@link InventoryBackend} interface are
      * encouraged to inherit from this class and add additional information to it. The base inventory implementation

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/Constants.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
  */
 package org.hawkular.inventory.impl.tinkerpop;
 
+import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__identityHash;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__metric_data_type;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__metric_interval;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__sourceCp;
@@ -130,7 +131,11 @@ final class Constants {
 
         __sourceEid,
 
-        __targetEid;
+        __targetEid,
+
+        __identityHash,
+
+        __targetIdentityHash;
 
 
         private static final HashSet<String> MIRRORED_PROPERTIES = new HashSet<>(Arrays.asList(__type.name(),
@@ -154,8 +159,8 @@ final class Constants {
      */
     enum Type {
         tenant(Tenant.class, name), environment(Environment.class, name), feed(Feed.class, name),
-        resourceType(ResourceType.class, name), metricType(MetricType.class, name, __unit, __metric_data_type,
-                __metric_interval),
+        resourceType(ResourceType.class, name, __identityHash),
+        metricType(MetricType.class, name, __unit, __metric_data_type, __metric_interval, __identityHash),
         operationType(OperationType.class, name), resource(Resource.class, name),
         metric(Metric.class, name, __metric_interval), metadatapack(MetadataPack.class, name),
         relationship(Relationship.class, __sourceType, __targetType, __sourceCp, __targetCp, __sourceEid, __targetEid),
@@ -324,6 +329,13 @@ final class Constants {
         }
     }
 
+    enum InternalEdge {
+        __withIdentityHash, __containsIdentityHash
+    }
+
+    enum InternalType {
+        __identityHash
+    }
     private Constants() {
         //no instances, thank you
     }

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterApplicator.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterApplicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -82,6 +82,7 @@ abstract class FilterApplicator<T extends Filter> {
         applicators.put(With.DataValued.class, DataValuedApplicator.class);
         applicators.put(With.DataOfTypes.class, DataOfTypesApplicator.class);
         applicators.put(RecurseFilter.class, RecurseApplicator.class);
+        applicators.put(With.SameIdentityHash.class, SameIdentityHashApplicator.class);
     }
 
     protected final T filter;
@@ -510,6 +511,18 @@ abstract class FilterApplicator<T extends Filter> {
     private static final class RecurseApplicator extends FilterApplicator<RecurseFilter> {
 
         private RecurseApplicator(RecurseFilter f) {
+            super(f);
+        }
+
+        @Override
+        public void applyTo(HawkularPipeline<?, ?> query, QueryTranslationState state) {
+            visitor.visit(query, filter, state);
+        }
+    }
+
+    private static final class SameIdentityHashApplicator extends FilterApplicator<With.SameIdentityHash> {
+
+        private SameIdentityHashApplicator(With.SameIdentityHash f) {
             super(f);
         }
 

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterVisitor.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@ package org.hawkular.inventory.impl.tinkerpop;
 
 import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
 import static org.hawkular.inventory.api.Relationships.WellKnown.hasData;
+import static org.hawkular.inventory.impl.tinkerpop.Constants.InternalEdge.__withIdentityHash;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__cp;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__eid;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__sourceCp;
@@ -451,6 +452,12 @@ class FilterVisitor {
         goBackFromEdges(query, state);
 
         query.loop(label, (x) -> true, (x) -> true);
+    }
+
+    public void visit(HawkularPipeline<?, ?> query, @SuppressWarnings("UnusedParameters") With.SameIdentityHash filter,
+                      QueryTranslationState state) {
+        goBackFromEdges(query, state);
+        query.out(__withIdentityHash.name()).in(__withIdentityHash.name());
     }
 
     private void convertToPipeline(RelativePath path, HawkularPipeline<?, ?> pipeline) {

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopInventory.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopInventory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -155,6 +155,20 @@ public final class TinkerpopInventory extends BaseInventory<Element> {
                         .withElementType(Edge.class)
                         .withProperty(IndexSpec.Property.builder()
                                 .withName(Constants.Property.__targetType.name())
+                                .withType(String.class)
+                                .build())
+                        .build(),
+                IndexSpec.builder()
+                        .withElementType(Vertex.class)
+                        .withProperty(IndexSpec.Property.builder()
+                                .withName(Constants.Property.__identityHash.name())
+                                .withType(String.class)
+                                .build())
+                        .build(),
+                IndexSpec.builder()
+                        .withElementType(Edge.class)
+                        .withProperty(IndexSpec.Property.builder()
+                                .withName(Constants.Property.__targetIdentityHash.name())
                                 .withType(String.class)
                                 .build())
                         .build());

--- a/hawkular-inventory-itest-parent/pom.xml
+++ b/hawkular-inventory-itest-parent/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +33,10 @@
     <module>hawkular-inventory-itest</module>
     <module>hawkular-inventory-itest-dist</module>
   </modules>
+
+  <properties>
+    <version.org.hawkular.dist>1.0.0.Alpha6-SNAPSHOT</version.org.hawkular.dist>
+  </properties>
 
   <build>
     <plugins>


### PR DESCRIPTION
This is done using an internal "IdentityHash" vertex that is referenced
from the tenant (to allow for universal access) using
"__containsIdentityHash" edges (so that it doesn't "pollute" the
potentially crowded "contains" edges.

These identity hash vertices are then referenced by the individual resource
and metric types using the "__identityHash" edges. The identity hash
of metric and resource types are recomputed on any update of their
"hash-significant" values or of any values of their contained entities
(op types, data).

To query for identical resource types, then, is a simple matter of going
out to the hash vertex and then back across all the "__identityHash"
edges.

The identity hash vertices are cleared out automatically when they are no
longer referenced by any resource/metric type.
