### PR TITLE
Adding the newly created entity/relationship as a JSON payload in the HTTP response

### DIFF
--- a/hawkular-inventory-itest/src/test/groovy/org/hawkular/inventory/rest/test/InventoryITest.groovy
+++ b/hawkular-inventory-itest/src/test/groovy/org/hawkular/inventory/rest/test/InventoryITest.groovy
@@ -68,6 +68,7 @@ class InventoryITest extends AbstractTestBase {
     private static final String responseStatusCodeMetricId = "itest-response-status-code-" + host1ResourceId;
     private static final String feedId = "itest-feed-" + UUID.randomUUID().toString();
     private static final String bulkResourcePrefix = "bulk-resource-" + UUID.randomUUID().toString();
+    private static final String customRelationName = "inTheSameRoom";
 
     /* key is the path to delete while value is the path to GET to verify the deletion */
     private static Map<String, String> pathsToDelete = new LinkedHashMap();
@@ -128,6 +129,9 @@ class InventoryITest extends AbstractTestBase {
         /* Create an environment that will be used exclusively by this test */
         response = postDeletable(path: "environments", body: [id : environmentId])
         assertEquals(201, response.status)
+        assertEquals(environmentId, response.data.id)
+        assertEquals(CanonicalPath.of().tenant(tenantId).environment(environmentId).get().toString(),
+            response.data.path)
         assertEquals(baseURI + "$basePath/environments/$environmentId", response.headers.Location)
 
         /* URL resource type should have been autocreated */
@@ -141,6 +145,7 @@ class InventoryITest extends AbstractTestBase {
                 id : pingableHostRTypeId
             ])
         assertEquals(201, response.status)
+        assertEquals(pingableHostRTypeId, response.data.id)
         assertEquals(baseURI + "$basePath/resourceTypes/$pingableHostRTypeId", response.headers.Location)
 
         /* Create room resource type */
@@ -192,6 +197,7 @@ class InventoryITest extends AbstractTestBase {
                 body: [id: responseTimeMetricId, metricTypePath: "../" + responseTimeMTypeId]);
         //path relative to env
         assertEquals(201, response.status)
+        assertEquals(responseTimeMetricId, response.data.id)
         assertEquals(baseURI + "$basePath/$environmentId/metrics/$responseTimeMetricId", response.headers.Location)
 
         /* add another metric */
@@ -199,12 +205,18 @@ class InventoryITest extends AbstractTestBase {
                 //now try using canonical path for referencing the metric type
                 body: [id: responseStatusCodeMetricId, metricTypePath: "/$responseStatusCodeMTypeId".toString()]);
         assertEquals(201, response.status)
+        assertEquals(responseStatusCodeMetricId, response.data.id)
         assertEquals(baseURI + "$basePath/$environmentId/metrics/$responseStatusCodeMetricId", response.headers.Location)
 
         /* add a resource */
         response = postDeletable(path: "$environmentId/resources",
                 body: [id: host1ResourceId, resourceTypePath: "../$pingableHostRTypeId".toString()])
         assertEquals(201, response.status)
+        assertEquals(host1ResourceId, response.data.id)
+        assertEquals(CanonicalPath.of().tenant(tenantId).environment(environmentId).
+            resource(host1ResourceId).get().toString(), response.data.path)
+        assertEquals(CanonicalPath.of().tenant(tenantId).resourceType(pingableHostRTypeId).get().toString(),
+            response.data.type.path)
         assertEquals(baseURI + "$basePath/$environmentId/resources/$host1ResourceId", response.headers.Location)
 
         /* add another resource */
@@ -293,7 +305,7 @@ class InventoryITest extends AbstractTestBase {
         /* add a custom relationship, no need to clean up, it'll be deleted together with the resources */
         def relation = [id        : 42, // it's ignored anyway
                         source    : "/t;" + tenantId + "/e;" + environmentId + "/r;" + host2ResourceId,
-                        name      : "inTheSameRoom",
+                        name      : customRelationName,
                         target    : "/t;" + tenantId + "/e;" + environmentId + "/r;" + host1ResourceId,
                         properties: [
                             from      : "2000-01-01",
@@ -302,6 +314,7 @@ class InventoryITest extends AbstractTestBase {
         response = AbstractTestBase.client.post(path: "$basePath/$environmentId/resources/$host2ResourceId/relationships",
                 body: relation)
         assertEquals(201, response.status)
+        assertEquals(customRelationName, response.data.name)
 
         // relationship with tenant
         response = AbstractTestBase.client.post(path: "$basePath/tenants/relationships", body: [
@@ -806,7 +819,7 @@ class InventoryITest extends AbstractTestBase {
     void testCustomRelationship() {
         assertRelationshipJsonldExists("$environmentId/resources/$host2ResourceId/relationships",
                 host2ResourceId,
-                "inTheSameRoom",
+                customRelationName,
                 host1ResourceId)
     }
 
@@ -814,18 +827,18 @@ class InventoryITest extends AbstractTestBase {
     void testRelationshipFiltering() {
         assertRelationshipExists("$environmentId/resources/$host2ResourceId/relationships",
                 "/t;$tenantId/e;$environmentId/r;$host2ResourceId",
-                "inTheSameRoom",
+                customRelationName,
                 "/t;$tenantId/e;$environmentId/r;$host1ResourceId", [property: "from", propertyValue: "2000-01-01"])
 
         assertRelationshipExists("$environmentId/resources/$host2ResourceId/relationships",
                 "/t;$tenantId/e;$environmentId/r;$host2ResourceId",
-                "inTheSameRoom",
+                customRelationName,
                 "/t;$tenantId/e;$environmentId/r;$host1ResourceId", [property: "confidence", propertyValue: "90%"])
 
         assertRelationshipExists("$environmentId/resources/$host2ResourceId/relationships",
                 "/t;$tenantId/e;$environmentId/r;$host2ResourceId",
-                "inTheSameRoom",
-                "/t;$tenantId/e;$environmentId/r;$host1ResourceId", [named: "inTheSameRoom"])
+                customRelationName,
+                "/t;$tenantId/e;$environmentId/r;$host1ResourceId", [named: customRelationName])
     }
 
     @Test

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/ResponseUtil.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/ResponseUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,6 +32,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
+import org.hawkular.inventory.api.model.AbstractElement;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.PageContext;
 import org.hawkular.inventory.bus.Log;
@@ -52,16 +53,20 @@ final class ResponseUtil {
      * This method exists solely to concentrate usage of {@link javax.ws.rs.core.Response#created(java.net.URI)} into
      * one place until <a href="https://issues.jboss.org/browse/RESTEASY-1162">this JIRA</a> is resolved somehow.
      *
+     * @param element the newly created element. This will be returned in the response body as a JSON payload
      * @param info the UriInfo instance of the current request
      * @param id   the ID of a newly created entity under the base
      * @return the response builder with status 201 and location set to the entity with the provided id.
      */
-    public static Response.ResponseBuilder created(UriInfo info, String id) {
-        return Response.status(CREATED).location(info.getRequestUriBuilder().segment(id).build());
+    public static Response.ResponseBuilder created(AbstractElement element, UriInfo info, String id) {
+        return Response.status(CREATED)
+                .location(info.getRequestUriBuilder().segment(id).build())
+                .entity(element);
     }
 
     /**
-     * Similar to {@link #created(UriInfo, String)} but used when more than 1 entity is created during the request.
+     * Similar to {@link #created(AbstractElement, UriInfo, String)} but used when more than 1 entity is created
+     * during the request.
      * <p>
      * The provided list of ids is converted to URIs (by merely appending the ids using the
      * {@link UriBuilder#segment(String...)} method) and put in the response as its entity.

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestEnvironments.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestEnvironments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.inventory.rest;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -107,8 +106,8 @@ public class RestEnvironments extends RestBase {
             return Response.status(FORBIDDEN).build();
         }
 
-        inventory.tenants().get(tenantId).environments().create(environmentBlueprint);
-        return ResponseUtil.created(uriInfo, environmentBlueprint.getId()).build();
+        Environment entity = inventory.tenants().get(tenantId).environments().create(environmentBlueprint).entity();
+        return ResponseUtil.created(entity, uriInfo, environmentBlueprint.getId()).build();
     }
 
     @PUT

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestFeeds.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestFeeds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -74,7 +74,7 @@ public class RestFeeds extends RestBase {
         }
 
         Feed feed = inventory.inspect(tenant, Tenants.Single.class).feeds().create(blueprint).entity();
-        return ResponseUtil.created(uriInfo, feed.getId()).entity(feed).build();
+        return ResponseUtil.created(feed, uriInfo, feed.getId()).entity(feed).build();
     }
 
     @GET

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestMetadataPacks.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestMetadataPacks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -79,7 +79,7 @@ public class RestMetadataPacks extends RestBase {
         }
         MetadataPack ret = inventory.tenants().get(tenantId).metadataPacks().create(blueprint).entity();
 
-        return ResponseUtil.created(ui, ret.getId()).entity(ret).build();
+        return ResponseUtil.created(ret, ui, ret.getId()).entity(ret).build();
     }
 
     @PUT

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestMetricTypes.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestMetricTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.inventory.rest;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -137,9 +136,9 @@ public class RestMetricTypes extends RestBase {
             return Response.status(FORBIDDEN).build();
         }
 
-        createMetricType(inventory.inspect(tenant, Tenants.Single.class).metricTypes(), metricType);
+        MetricType entity = createMetricType(inventory.inspect(tenant, Tenants.Single.class).metricTypes(), metricType);
 
-        return ResponseUtil.created(uriInfo, metricType.getId()).build();
+        return ResponseUtil.created(entity, uriInfo, metricType.getId()).build();
     }
 
     @POST
@@ -162,12 +161,12 @@ public class RestMetricTypes extends RestBase {
             return Response.status(FORBIDDEN).build();
         }
 
-        createMetricType(inventory.inspect(feed, Feeds.Single.class).metricTypes(), metricType);
+        MetricType entity = createMetricType(inventory.inspect(feed, Feeds.Single.class).metricTypes(), metricType);
 
-        return ResponseUtil.created(uriInfo, metricType.getId()).build();
+        return ResponseUtil.created(entity, uriInfo, metricType.getId()).build();
     }
 
-    private void createMetricType(MetricTypes.ReadWrite accessInterface, MetricType.Blueprint metricType) {
+    private MetricType createMetricType(MetricTypes.ReadWrite accessInterface, MetricType.Blueprint metricType) {
         if (metricType == null) {
             throw new IllegalArgumentException("metricType to create not specified");
         }
@@ -176,7 +175,7 @@ public class RestMetricTypes extends RestBase {
             throw new IllegalArgumentException("metricType id not specified");
         }
 
-        accessInterface.create(metricType);
+        return accessInterface.create(metricType).entity();
     }
 
     @PUT

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestMetrics.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.inventory.rest;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -80,8 +79,8 @@ public class RestMetrics extends RestBase {
             return Response.status(FORBIDDEN).build();
         }
 
-        createMetric(inventory.inspect(env, Environments.Single.class).metrics(), metric);
-        return ResponseUtil.created(uriInfo, metric.getId()).build();
+        Metric entity = createMetric(inventory.inspect(env, Environments.Single.class).metrics(), metric);
+        return ResponseUtil.created(entity, uriInfo, metric.getId()).build();
     }
 
     @POST
@@ -105,12 +104,12 @@ public class RestMetrics extends RestBase {
             return Response.status(FORBIDDEN).build();
         }
 
-        createMetric(inventory.inspect(feed, Feeds.Single.class).metrics(), metric);
+        Metric entity = createMetric(inventory.inspect(feed, Feeds.Single.class).metrics(), metric);
 
-        return ResponseUtil.created(uriInfo, metric.getId()).build();
+        return ResponseUtil.created(entity, uriInfo, metric.getId()).build();
     }
 
-    private void createMetric(Metrics.ReadWrite accessInterface, Metric.Blueprint metric) {
+    private Metric createMetric(Metrics.ReadWrite accessInterface, Metric.Blueprint metric) {
         if (metric == null) {
             throw new IllegalArgumentException("metric to create not specified");
         }
@@ -123,7 +122,7 @@ public class RestMetrics extends RestBase {
             throw new IllegalArgumentException("metric type id not specified");
         }
 
-        accessInterface.create(metric);
+        return accessInterface.create(metric).entity();
     }
 
     @GET

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestRelationships.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestRelationships.java
@@ -234,14 +234,15 @@ public class RestRelationships extends RestBase {
         }
 
         // link the current entity with the target or the source of the relationship
-        String newId = resolvable.relationships(directed).linkWith(relation.getName(), theOtherSide, relation
-                .getProperties()).entity().getId();
+        Relationship rel = resolvable.relationships(directed).linkWith(relation.getName(), theOtherSide, relation
+                .getProperties()).entity();
+        String newId = rel.getId();
         if (RestApiLogger.LOGGER.isDebugEnabled()) {
             RestApiLogger.LOGGER.debug("creating relationship with id: " + newId + " and name: " +
                                                relation.getName());
         }
 
-        return ResponseUtil.created(uriInfo, newId).build();
+        return ResponseUtil.created(rel, uriInfo, newId).build();
     }
 
     @PUT

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypes.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.inventory.rest;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -106,9 +105,9 @@ public class RestResourceTypes extends RestBase {
             return Response.status(FORBIDDEN).build();
         }
 
-        inventory.tenants().get(tenantId).resourceTypes().create(resourceType);
+        ResourceType entity = inventory.tenants().get(tenantId).resourceTypes().create(resourceType).entity();
 
-        return ResponseUtil.created(uriInfo, resourceType.getId()).build();
+        return ResponseUtil.created(entity, uriInfo, resourceType.getId()).build();
     }
 
     @PUT
@@ -200,9 +199,10 @@ public class RestResourceTypes extends RestBase {
             return Response.status(FORBIDDEN).build();
         }
 
-        inventory.tenants().get(tenantId).feeds().get(feedId).resourceTypes().create(resourceType);
+        ResourceType entity =
+                inventory.tenants().get(tenantId).feeds().get(feedId).resourceTypes().create(resourceType).entity();
 
-        return ResponseUtil.created(uriInfo, resourceType.getId()).build();
+        return ResponseUtil.created(entity, uriInfo, resourceType.getId()).build();
     }
 
     @PUT

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesData.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -190,9 +190,10 @@ public class RestResourceTypesData extends RestBase {
         if (!security.canUpdate(resourceType)) {
             return Response.status(FORBIDDEN).build();
         }
-        inventory.inspect(resourceType, ResourceTypes.Single.class).data().create(blueprint);
+        DataEntity entity =
+                inventory.inspect(resourceType, ResourceTypes.Single.class).data().create(blueprint).entity();
 
-        return ResponseUtil.created(uriInfo, blueprint.getRole().name()).build();
+        return ResponseUtil.created(entity, uriInfo, blueprint.getRole().name()).build();
 
     }
 

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesOperationTypes.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesOperationTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -224,9 +224,10 @@ public class RestResourceTypesOperationTypes extends RestBase {
         if (!security.canUpdate(resourceType)) {
             return Response.status(FORBIDDEN).build();
         }
-        inventory.inspect(resourceType, ResourceTypes.Single.class).operationTypes().create(blueprint);
+        OperationType entity =
+                inventory.inspect(resourceType, ResourceTypes.Single.class).operationTypes().create(blueprint).entity();
 
-        return ResponseUtil.created(uriInfo, blueprint.getId()).build();
+        return ResponseUtil.created(entity, uriInfo, blueprint.getId()).build();
 
     }
 

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesOperationTypesData.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesOperationTypesData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -201,9 +201,10 @@ public class RestResourceTypesOperationTypesData extends RestBase {
         if (!security.canUpdate(operationType)) {
             return Response.status(FORBIDDEN).build();
         }
-        inventory.inspect(operationType, OperationTypes.Single.class).data().create(blueprint);
+        DataEntity entity =
+                inventory.inspect(operationType, OperationTypes.Single.class).data().create(blueprint).entity();
 
-        return ResponseUtil.created(uriInfo, blueprint.getRole().name()).build();
+        return ResponseUtil.created(entity, uriInfo, blueprint.getRole().name()).build();
 
     }
 

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResources.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.inventory.rest;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -94,9 +93,9 @@ public class RestResources extends RestBase {
             return Response.status(FORBIDDEN).build();
         }
 
-        inventory.inspect(env, Environments.Single.class).resources().create(resource);
+        Resource entity = inventory.inspect(env, Environments.Single.class).resources().create(resource).entity();
 
-        return ResponseUtil.created(uriInfo, resource.getId()).build();
+        return ResponseUtil.created(entity, uriInfo, resource.getId()).build();
     }
 
     @POST
@@ -121,9 +120,9 @@ public class RestResources extends RestBase {
             return Response.status(FORBIDDEN).build();
         }
 
-        inventory.inspect(parent, Resources.Single.class).resources().create(resource);
+        Resource entity = inventory.inspect(parent, Resources.Single.class).resources().create(resource).entity();
 
-        return ResponseUtil.created(uriInfo, resource.getId()).build();
+        return ResponseUtil.created(entity, uriInfo, resource.getId()).build();
     }
 
     @POST
@@ -147,9 +146,9 @@ public class RestResources extends RestBase {
             return Response.status(FORBIDDEN).build();
         }
 
-        inventory.inspect(feed, Feeds.Single.class).resources().create(resource);
+        Resource entity = inventory.inspect(feed, Feeds.Single.class).resources().create(resource).entity();
 
-        return ResponseUtil.created(uriInfo, resource.getId()).build();
+        return ResponseUtil.created(entity, uriInfo, resource.getId()).build();
     }
 
     @POST
@@ -174,9 +173,9 @@ public class RestResources extends RestBase {
             return Response.status(FORBIDDEN).build();
         }
 
-        inventory.inspect(parent, Resources.Single.class).resources().create(resource);
+        Resource entity = inventory.inspect(parent, Resources.Single.class).resources().create(resource).entity();
 
-        return ResponseUtil.created(uriInfo, resource.getId()).build();
+        return ResponseUtil.created(entity, uriInfo, resource.getId()).build();
     }
 
     // TODO the is one of the few bits of querying in the API. How should we go about it generally?

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourcesData.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourcesData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.inventory.rest;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -98,9 +97,9 @@ public class RestResourcesData extends RestResources {
         if (!security.canUpdate(resource)) {
             return Response.status(FORBIDDEN).build();
         }
-        inventory.inspect(resource, Resources.Single.class).data().create(configuration);
+        DataEntity entity = inventory.inspect(resource, Resources.Single.class).data().create(configuration).entity();
 
-        return ResponseUtil.created(uriInfo, configuration.getRole().name()).build();
+        return ResponseUtil.created(entity, uriInfo, configuration.getRole().name()).build();
     }
 
     @GET


### PR DESCRIPTION
It should be easier for the REST API consumer to get the canonical path or id of newly created element (entity or relationship).

This assumes the 

``` java
inventory.foo().bar().create().entity()
```

is relatively fast operation (i.e. the newly created entity is in cache)

Although, the bulk insert doesn't use the "small" create endpoints so it has no perf impact on agent discovery.
