### PR TITLE
[HWKINVENT-168] no duplicate relationships + a couple of other fixes

### DIFF
--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Util.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Util.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.hawkular.inventory.api.Action;

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Util.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Util.java
@@ -24,6 +24,7 @@ import static org.hawkular.inventory.api.Relationships.Direction.both;
 import static org.hawkular.inventory.api.Relationships.Direction.outgoing;
 import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
 import static org.hawkular.inventory.api.Relationships.WellKnown.defines;
+import static org.hawkular.inventory.api.Relationships.WellKnown.hasData;
 
 import java.util.HashSet;
 import java.util.Random;
@@ -344,13 +345,14 @@ final class Util {
             }
 
             Set<BE> verticesToDeleteThatDefineSomething = new HashSet<>();
+            Set<BE> dataToBeDeleted = new HashSet<>();
 
             Set<BE> deleted = new HashSet<>();
             Set<BE> deletedRels = new HashSet<>();
             Set<?> deletedEntities;
             Set<Relationship> deletedRelationships;
 
-            context.backend.getTransitiveClosureOver(entity, outgoing, contains.name()).forEachRemaining((e) -> {
+            Consumer<BE> categorizer = (e) -> {
                 if (context.backend.hasRelationship(e, outgoing, defines.name())) {
                     verticesToDeleteThatDefineSomething.add(e);
                 } else {
@@ -358,14 +360,15 @@ final class Util {
                 }
                 //not only the entity, but also its relationships are going to disappear
                 deletedRels.addAll(context.backend.getRelationships(e, both));
-            });
 
-            if (context.backend.hasRelationship(entity, outgoing, defines.name())) {
-                verticesToDeleteThatDefineSomething.add(entity);
-            } else {
-                deleted.add(entity);
-            }
-            deletedRels.addAll(context.backend.getRelationships(entity, both));
+                context.backend.getRelationships(e, outgoing, hasData.name()).forEach(rel -> {
+                    dataToBeDeleted.add(context.backend.getRelationshipTarget(rel));
+                });
+            };
+
+            categorizer.accept(entity);
+            context.backend.getTransitiveClosureOver(entity, outgoing, contains.name())
+                    .forEachRemaining(categorizer::accept);
 
             //we've gathered all entities to be deleted. Now convert them all to entities for reporting purposes.
             //We have to do it prior to actually deleting the objects in the backend so that all information and
@@ -404,6 +407,8 @@ final class Util {
                     context.backend.delete(e);
                 }
             }
+
+            dataToBeDeleted.forEach(context.backend::deleteStructuredData);
 
             if (postDelete != null) {
                 postDelete.accept(entity, transaction);

--- a/hawkular-inventory-dist/pom.xml
+++ b/hawkular-inventory-dist/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,10 +41,6 @@
     <developerConnection>scm:git:git@github.com:hawkular/hawkular-inventory.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
-
-  <properties>
-    <checkstyle.suppressions.file>checkstyle-suppressions.xml</checkstyle.suppressions.file>
-  </properties>
 
   <dependencies>
 

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-tinkergraph-provider/pom.xml
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-tinkergraph-provider/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@
   </parent>
 
   <artifactId>hawkular-inventory-impl-tinkerpop-tinkergraph-provider</artifactId>
+  <packaging>jar</packaging>
 
   <name>Hawkular Inventory Tinkerpop TinkerGraph Provider</name>
 
@@ -35,12 +36,93 @@
   <dependencies>
     <dependency>
       <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.inventory</groupId>
       <artifactId>hawkular-inventory-impl-tinkerpop-spi</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.tinkerpop.gremlin</groupId>
+      <artifactId>gremlin-java</artifactId>
+      <version>${version.com.tinkerpop.gremlin}</version>
+    </dependency>
+
+    <!-- Test deps -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-impl-tinkerpop</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-api</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.mail</groupId>
+      <artifactId>javax.mail-api</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
   <build>
     <finalName>hawkular-${project.artifactId}-${project.version}</finalName>
+    <testResources>
+      <testResource>
+        <directory>${project.basedir}/src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <graph.config>${project.build.testOutputDirectory}/testsuite-graph.properties</graph.config>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-tinkergraph-provider/src/test/java/org/hawkular/inventory/impl/tinkerpop/provider/TinkerGraphTest.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-tinkergraph-provider/src/test/java/org/hawkular/inventory/impl/tinkerpop/provider/TinkerGraphTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.inventory.impl.tinkerpop.test;
+package org.hawkular.inventory.impl.tinkerpop.provider;
 
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -24,24 +24,35 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 
-import org.hawkular.inventory.api.test.AbstractBaseInventoryPersistenceCheck;
+import org.hawkular.inventory.api.test.AbstractBaseInventoryTestsuite;
 import org.hawkular.inventory.base.BaseInventory;
 import org.hawkular.inventory.impl.tinkerpop.TinkerpopInventory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 import com.tinkerpop.blueprints.Element;
 
 /**
  * @author Lukas Krejci
- * @since 0.0.6
+ * @since 0.11.0
  */
-public class TinkerpopTest extends AbstractBaseInventoryPersistenceCheck<Element> {
-    @Override
-    protected BaseInventory<Element> instantiateNewInventory() {
-        return new TinkerpopInventory();
+public class TinkerGraphTest extends AbstractBaseInventoryTestsuite<Element> {
+
+    private static TinkerpopInventory INVENTORY;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        INVENTORY = new TinkerpopInventory();
+        setupNewInventory(INVENTORY);
     }
 
     @Override
-    protected void destroyStorage() throws IOException {
+    protected BaseInventory<Element> getInventoryForTest() {
+        return INVENTORY;
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
         Path path = Paths.get("target", "__tinker.graph");
 
         if (!path.toFile().exists()) {

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-tinkergraph-provider/src/test/resources/testsuite-graph.properties
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-tinkergraph-provider/src/test/resources/testsuite-graph.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 Red Hat, Inc. and/or its affiliates
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-titan-provider/checkstyle-suppressions.xml
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-titan-provider/checkstyle-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-titan-provider/pom.xml
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-titan-provider/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,10 @@
   <artifactId>hawkular-inventory-impl-tinkerpop-titan-provider</artifactId>
 
   <name>Hawkular Inventory Tinkerpop Titan Provider</name>
+
+  <properties>
+    <checkstyle.suppressions.file>checkstyle-suppressions.xml</checkstyle.suppressions.file>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -65,9 +69,111 @@
       <artifactId>jboss-logging-processor</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <!--
+    technically, this is incorrect, because titan itself doesn't depend on
+    cassandra, but because we use Titan with Cassandra in Hawkular, let's just
+    do this. If we ever decide to use Titan without C*, we'll worry about it then.
+    -->
+    <dependency>
+      <groupId>org.apache.cassandra</groupId>
+      <artifactId>cassandra-all</artifactId>
+    </dependency>
+
+    <!-- Test deps -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-impl-tinkerpop</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-api</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+
+    <dependency>
+      <groupId>com.thinkaurelius.titan</groupId>
+      <artifactId>titan-cassandra</artifactId>
+      <version>${version.com.thinkaurelius.titan}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.mail</groupId>
+      <artifactId>javax.mail-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.codahale.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>3.0.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
     <finalName>hawkular-${project.artifactId}-${project.version}</finalName>
+
+    <testResources>
+      <testResource>
+        <directory>${project.basedir}/src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <graph.config>${project.build.testOutputDirectory}/testsuite-graph.properties</graph.config>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <configuration>
+          <analysisConfiguration><![CDATA[
+            {
+              "revapi": {
+                "filter": {
+                  "archives": {
+                    "include": ["org\\.revapi.*"]
+                  },
+                  "elements": {
+                    "include": ["org\\.revapi.*"]
+                  }
+                },
+                "java": {
+                  "missing-classes": {
+                    "behavior": "report"
+                  }
+                }
+              }
+            }
+          ]]></analysisConfiguration>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-titan-provider/src/main/java/org/apache/cassandra/dht/BytesToken.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-titan-provider/src/main/java/org/apache/cassandra/dht/BytesToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-titan-provider/src/test/java/org/hawkular/inventory/impl/tinkerpop/provider/TitanTest.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-titan-provider/src/test/java/org/hawkular/inventory/impl/tinkerpop/provider/TitanTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.impl.tinkerpop.provider;
+
+import java.net.URL;
+
+import org.apache.cassandra.service.CassandraDaemon;
+import org.hawkular.inventory.api.test.AbstractBaseInventoryTestsuite;
+import org.hawkular.inventory.base.BaseInventory;
+import org.hawkular.inventory.impl.tinkerpop.TinkerpopInventory;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestName;
+
+import com.tinkerpop.blueprints.Element;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.11.0
+ */
+public class TitanTest extends AbstractBaseInventoryTestsuite<Element> {
+
+    private static CassandraDaemon CASSANDRA_DAEMON;
+    private static TinkerpopInventory INVENTORY;
+
+    @Rule public TestName name = new TestName();
+
+    @BeforeClass
+    public static void startCassandra() throws Exception {
+        URL cassandraConfigFile = TitanTest.class.getResource("/cassandra-config.yaml");
+        System.setProperty("cassandra.config", cassandraConfigFile.toString());
+        CASSANDRA_DAEMON = new CassandraDaemon(true);
+        CASSANDRA_DAEMON.activate();
+        INVENTORY = new TinkerpopInventory();
+        setupNewInventory(INVENTORY);
+    }
+
+    @AfterClass
+    public static void stopCassandra() throws Exception {
+        if (CASSANDRA_DAEMON != null) {
+            CASSANDRA_DAEMON.deactivate();
+        }
+    }
+
+    @Before
+    public void reportStart() {
+        System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>> " + name.getMethodName());
+    }
+
+    @After
+    public void reportEnd() {
+        System.out.println("<<<<<<<<<<<<<<<<<<<<<<<<<< " + name.getMethodName());
+    }
+
+    @Override protected BaseInventory<Element> getInventoryForTest() {
+        return INVENTORY;
+    }
+}

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-titan-provider/src/test/resources/cassandra-config.yaml
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-titan-provider/src/test/resources/cassandra-config.yaml
@@ -1,0 +1,106 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+authenticator: AllowAllAuthenticator
+authorizer: AllowAllAuthorizer
+auto_bootstrap: false
+auto_snapshot: false
+batch_size_warn_threshold_in_kb: 5
+batchlog_replay_throttle_in_kb: 1024
+cas_contention_timeout_in_ms: 1000
+client_encryption_options:
+  enabled: false
+  keystore: conf/.keystore
+  keystore_password: cassandra
+cluster_name: hawkular-data
+column_index_size_in_kb: 64
+commit_failure_policy: stop
+commitlog_segment_size_in_mb: 32
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+compaction_throughput_mb_per_sec: 16
+concurrent_counter_writes: 32
+concurrent_reads: 32
+concurrent_writes: 32
+counter_cache_save_period: 7200
+counter_cache_size_in_mb: null
+counter_write_request_timeout_in_ms: 5000
+cross_node_timeout: false
+disk_failure_policy: stop
+dynamic_snitch_badness_threshold: 0.1
+dynamic_snitch_reset_interval_in_ms: 600000
+dynamic_snitch_update_interval_in_ms: 100
+endpoint_snitch: SimpleSnitch
+hinted_handoff_enabled: true
+hinted_handoff_throttle_in_kb: 1024
+incremental_backups: false
+index_summary_capacity_in_mb: null
+index_summary_resize_interval_in_minutes: 60
+initial_token: -9223372036854775808
+inter_dc_tcp_nodelay: false
+internode_compression: all
+key_cache_save_period: 14400
+key_cache_size_in_mb: null
+listen_address: 127.0.0.1
+max_hint_window_in_ms: 10800000
+max_hints_delivery_threads: 2
+memtable_allocation_type: heap_buffers
+native_transport_port: 9042
+num_tokens: 256
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+permissions_validity_in_ms: 2000
+range_request_timeout_in_ms: 10000
+read_request_timeout_in_ms: 5000
+request_scheduler: org.apache.cassandra.scheduler.NoScheduler
+request_timeout_in_ms: 10000
+row_cache_save_period: 0
+row_cache_size_in_mb: 0
+rpc_address: 127.0.0.1
+rpc_keepalive: true
+rpc_port: 9160
+rpc_server_type: sync
+# these 2 are important for hsha - with the max threads unset, there is a likelihood of OOMs because the
+# thrift server tries to start an ungodly number of threads (MAX_INT / number of cores)
+rpc_min_threads: 16
+rpc_max_threads: 1024
+seed_provider:
+- class_name: org.apache.cassandra.locator.SimpleSeedProvider
+  parameters:
+  - seeds: 127.0.0.1
+server_encryption_options:
+  internode_encryption: none
+  keystore: conf/.keystore
+  keystore_password: cassandra
+  truststore: conf/.truststore
+  truststore_password: cassandra
+snapshot_before_compaction: false
+ssl_storage_port: 7001
+sstable_preemptive_open_interval_in_mb: 50
+start_native_transport: true
+start_rpc: true
+storage_port: 7000
+thrift_framed_transport_size_in_mb: 15
+tombstone_failure_threshold: 100000
+tombstone_warn_threshold: 1000
+trickle_fsync: false
+trickle_fsync_interval_in_kb: 10240
+truncate_request_timeout_in_ms: 60000
+write_request_timeout_in_ms: 2000
+
+commitlog_directory: ${project.build.directory}/cassandra/commitlog
+saved_caches_directory: ${project.build.directory}/cassandra/saved_caches
+data_file_directories: [${project.build.directory}/cassandra/data]

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-titan-provider/src/test/resources/testsuite-graph.properties
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-titan-provider/src/test/resources/testsuite-graph.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 Red Hat, Inc. and/or its affiliates
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-storage.backend=cassandra
+storage.backend=cassandrathrift

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/pom.xml
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,12 +45,6 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
     </dependency>
@@ -76,6 +70,12 @@
     <!-- test deps -->
 
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <scope>test</scope>
@@ -92,97 +92,12 @@
     <dependency>
       <groupId>javax.mail</groupId>
       <artifactId>javax.mail-api</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>
 
   <build>
     <finalName>hawkular-${project.artifactId}-${project.version}</finalName>
-    <testResources>
-      <testResource>
-        <directory>${project.basedir}/src/test/resources</directory>
-        <filtering>true</filtering>
-      </testResource>
-    </testResources>
   </build>
-
-  <profiles>
-    <profile>
-      <id>test-with-tinkergraph</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-
-      <dependencies>
-        <dependency>
-          <groupId>org.hawkular.inventory</groupId>
-          <artifactId>hawkular-inventory-impl-tinkerpop-tinkergraph-provider</artifactId>
-          <version>${project.version}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <systemPropertyVariables>
-                <graph.config>${project.build.testOutputDirectory}/test-tinkergraph.properties</graph.config>
-              </systemPropertyVariables>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>test-with-titan</id>
-
-      <dependencies>
-        <dependency>
-          <groupId>org.hawkular.inventory</groupId>
-          <artifactId>hawkular-inventory-impl-tinkerpop-titan-provider</artifactId>
-          <version>${project.version}</version>
-          <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-          <groupId>com.thinkaurelius.titan</groupId>
-          <artifactId>titan-core</artifactId>
-          <version>${version.com.thinkaurelius.titan}</version>
-          <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-          <groupId>com.thinkaurelius.titan</groupId>
-          <artifactId>titan-cassandra</artifactId>
-          <version>${version.com.thinkaurelius.titan}</version>
-          <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-          <groupId>com.thinkaurelius.titan</groupId>
-          <artifactId>titan-es</artifactId>
-          <version>${version.com.thinkaurelius.titan}</version>
-          <scope>runtime</scope>
-        </dependency>
-      </dependencies>
-
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <systemPropertyVariables>
-                <graph.config>${project.build.testOutputDirectory}/test-titan.properties</graph.config>
-              </systemPropertyVariables>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
@@ -115,13 +115,17 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
 
     @Override
     public Element find(CanonicalPath path) throws ElementNotFoundException {
-        GraphQuery query = context.getGraph().query().has(__cp.name(), path.toString());
-        Iterator<? extends Element> it = query.vertices().iterator();
-        if (!it.hasNext()) {
+        Iterator<? extends Element> it;
+        if (Relationship.class.equals(path.getSegment().getElementType())) {
+            //__eid is globally unique for relationships
+            GraphQuery query = context.getGraph().query().has(__eid.name(), path.getSegment().getElementId());
             it = query.edges().iterator();
-            if (!it.hasNext()) {
-                throw new ElementNotFoundException();
-            }
+        } else {
+            GraphQuery query = context.getGraph().query().has(__cp.name(), path.toString());
+            it = query.vertices().iterator();
+        }
+        if (!it.hasNext()) {
+            throw new ElementNotFoundException();
         }
         return it.next();
     }
@@ -982,6 +986,8 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
         while (dataElements.hasNext()) {
             delete(dataElements.next());
         }
+
+        delete(dataRepresentation);
     }
 
     @Override

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
@@ -311,8 +311,9 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
 
         Vertex t = (Vertex) target;
 
-        Iterator<Edge> it = new HawkularPipeline<>(source).outE(relationshipName).remember().inV().hasType(getType(t))
-                .hasEid(getEid(t)).recall().cast(Edge.class);
+
+        Iterator<Edge> it = new HawkularPipeline<>(source).outE(relationshipName)
+                .has(__targetCp.name(), t.getProperty(__cp.name())).cast(Edge.class);
 
         if (!it.hasNext()) {
             throw new ElementNotFoundException();
@@ -416,8 +417,8 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
         CanonicalPath cp = extractCanonicalPath(entity);
         String tenantId = cp.ids().getTenantId();
 
-        Vertex tenantVertex = new HawkularPipeline<Graph, Vertex>(context.getGraph()).V().hasEid(tenantId)
-                .cast(Vertex.class).next();
+        Vertex tenantVertex = new HawkularPipeline<Graph, Vertex>(context.getGraph()).V()
+                .hasCanonicalPath(CanonicalPath.of().tenant(tenantId).get()).cast(Vertex.class).next();
 
         Iterator<Vertex> hashNodesIt = tenantVertex.query().direction(Direction.OUT)
                 .labels(Constants.InternalEdge.__containsIdentityHash.name())

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,6 @@
         <artifactId>joda-time</artifactId>
         <version>${version.joda-time}</version>
       </dependency>
-
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
This contains a couple of things:
- fix for deleting data nodes of the data entities that were left behind during recursive delete
- fix for finding relationships by canonical path
- refactoring of the build so that the inventory unit tests run on both tinkergraph (quick) and Titan (distribution-compatible). This will make sure that we're testing with the same stuff with deploying with.
- finally, fix for https://issues.jboss.org/browse/HWKINVENT-168 itself - this was caused by the `linkWith()` method from generic relationships using custom code for creating them. This has now been modified to use the common code path with the rest of the codebase to ensure uniform behavior.
