### PR TITLE
Reinstated the Secret Store

### DIFF
--- a/hawkular-inventory-rest-api/pom.xml
+++ b/hawkular-inventory-rest-api/pom.xml
@@ -183,6 +183,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.keycloak.secretstore</groupId>
+      <artifactId>secret-store-undertow-filter</artifactId>
+      <version>${version.org.keycloak.secretstore}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.hawkular.commons</groupId>
       <artifactId>hawkular-rest-status</artifactId>
       <version>${version.org.hawkular.commons}</version>


### PR DESCRIPTION
This kinda reverts 1eee1e5 : the dependency has to be declared here, so that it's included in the WAR, but the version can be managed somewhere else.
