### PR TITLE
swager update

### DIFF
--- a/hawkular-inventory-rest-api/pom.xml
+++ b/hawkular-inventory-rest-api/pom.xml
@@ -232,26 +232,32 @@
     </dependency>
 
     <!-- docs -->
-
     <dependency>
-      <groupId>com.wordnik</groupId>
+      <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
+      <version>${version.io.swagger}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-core</artifactId>
+      <version>${version.io.swagger}</version>
       <scope>provided</scope>
     </dependency>
 
     <!-- javadoc requires all the annotations on the classpath -->
-    <dependency>
-      <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.1-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
+    <!--<dependency>-->
+      <!--<groupId>org.hibernate.javax.persistence</groupId>-->
+      <!--<artifactId>hibernate-jpa-2.1-api</artifactId>-->
+      <!--<scope>provided</scope>-->
+    <!--</dependency>-->
 
-    <dependency>
-      <groupId>javax.interceptor</groupId>
-      <artifactId>javax.interceptor-api</artifactId>
-      <version>1.2</version>
-      <scope>provided</scope>
-    </dependency>
+    <!--<dependency>-->
+      <!--<groupId>javax.interceptor</groupId>-->
+      <!--<artifactId>javax.interceptor-api</artifactId>-->
+      <!--<version>1.2</version>-->
+      <!--<scope>provided</scope>-->
+    <!--</dependency>-->
   </dependencies>
 
   <build>
@@ -292,6 +298,10 @@
   <profiles>
     <profile>
       <id>docgen</id>
+      <properties>
+        <restDocDirectory>${project.basedir}/src/main/rest-doc</restDocDirectory>
+        <swaggerDirectory>${project.build.directory}/generated/swagger-ui</swaggerDirectory>
+      </properties>
       <build>
         <!-- Document generation from the Swagger annotations on the REST-API. -->
         <plugins>
@@ -301,13 +311,14 @@
             <configuration>
               <apiSources>
                 <apiSource>
+                  <springmvc>false</springmvc>
                   <locations>org.hawkular.inventory.rest</locations>
-                  <apiVersion>0.1</apiVersion>
-                  <basePath>http://localhost:8080/hawkular/inventory</basePath>
-                  <outputTemplate>https://raw.githubusercontent.com/hawkular/hawkular.github.io/swagger/asciidoc.mustache</outputTemplate>
-                  <swaggerDirectory>${project.build.directory}/generated/swagger-ui</swaggerDirectory>
-                  <swaggerApiReader>com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader</swaggerApiReader>
-                  <outputPath>${project.build.directory}/generated/rest-inventory.adoc</outputPath>
+                  <basePath>/hawkular/inventory</basePath>
+                  <info>
+                    <title>Hawkular Inventory</title>
+                    <version>0.1</version>
+                  </info>
+                  <swaggerDirectory>${swaggerDirectory}</swaggerDirectory>
                 </apiSource>
               </apiSources>
             </configuration>
@@ -316,6 +327,36 @@
                 <phase>compile</phase>
                 <goals>
                   <goal>generate</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.gmavenplus</groupId>
+            <artifactId>gmavenplus-plugin</artifactId>
+            <dependencies>
+              <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>${version.org.codehaus.groovy}</version>
+              </dependency>
+            </dependencies>
+            <configuration>
+              <properties>
+                <baseFile>${restDocDirectory}/base.adoc</baseFile>
+                <swaggerFile>${swaggerDirectory}/swagger.json</swaggerFile>
+                <outputFile>${project.build.directory}/generated/rest-inventory.adoc</outputFile>
+              </properties>
+              <scripts>
+                <script>file:///${restDocDirectory}/apidoc.groovy</script>
+              </scripts>
+            </configuration>
+            <executions>
+              <execution>
+                <id>generate-api-doc</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>execute</goal>
                 </goals>
               </execution>
             </executions>

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/PingHandler.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/PingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,12 +26,15 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
-import com.wordnik.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
 
 /**
  * @author Stefan Negrea
  */
 @Path("/ping")
+@Api(value = "/ping", description = "Ping", tags = "Ping")
 public class PingHandler {
 
     @GET

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestBulk.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestBulk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,11 +73,11 @@ import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.api.model.ResourceType;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 /**
  * @author Lukas Krejci
@@ -86,7 +86,7 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @javax.ws.rs.Path("/bulk")
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
-@Api(value = "/bulk", description = "Endpoint for bulk operations on inventory entities")
+@Api(value = "/bulk", description = "Endpoint for bulk operations on inventory entities", tags = "Bulk Create")
 public class RestBulk extends RestBase {
 
     private static CanonicalPath canonicalize(String path, CanonicalPath rootPath) {

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestEnvironments.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestEnvironments.java
@@ -40,11 +40,11 @@ import org.hawkular.inventory.api.model.Environment;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.rest.json.ApiError;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 /**
  * @author Lukas Krejci
@@ -53,7 +53,7 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @Path("/")
 @Produces(value = APPLICATION_JSON)
 @Consumes(value = APPLICATION_JSON)
-@Api(value = "/", description = "CRUD of environments.")
+@Api(value = "/", description = "CRUD of environments.", tags = "Environments")
 public class RestEnvironments extends RestBase {
 
     @GET

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestEnvironmentsFeeds.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestEnvironmentsFeeds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,11 +46,11 @@ import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.rest.json.ApiError;
 import org.hawkular.inventory.rest.security.EntityIdUtils;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 /**
  * @author Lukas Krejci
@@ -59,7 +59,7 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @javax.ws.rs.Path("/")
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
-@Api(value = "/", description = "Manages associations between environments and feeds")
+@Api(value = "/", description = "Manages associations between environments and feeds", tags = "Environments Feeds")
 public class RestEnvironmentsFeeds extends RestBase {
 
     @POST

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestEvents.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.inventory.rest;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -43,11 +42,10 @@ import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.rest.json.ApiError;
 import org.hawkular.inventory.rest.security.SecurityIntegration;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
-
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import rx.Subscription;
 import rx.functions.Func1;
 
@@ -57,7 +55,7 @@ import rx.functions.Func1;
 @Path("/events")
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
-@Api(value = "/events", description = "Work with the events emitted by inventory")
+@Api(value = "/events", description = "Work with the events emitted by inventory", tags = "Events")
 public class RestEvents extends RestBase {
 
     @Inject
@@ -67,11 +65,11 @@ public class RestEvents extends RestBase {
     @Path("/")
     @ApiOperation("Listen on stream of the events")
     @ApiResponses({
-                          @ApiResponse(code = 200, message = "OK"),
-                          @ApiResponse(code = 401, message = "Unauthorized access"),
-                          @ApiResponse(code = 404, message = "Tenant doesn't exist", response = ApiError.class),
-                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
-                  })
+            @ApiResponse(code = 200, message = "OK"),
+            @ApiResponse(code = 401, message = "Unauthorized access"),
+            @ApiResponse(code = 404, message = "Tenant doesn't exist", response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+    })
     public void getEvents(@Suspended AsyncResponse asyncResponse,
                           @QueryParam("type") @DefaultValue("resource") String type,
                           @QueryParam("action") @DefaultValue("created") String actionString) {

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestFeeds.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestFeeds.java
@@ -41,9 +41,10 @@ import org.hawkular.inventory.api.model.Feed;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.rest.json.ApiError;
 
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 /**
  * @author Lukas Krejci
@@ -52,6 +53,7 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @Path("/")
 @Produces(value = APPLICATION_JSON)
 @Consumes(value = APPLICATION_JSON)
+@Api(value = "/", description = "CRUD of feeds", tags = "Feeds")
 public class RestFeeds extends RestBase {
 
     @POST
@@ -118,8 +120,7 @@ public class RestFeeds extends RestBase {
     @ApiResponses({
             @ApiResponse(code = 204, message = "OK"),
             @ApiResponse(code = 401, message = "Unauthorized access"),
-            @ApiResponse(code = 404, message = "Environment or the feed doesn't exist",
-                    response = ApiError.class),
+            @ApiResponse(code = 404, message = "Environment or the feed doesn't exist", response = ApiError.class),
             @ApiResponse(code = 400, message = "The update failed because of invalid data"),
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })
@@ -141,8 +142,7 @@ public class RestFeeds extends RestBase {
     @ApiResponses({
             @ApiResponse(code = 204, message = "OK"),
             @ApiResponse(code = 401, message = "Unauthorized access"),
-            @ApiResponse(code = 404, message = "Environment or the feed doesn't exist",
-                    response = ApiError.class),
+            @ApiResponse(code = 404, message = "Environment or the feed doesn't exist", response = ApiError.class),
             @ApiResponse(code = 400, message = "The delete failed because it would make inventory invalid"),
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestGraphSON.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestGraphSON.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.inventory.rest;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -29,10 +28,10 @@ import javax.ws.rs.core.Response;
 
 import org.hawkular.inventory.rest.json.ApiError;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 /**
  * @author Jirka Kremser
@@ -41,7 +40,7 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @Path("/graph")
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
-@Api(value = "/graph", description = "Retrieves whole graph in the JSON representation.")
+@Api(value = "/graph", description = "Retrieves whole graph in the JSON representation.", tags = "Graph")
 public class RestGraphSON extends RestBase {
 
     @GET

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestMetadataPacks.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestMetadataPacks.java
@@ -36,11 +36,11 @@ import org.hawkular.inventory.api.model.Feed;
 import org.hawkular.inventory.api.model.MetadataPack;
 import org.hawkular.inventory.rest.json.ApiError;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 /**
  * @author Lukas Krejci
@@ -49,7 +49,7 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @Path("/metadatapacks")
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
-@Api(value = "/metadatapacks", description = "CRUD for the metadata packs.")
+@Api(value = "/metadatapacks", description = "CRUD for the metadata packs.", tags = "Metadata packs")
 public class RestMetadataPacks extends RestBase {
 
     @GET

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestMetricTypes.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestMetricTypes.java
@@ -44,11 +44,11 @@ import org.hawkular.inventory.api.model.MetricType;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.rest.json.ApiError;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 /**
  * @author Lukas Krejci
@@ -57,7 +57,7 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @Path("/")
 @Produces(value = APPLICATION_JSON)
 @Consumes(value = APPLICATION_JSON)
-@Api(value = "/", description = "Metric types CRUD")
+@Api(value = "/", description = "Metric types CRUD", tags = "MetricTypes")
 public class RestMetricTypes extends RestBase {
 
     @GET

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestMetrics.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestMetrics.java
@@ -42,11 +42,11 @@ import org.hawkular.inventory.api.model.Metric;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.rest.json.ApiError;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 /**
  * @author Lukas Krejci
@@ -55,7 +55,7 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @Path("/")
 @Produces(value = APPLICATION_JSON)
 @Consumes(value = APPLICATION_JSON)
-@Api(value = "/", description = "Metrics CRUD")
+@Api(value = "/", description = "Metrics CRUD", tags = "Metrics")
 public class RestMetrics extends RestBase {
 
     @POST
@@ -131,8 +131,7 @@ public class RestMetrics extends RestBase {
     @ApiResponses({
             @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 401, message = "Unauthorized access"),
-            @ApiResponse(code = 404, message = "Rnvironment or metrics doesn't exist",
-                    response = ApiError.class),
+            @ApiResponse(code = 404, message = "Rnvironment or metrics doesn't exist", response = ApiError.class),
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })
     public Metric getMetric(@PathParam("environmentId") String environmentId,
@@ -148,8 +147,7 @@ public class RestMetrics extends RestBase {
     @ApiResponses({
             @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 401, message = "Unauthorized access"),
-            @ApiResponse(code = 404, message = "Environment, feed or metric doesn't exist",
-                    response = ApiError.class),
+            @ApiResponse(code = 404, message = "Environment, feed or metric doesn't exist", response = ApiError.class),
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })
     public Metric getMetricInFeed(@PathParam("feedId") String feedId,
@@ -164,8 +162,7 @@ public class RestMetrics extends RestBase {
     @ApiResponses({
             @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 401, message = "Unauthorized access"),
-            @ApiResponse(code = 404, message = "Tenant or environment doesn't exist",
-                    response = ApiError.class),
+            @ApiResponse(code = 404, message = "Tenant or environment doesn't exist", response = ApiError.class),
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })
     public Response getMetrics(@PathParam("environmentId") String environmentId,
@@ -187,8 +184,7 @@ public class RestMetrics extends RestBase {
     @ApiResponses({
             @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 401, message = "Unauthorized access"),
-            @ApiResponse(code = 404, message = "Tenant, environment or feed doesn't exist",
-                    response = ApiError.class),
+            @ApiResponse(code = 404, message = "Tenant, environment or feed doesn't exist", response = ApiError.class),
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })
     public Response getMetrics(@PathParam("feedId") String feedId, @Context UriInfo uriInfo) {
@@ -282,8 +278,7 @@ public class RestMetrics extends RestBase {
     @ApiOperation("Deletes a metric")
     @ApiResponses({
             @ApiResponse(code = 204, message = "OK"),
-            @ApiResponse(code = 404, message = "Tenant, feed or the metric doesn't exist",
-                    response = ApiError.class),
+            @ApiResponse(code = 404, message = "Tenant, feed or the metric doesn't exist", response = ApiError.class),
             @ApiResponse(code = 400, message = "The delete failed because it would make inventory invalid"),
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestPath.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,10 +47,11 @@ import org.hawkular.inventory.rest.json.ApiError;
 import org.hawkular.inventory.rest.json.JsonLd;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 /**
  * @author Lukas Krejci
@@ -59,7 +60,8 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @Path("/path")
 @Produces(value = APPLICATION_JSON)
 @Consumes(value = APPLICATION_JSON)
-@Api(value = "/path", description = "The endpoint to obtain inventory entities by their canonical path.")
+@Api(value = "/path", description = "The endpoint to obtain inventory entities by their canonical path.",
+        tags = "CanonicalPath")
 public class RestPath extends RestBase {
 
     @Context

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestPing.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestPing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,6 +41,8 @@ import org.jboss.resteasy.core.ResourceInvoker;
 import org.jboss.resteasy.core.ResourceMethodInvoker;
 import org.jboss.resteasy.core.ResourceMethodRegistry;
 
+import io.swagger.annotations.Api;
+
 /**
  * @author Lukas Krejci
  * @since 1.0
@@ -48,6 +50,7 @@ import org.jboss.resteasy.core.ResourceMethodRegistry;
 @Path("/")
 @Produces(value = APPLICATION_JSON)
 @Consumes(value = APPLICATION_JSON)
+@Api(value = "/", tags = "REST API Endpoints")
 public class RestPing {
 
     @Context

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestRelationships.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestRelationships.java
@@ -67,11 +67,12 @@ import org.hawkular.inventory.rest.security.EntityIdUtils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 /**
  * @author Jiri Kremser
@@ -80,7 +81,7 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @Path("/")
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
-@Api(value = "/.*/relationships", description = "Work with the relationships.")
+@Api(value = "/.*/relationships", description = "Work with the relationships.", tags = "Relationships")
 public class RestRelationships extends RestBase {
 
     public static Map<String, Class<? extends Entity<?, ?>>> entityMap;
@@ -111,8 +112,7 @@ public class RestRelationships extends RestBase {
     @ApiOperation("Retrieves relationships")
     @ApiResponses({
             @ApiResponse(code = 200, message = "The list of relationships"),
-            @ApiResponse(code = 404, message = "Accompanying entity doesn't exist", response = ApiError
-                    .class),
+            @ApiResponse(code = 404, message = "Accompanying entity doesn't exist", response = ApiError.class),
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })
     public Response get(@PathParam("path") String path,
@@ -150,8 +150,7 @@ public class RestRelationships extends RestBase {
     @ApiOperation("Retrieves relationship info")
     @ApiResponses({
         @ApiResponse(code = 200, message = "The details of relationship"),
-        @ApiResponse(code = 404, message = "Accompanying entity doesn't exist", response = ApiError
-            .class),
+        @ApiResponse(code = 404, message = "Accompanying entity doesn't exist", response = ApiError.class),
         @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })
     public Response getRelationship(@PathParam("relationshipId") String relationshipId,
@@ -168,8 +167,7 @@ public class RestRelationships extends RestBase {
     @ApiOperation("Deletes a relationship")
     @ApiResponses({
             @ApiResponse(code = 200, message = "The list of relationships"),
-            @ApiResponse(code = 404, message = "Accompanying entity doesn't exist", response = ApiError
-                    .class),
+            @ApiResponse(code = 404, message = "Accompanying entity doesn't exist", response = ApiError.class),
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })
     public Response delete(@PathParam("path") String path,
@@ -200,8 +198,7 @@ public class RestRelationships extends RestBase {
     @ApiResponses({
             @ApiResponse(code = 201, message = "OK"),
             @ApiResponse(code = 400, message = "Invalid input data", response = ApiError.class),
-            @ApiResponse(code = 404, message = "Accompanying entity doesn't exist", response =
-                    ApiError.class),
+            @ApiResponse(code = 404, message = "Accompanying entity doesn't exist", response = ApiError.class),
             @ApiResponse(code = 409, message = "Relationship already exists", response = ApiError.class),
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })
@@ -251,8 +248,7 @@ public class RestRelationships extends RestBase {
     @ApiResponses({
             @ApiResponse(code = 204, message = "OK"),
             @ApiResponse(code = 400, message = "Invalid input data", response = ApiError.class),
-            @ApiResponse(code = 404, message = "Accompanying entity doesn't exist", response =
-                    ApiError.class),
+            @ApiResponse(code = 404, message = "Accompanying entity doesn't exist", response = ApiError.class),
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })
     public Response update(@PathParam("path") String path,

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypes.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypes.java
@@ -42,11 +42,12 @@ import org.hawkular.inventory.api.model.ResourceType;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.rest.json.ApiError;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
 
 /**
  * @author Lukas Krejci
@@ -55,7 +56,7 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @Path("/")
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
-@Api(value = "/", description = "Resource type CRUD")
+@Api(value = "/", description = "Resource type CRUD", tags = "ResourceTypes")
 public class RestResourceTypes extends RestBase {
 
     @GET

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesData.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesData.java
@@ -38,11 +38,12 @@ import org.hawkular.inventory.api.model.CanonicalPath;
 import org.hawkular.inventory.api.model.DataEntity;
 import org.hawkular.inventory.rest.json.ApiError;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
 
 /**
  * @author Lukas Krejci
@@ -51,7 +52,7 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @Path("/")
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
-@Api(value = "/", description = "CRUD for resource type data")
+@Api(value = "/", description = "CRUD for resource type data", tags = "ResourceTypes Data")
 public class RestResourceTypesData extends RestBase {
 
     @POST

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesMetricTypes.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesMetricTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,11 +46,12 @@ import org.hawkular.inventory.api.model.ResourceType;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.rest.json.ApiError;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
 
 /**
  * @author Lukas Krejci
@@ -59,7 +60,8 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @Path("/")
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
-@Api(value = "/", description = "Manages associations between resource types and metric types")
+@Api(value = "/", description = "Manages associations between resource types and metric types",
+        tags = "ResourceTypes MetricTypes")
 public class RestResourceTypesMetricTypes extends RestBase {
 
     @GET

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesOperationTypes.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesOperationTypes.java
@@ -40,11 +40,12 @@ import org.hawkular.inventory.api.model.OperationType;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.rest.json.ApiError;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
 
 /**
  * @author Lukas Krejci
@@ -53,7 +54,8 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @Path("/")
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
-@Api(value = "/", description = "Manages associations between resource types and metric types")
+@Api(value = "/", description = "Manages associations between resource types and metric types",
+        tags = "ResourceTypes OperationTypes")
 public class RestResourceTypesOperationTypes extends RestBase {
     @POST
     @javax.ws.rs.Path("/resourceTypes/{resourceTypeId}/operationTypes")

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesOperationTypesData.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesOperationTypesData.java
@@ -38,11 +38,12 @@ import org.hawkular.inventory.api.model.CanonicalPath;
 import org.hawkular.inventory.api.model.DataEntity;
 import org.hawkular.inventory.rest.json.ApiError;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
 
 /**
  * @author Lukas Krejci
@@ -51,15 +52,15 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @Path("/")
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
-@Api(value = "/", description = "CRUD for operation type data")
+@Api(value = "/", description = "CRUD for operation type data",
+        tags = "ResourceTypes OperationTypes Data")
 public class RestResourceTypesOperationTypesData extends RestBase {
     @POST
     @javax.ws.rs.Path("/resourceTypes/{resourceTypeId}/operationTypes/{operationTypeId}/data")
     @ApiOperation("Creates the configuration for pre-existing resource type")
     @ApiResponses({
             @ApiResponse(code = 204, message = "OK Created"),
-            @ApiResponse(code = 404, message = "Tenant or resource type doesn't exist",
-                    response = ApiError.class),
+            @ApiResponse(code = 404, message = "Tenant or resource type doesn't exist", response = ApiError.class),
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })
     public Response createConfiguration(@PathParam("resourceTypeId") String resourceType,
@@ -95,8 +96,7 @@ public class RestResourceTypesOperationTypesData extends RestBase {
     @ApiOperation("Updates the configuration of a resource type")
     @ApiResponses({
             @ApiResponse(code = 204, message = "OK"),
-            @ApiResponse(code = 404, message = "Tenant, or resource type doesn't exist",
-                    response = ApiError.class),
+            @ApiResponse(code = 404, message = "Tenant, or resource type doesn't exist", response = ApiError.class),
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })
     public Response updateData(@PathParam("resourceTypeId") String resourceType,
@@ -132,8 +132,7 @@ public class RestResourceTypesOperationTypesData extends RestBase {
     @ApiOperation("Updates the configuration of a resource type")
     @ApiResponses({
             @ApiResponse(code = 204, message = "OK"),
-            @ApiResponse(code = 404, message = "Tenant, or resource type doesn't exist",
-                    response = ApiError.class),
+            @ApiResponse(code = 404, message = "Tenant, or resource type doesn't exist", response = ApiError.class),
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })
     public Response deleteData(@PathParam("resourceTypeId") String resourceType,

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesResources.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourceTypesResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,10 +34,11 @@ import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.rest.json.ApiError;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
 
 /**
  * @author Lukas Krejci
@@ -46,7 +47,8 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @Path("/")
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
-@Api(value = "/", description = "Manages associations between resource types and resources")
+@Api(value = "/", description = "Manages associations between resource types and resources",
+        tags = "ResourceTypes Resources")
 public class RestResourceTypesResources extends RestBase {
 
     @GET

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResources.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResources.java
@@ -56,11 +56,12 @@ import org.hawkular.inventory.api.paging.Pager;
 import org.hawkular.inventory.rest.filters.ResourceFilters;
 import org.hawkular.inventory.rest.json.ApiError;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
 
 /**
  * @author Lukas Krejci
@@ -69,7 +70,7 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @javax.ws.rs.Path("/")
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
-@Api(value = "/", description = "Resources CRUD")
+@Api(value = "/", description = "Resources CRUD", tags = "Resources")
 public class RestResources extends RestBase {
 
     @POST
@@ -83,7 +84,7 @@ public class RestResources extends RestBase {
             @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
     })
     public Response addResource(@PathParam("environmentId") String environmentId,
-            @ApiParam(required = true) Resource.Blueprint resource, @Context UriInfo uriInfo) {
+                                @ApiParam(required = true) Resource.Blueprint resource, @Context UriInfo uriInfo) {
 
         String tenantId = getTenantId();
 
@@ -439,7 +440,8 @@ public class RestResources extends RestBase {
             "the child will no longer be considered a child of the resource, otherwise an error will be returned.")
     @ApiResponses({
             @ApiResponse(code = 204, message = "OK"),
-            @ApiResponse(code = 404, message = "environment, the parent resource or the child resource not found"),
+            @ApiResponse(code = 404, message = "environment, the parent resource or the child resource not found",
+                    response = ApiError.class),
             @ApiResponse(code = 500, message = "Internal server error", response = ApiError.class)
     })
     public Response disassociateChild(@PathParam("environmentId") String environmentId,
@@ -470,8 +472,7 @@ public class RestResources extends RestBase {
             "the child will no longer be considered a child of the resource, otherwise an error will be returned.")
     @ApiResponses({
             @ApiResponse(code = 204, message = "OK"),
-            @ApiResponse(code = 404, message = "feed, the parent resource or the child resource not " +
-                    "found"),
+            @ApiResponse(code = 404, message = "feed, the parent resource or the child resource not found"),
             @ApiResponse(code = 500, message = "Internal server error", response = ApiError.class)
     })
     public Response disassociateChildInFeed(@PathParam("feedId") String feedId,

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourcesData.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourcesData.java
@@ -38,11 +38,12 @@ import org.hawkular.inventory.api.model.CanonicalPath;
 import org.hawkular.inventory.api.model.DataEntity;
 import org.hawkular.inventory.rest.json.ApiError;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
 
 /**
  * @author Jirka Kremser
@@ -51,17 +52,17 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @javax.ws.rs.Path("/")
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
-@Api(value = "/", description = "Resource Data CRUD")
+@Api(value = "/", description = "Resource Data CRUD", tags = "Resources Data")
 public class RestResourcesData extends RestResources {
 
     @POST
     @javax.ws.rs.Path("/feeds/{feedId}/resources/{resourcePath:.+}/data")
     @ApiOperation("Creates the configuration for pre-existing resource")
     @ApiResponses({
-                          @ApiResponse(code = 204, message = "OK Created"),
-                          @ApiResponse(code = 404, message = "Tenant, environment, resource or feed doesn't exist",
-                                       response = ApiError.class),
-                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+            @ApiResponse(code = 204, message = "OK Created"),
+            @ApiResponse(code = 404, message = "Tenant, environment, resource or feed doesn't exist",
+                    response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
                   })
     public Response createConfigurationF(@PathParam("feedId") String feedId,
                                          @Encoded @PathParam("resourcePath") String resourcePath,
@@ -76,10 +77,10 @@ public class RestResourcesData extends RestResources {
     @javax.ws.rs.Path("/{environmentId}/resources/{resourcePath:.+}/data")
     @ApiOperation("Creates the configuration for pre-existing resource")
     @ApiResponses({
-                          @ApiResponse(code = 204, message = "OK Created"),
-                          @ApiResponse(code = 404, message = "Tenant, environment or resource doesn't exist",
-                                       response = ApiError.class),
-                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+            @ApiResponse(code = 204, message = "OK Created"),
+            @ApiResponse(code = 404, message = "Tenant, environment or resource doesn't exist",
+                    response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
                   })
     public Response createConfiguration(@PathParam("environmentId") String environmentId,
             @Encoded @PathParam("resourcePath") String resourcePath,
@@ -106,11 +107,11 @@ public class RestResourcesData extends RestResources {
     @javax.ws.rs.Path("/feeds/{feedId}/resources/{resourcePath:.+}/data")
     @ApiOperation("Retrieves the configuration of a resource")
     @ApiResponses({
-                          @ApiResponse(code = 204, message = "OK"),
-                          @ApiResponse(code = 404, message = "Tenant, environment, resource or feed doesn't exist",
-                                       response = ApiError.class),
-                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
-                  })
+            @ApiResponse(code = 204, message = "OK"),
+            @ApiResponse(code = 404, message = "Tenant, environment, resource or feed doesn't exist",
+                    response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+    })
     public Response getConfigurationF(@PathParam("feedId") String feedId,
                                       @Encoded @PathParam("resourcePath") String resourcePath,
                                       @DefaultValue("configuration") @QueryParam("dataType")
@@ -123,11 +124,11 @@ public class RestResourcesData extends RestResources {
     @javax.ws.rs.Path("/{environmentId}/resources/{resourcePath:.+}/data")
     @ApiOperation("Retrieves the configuration of a resource")
     @ApiResponses({
-                          @ApiResponse(code = 204, message = "OK"),
-                          @ApiResponse(code = 404, message = "Tenant, environment or resource doesn't exist",
-                                       response = ApiError.class),
-                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
-                  })
+            @ApiResponse(code = 204, message = "OK"),
+            @ApiResponse(code = 404, message = "Tenant, environment or resource doesn't exist",
+                    response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+    })
     public Response getConfiguration(@PathParam("environmentId") String environmentId,
                                      @Encoded @PathParam("resourcePath") String resourcePath,
                                      @DefaultValue("configuration") @QueryParam("dataType") Resources.DataRole dataType)
@@ -150,11 +151,11 @@ public class RestResourcesData extends RestResources {
     @javax.ws.rs.Path("/feeds/{feedId}/resources/{resourcePath:.+}/data")
     @ApiOperation("Updates the configuration of a resource")
     @ApiResponses({
-                          @ApiResponse(code = 204, message = "OK"),
-                          @ApiResponse(code = 404, message = "Tenant, environment, resource or feed doesn't exist",
-                                       response = ApiError.class),
-                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
-                  })
+            @ApiResponse(code = 204, message = "OK"),
+            @ApiResponse(code = 404, message = "Tenant, environment, resource or feed doesn't exist",
+                    response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+    })
     public Response updateConfigurationF(@PathParam("feedId") String feedId,
                                          @Encoded @PathParam("resourcePath") String resourcePath,
                                          @DefaultValue("configuration") @QueryParam("dataType")
@@ -168,10 +169,10 @@ public class RestResourcesData extends RestResources {
     @javax.ws.rs.Path("/{environmentId}/resources/{resourcePath:.+}/data")
     @ApiOperation("Updates the configuration of a resource")
     @ApiResponses({
-                          @ApiResponse(code = 204, message = "OK"),
-                          @ApiResponse(code = 404, message = "Tenant, environment or resource doesn't exist",
-                                       response = ApiError.class),
-                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+            @ApiResponse(code = 204, message = "OK"),
+            @ApiResponse(code = 404, message = "Tenant, environment or resource doesn't exist",
+                    response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
                   })
     public Response updateConfiguration(@PathParam("environmentId") String environmentId,
                                         @Encoded @PathParam("resourcePath") String resourcePath,
@@ -196,11 +197,11 @@ public class RestResourcesData extends RestResources {
     @javax.ws.rs.Path("/feeds/{feedId}/resources/{resourcePath:.+}/data")
     @ApiOperation("Deletes the configuration of a resource")
     @ApiResponses({
-                          @ApiResponse(code = 204, message = "OK"),
-                          @ApiResponse(code = 404, message = "Tenant, environment, resource or feed doesn't exist",
-                                       response = ApiError.class),
-                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
-                  })
+            @ApiResponse(code = 204, message = "OK"),
+            @ApiResponse(code = 404, message = "Tenant, environment, resource or feed doesn't exist",
+                    response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+    })
     public Response deleteConfigurationF(@PathParam("feedId") String feedId,
                                          @Encoded @PathParam("resourcePath") String resourcePath,
                                          @DefaultValue("configuration") @QueryParam("dataType")
@@ -213,11 +214,11 @@ public class RestResourcesData extends RestResources {
     @javax.ws.rs.Path("/{environmentId}/resources/{resourcePath:.+}/data")
     @ApiOperation("Deletes the configuration of a resource")
     @ApiResponses({
-                          @ApiResponse(code = 204, message = "OK"),
-                          @ApiResponse(code = 404, message = "Tenant, environment or resource doesn't exist",
-                                       response = ApiError.class),
-                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
-                  })
+            @ApiResponse(code = 204, message = "OK"),
+            @ApiResponse(code = 404, message = "Tenant, environment or resource doesn't exist",
+                    response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+    })
     public Response deleteConfiguration(@PathParam("environmentId") String environmentId,
                                         @Encoded @PathParam("resourcePath") String resourcePath,
                                         @DefaultValue("configuration") @QueryParam("dataType")

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourcesMetrics.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestResourcesMetrics.java
@@ -48,11 +48,12 @@ import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.rest.json.ApiError;
 import org.hawkular.inventory.rest.security.EntityIdUtils;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
 
 /**
  * @author Lukas Krejci
@@ -61,7 +62,7 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @javax.ws.rs.Path("/")
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
-@Api(value = "/", description = "Resource Metrics CRUD")
+@Api(value = "/", description = "Resource Metrics CRUD", tags = "Resources Metrics")
 public class RestResourcesMetrics extends RestResources {
 
     @POST

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestTenants.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestTenants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.inventory.rest;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -37,11 +36,12 @@ import org.hawkular.inventory.api.model.CanonicalPath;
 import org.hawkular.inventory.api.model.Tenant;
 import org.hawkular.inventory.rest.json.ApiError;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
 
 /**
  * @author Lukas Krejci
@@ -50,7 +50,7 @@ import com.wordnik.swagger.annotations.ApiResponses;
 @Path("/tenant")
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
-@Api(value = "/tenant", description = "Work with the tenant of the current persona")
+@Api(value = "/tenant", description = "Work with the tenant of the current persona", tags = "Tenants")
 public class RestTenants extends RestBase {
 
     @Inject
@@ -74,11 +74,11 @@ public class RestTenants extends RestBase {
     @Path("/relationships")
     @ApiOperation("Retrieves tenant's relationships")
     @ApiResponses({
-                          @ApiResponse(code = 200, message = "OK"),
-                          @ApiResponse(code = 401, message = "Unauthorized access"),
-                          @ApiResponse(code = 404, message = "Tenant doesn't exist", response = ApiError.class),
-                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
-                  })
+            @ApiResponse(code = 200, message = "OK"),
+            @ApiResponse(code = 401, message = "Unauthorized access"),
+            @ApiResponse(code = 404, message = "Tenant doesn't exist", response = ApiError.class),
+            @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+    })
     public Response getTenantRelationships(@DefaultValue("both") @QueryParam("direction") String direction,
                                            @DefaultValue("") @QueryParam("property") String propertyName,
                                            @DefaultValue("") @QueryParam("propertyValue") String propertyValue,

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/json/ApiError.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/json/ApiError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,8 +20,11 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.wordnik.swagger.annotations.ApiModel;
-import com.wordnik.swagger.annotations.ApiModelProperty;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+//import io.swagger.annotations.ApiModelProperty;
 
 /**
  * Return information what failed in the REST-call.

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/json/Link.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/json/Link.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,8 +22,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.wordnik.swagger.annotations.ApiModel;
-import com.wordnik.swagger.annotations.ApiModelProperty;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 
 /**
  * A link between two resources

--- a/hawkular-inventory-rest-api/src/main/rest-doc/apidoc.groovy
+++ b/hawkular-inventory-rest-api/src/main/rest-doc/apidoc.groovy
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.util.Map.Entry
+
+import groovy.json.JsonSlurper
+
+def baseFile = new File(baseFile)
+if (!baseFile.canRead()) throw new RuntimeException("${baseFile.path} is not readable")
+
+def swaggerFile = new File(swaggerFile)
+if (!swaggerFile.canRead()) throw new RuntimeException("${swaggerFile.path} is not readable")
+
+def jsonSlurper = new JsonSlurper()
+def swagger = jsonSlurper.parse(swaggerFile)
+
+def apidocFile = new File(outputFile)
+
+baseFile.withInputStream { stream ->
+  apidocFile.append(stream)
+}
+
+apidocFile.withWriterAppend('UTF-8') { writer ->
+
+  writer.println """
+
+== Base Path
+`${swagger.basePath}`
+
+== REST APIs
+
+"""
+  swagger.tags.sort { t1, t2 -> t1.name.compareTo(t2.name) }.each { tag ->
+    writer.println "=== ${tag.name}"
+
+    swagger.paths.sort { p1, p2 -> p1.key.compareTo(p2.key) }.each { Entry path ->
+      path.value.each { Entry method ->
+        if (method.value.tags.contains(tag.name)) {
+          writeEndpointLink(writer, path, method)
+        }
+      }
+    }
+
+    swagger.paths.sort { p1, p2 -> p1.key.compareTo(p2.key) }.each { Entry path ->
+      path.value.each { Entry method ->
+        if (method.value.tags.contains(tag.name)) {
+
+          writeEndpointHeader(writer, path, method)
+
+          def params = (method.value.parameters ?: []).findAll { it.schema?.$ref != '#/definitions/AsyncResponse' }
+          writeParams(writer, 'Path', params.findAll { it.in == 'path' })
+          writeParams(writer, 'Query', params.findAll { it.in == 'query' })
+          writeBodyParams(writer, params.findAll { it.in == 'body' })
+
+          writeResponses(writer, method.value.responses ?: [:])
+
+          writeEndpointFooter(writer)
+        }
+      }
+    }
+  }
+  writer.println '''== Data Types
+
+'''
+
+  writeDataTypes(writer, swagger.definitions ?: [:])
+}
+
+private writeEndpointLink(Writer writer, Entry path, Entry method) {
+  def summary = method.value.summary.trim()
+  String endpoint = path.key
+  def httpMethod = method.key.toUpperCase()
+  Object anchor = getEndpointAnchor(httpMethod, endpoint)
+
+  writer.println ". link:#++${anchor}++[${summary}]"
+}
+
+def String getEndpointAnchor(def httpMethod, String endpoint) {
+  def anchor = httpMethod + '_' + endpoint.replace('/', '_').replace('{', '_').replace('}', '_')
+  anchor
+}
+
+private writeEndpointHeader(Writer writer, Entry path, Entry method) {
+  def summary = method.value.summary.trim()
+  def description = method.value.description?.trim()
+  String endpoint = path.key
+  def httpMethod = method.key.toUpperCase()
+  def anchor = getEndpointAnchor(httpMethod, endpoint)
+
+  writer.println """
+
+==============================================
+
+[[${anchor}]]
+*Endpoint ${httpMethod} `${endpoint}`*
+
+NOTE: *${summary}* +
+${description ? "_${description}_" : ''}
+
+"""
+}
+
+def writeParams(Writer writer, String paramType, List params) {
+  if (!params.empty) {
+    writer.println """
+*${paramType} parameters*
+
+[cols="15,^10,35,^15,^10,^15", options="header"]
+|=======================
+|Parameter|Required|Description|Type|Format|Allowable Values
+"""
+    params.each { param ->
+      def name = param.name
+      def required = required(param.required)
+      def description = param.description ?: '-'
+      def type = param.type
+      def format = param.format ?: '-'
+      def allowableValues = allowableValues(param.enum)
+      writer.println "|${name}|${required}|${description}|${type}|${format}|${allowableValues}"
+    }
+    writer.println '''
+|=======================
+
+'''
+  }
+}
+
+def writeBodyParams(Writer writer, List params) {
+  if (!params.empty) {
+    writer.println """
+*Body*
+
+[cols="^20,55,^25", options="header"]
+|=======================
+|Required|Description|Data Type
+"""
+    params.each { param ->
+      def schema = param.schema ?: [:]
+      def required = required(param.required)
+      def description = param.description ?: '-'
+      writer.println "|${required}|${description}|${schemaToType(schema)}"
+    }
+    writer.println """
+|=======================
+
+"""
+  }
+}
+
+def void writeResponses(Writer writer, Map responses) {
+  if (!responses.empty) {
+    writer.println """
+*Response*
+
+*Status codes*
+[cols="^20,55,^25", options="header"]
+|=======================
+|Status Code|Reason|Response Model
+"""
+    responses.each { Entry response ->
+      def code = response.key
+      def description = response.value.description ?: '-'
+      def schema = response.value.schema ?: [:]
+      writer.println "|${code}|${description}|${schemaToType(schema)}"
+    }
+    writer.println """
+|=======================
+
+"""
+  }
+}
+
+def writeEndpointFooter(Writer writer) {
+  writer.println """
+==============================================
+
+"""
+}
+
+def writeDataTypes(Writer writer, Map definitions) {
+  definitions.findAll { Entry definition -> definition.key != 'AsyncResponse' }.each { Entry definition ->
+    def definitionName = definition.key
+    writer.println """
+[[${definitionName}]]
+=== ${definitionName}
+[cols="15,^10,35,^15,^10,^15", options="header"]
+|=======================
+|Name|Required|Description|Type|Format|Allowable Values
+"""
+    definition.value.properties.each { Entry property ->
+      def propertyName = property.key
+      def required = required((definition.value.required ?: []).contains(propertyName))
+      def description = property.value.description ?: '-'
+      def type
+      switch (property.value.type) {
+        case 'array':
+          def items = property.value.items ?: [:]
+          if (items['$ref']) {
+            String itemsRef = items['$ref']
+            type = "array of <<${itemsRef.substring("#/definitions/".length())}>>"
+          } else {
+            type = "array of ${items.type}"
+          }
+          break;
+        default:
+          type = property.value.type
+      }
+      def format = property.value.format ?: '-'
+      def allowableValues = allowableValues(property.value.enum)
+      writer.println "|${propertyName}|${required}|${description}|${type}|${format}|${allowableValues}"
+    }
+    writer.println '''
+|=======================
+'''
+  }
+}
+
+def String required(boolean val) {
+  val ? 'Yes' : 'No'
+}
+
+def String allowableValues(def allowed) {
+  (allowed ?: []).join(', ') ?: '-'
+}
+
+def String schemaToType(Map schema) {
+  def model
+  if (schema['$ref']) {
+    String ref = schema['$ref']
+    model = "<<${ref.substring("#/definitions/".length())}>>"
+  } else if (schema.type) {
+    switch (schema.type) {
+      case "array":
+        def items = schema.items ?: [:]
+        if (items['$ref']) {
+          String itemsRef = items['$ref']
+          model = "array of <<${itemsRef.substring("#/definitions/".length())}>>"
+        } else {
+          model = "array of ${items.type}"
+        }
+        break;
+      default:
+        model = schema.type
+    }
+  } else {
+    model = '-'
+  }
+  return model
+}

--- a/hawkular-inventory-rest-api/src/main/rest-doc/base.adoc
+++ b/hawkular-inventory-rest-api/src/main/rest-doc/base.adoc
@@ -1,0 +1,18 @@
+
+== Overview
+
+=== Media Type
+
+The API uses *JSON* to communicate with clients.
+
+You _should_ add the following accept header to your requests:
+
+----
+Accept: application/json
+----
+
+When you send JSON data with a `POST` or `PUT` request, you _must_ add the following content type header:
+
+----
+Content-Type: application/json
+----

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,9 @@
     <version.org.hawkular.commons>0.3.5.Final</version.org.hawkular.commons>
 
     <version.io.reactivex>1.0.8</version.io.reactivex>
+    <version.io.swagger>1.5.7</version.io.swagger>
+    <!-- overrides 3.1.2 from parent which produces NPE -->
+    <version.com.github.kongchen.swagger-maven-plugin>3.1.1</version.com.github.kongchen.swagger-maven-plugin>
     <version.com.github.fge>2.2.6</version.com.github.fge>
     <version.com.thinkaurelius.titan>0.5.4</version.com.thinkaurelius.titan>
     <version.org.apache.httpcomponents>4.3.1</version.org.apache.httpcomponents>


### PR DESCRIPTION
Update to parent 35 broke docgen profile. For generating adoc is used groovy script from Metrics. It would be good to move it to hawkular-build-tools where lives old mustache template. 

Note: 
`<version.com.github.kongchen.swagger-maven-plugin>3.1.1</version.com.github.kongchen.swagger-maven-plugin>`
overrides parent's 3.1.2 which produces NPE instead of json...
