### PR TITLE
Also encode the URI path sub-delimiters in path segments

### DIFF
--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/PathSegmentCodec.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/PathSegmentCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -269,7 +269,9 @@ public final class PathSegmentCodec {
        * pchar = unreserved / pct-encoded / sub-delims / ":" / "@"
        *
        */
+
+        //we encode the sub-delims so that the URI processors don't try to assign them a meaning they don't have
         return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') ||
-                "-._~!$&\'()*+,;=:@".indexOf(c) >= 0;
+                "-._~:@".indexOf(c) >= 0;
     }
 }

--- a/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/CanonicalPathTest.java
+++ b/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/CanonicalPathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -121,10 +121,10 @@ public class CanonicalPathTest {
                 .environment("e").resource("r").data(connectionConfiguration).key("bl/ah").get().toString());
 
         // escaped chars scenario
-        Assert.assertEquals("/t;te%2Fnant/e;e;nv/r;r%25%2Fes;;", CanonicalPath.of().tenant("te/nant")
+        Assert.assertEquals("/t;te%2Fnant/e;e%3Bnv/r;r%25%2Fes%3B%3B", CanonicalPath.of().tenant("te/nant")
                 .environment("e;nv").resource("r%/es;;").get().toString());
 
-        Assert.assertEquals("/t;t/e;e/r;res%2F1;res%252/r;res;%203", CanonicalPath.of().tenant("t").environment("e")
+        Assert.assertEquals("/t;t/e;e/r;res%2F1%3Bres%252/r;res%3B%203", CanonicalPath.of().tenant("t").environment("e")
                 .resource("res/1;res%2").resource("res; 3").get().toString());
     }
 
@@ -148,7 +148,7 @@ public class CanonicalPathTest {
         Assert.assertEquals("/t;t", p.up().up().toString());
 
         CanonicalPath p2 = CanonicalPath.of().tenant("t").feed("f").metric("m/e;t%r%|%C").get();
-        Assert.assertEquals("/t;t/f;f/m;m%2Fe;t%25r%25%7C%25C", p2.down().up().toString());
+        Assert.assertEquals("/t;t/f;f/m;m%2Fe%3Bt%25r%25%7C%25C", p2.down().up().toString());
 
         CanonicalPath p3 = CanonicalPath.of().tenant("t").feed("f").resource("res1").resource("res2").get();
         Assert.assertEquals("/t;t/f;f/r;res1/r;res2", p3.down().up().toString());
@@ -173,10 +173,10 @@ public class CanonicalPathTest {
         Assert.assertEquals("/t;t/f;f/m;m%25et%25%2Fric", p2.toString());
 
         p2 = p.getRoot().extend(MetricType.class, "m%et%/ric;type").get();
-        Assert.assertEquals("/t;t/mt;m%25et%25%2Fric;type", p2.toString());
+        Assert.assertEquals("/t;t/mt;m%25et%25%2Fric%3Btype", p2.toString());
 
         CanonicalPath p3 = p.extend(Metric.class, "/;/%").get();
-        Assert.assertEquals("/t;t/f;f/m;%2F;%2F%25", p3.toString());
+        Assert.assertEquals("/t;t/f;f/m;%2F%3B%2F%25", p3.toString());
     }
 
     @Test
@@ -241,7 +241,7 @@ public class CanonicalPathTest {
 
         // escaped chars scenario
         rp = RelativePath.fromString("../e;e%2f;nv/../t;t%2fenant");
-        Assert.assertEquals("../e;e%2F;nv/../t;t%2Fenant", rp.toString());
+        Assert.assertEquals("../e;e%2F%3Bnv/../t;t%2Fenant", rp.toString());
 
         try {
             RelativePath.fromString("../r");
@@ -339,7 +339,7 @@ public class CanonicalPathTest {
 
         //testing robustness against letter case in escape sequences and trailing type delimiter, too
         mp = Path.fromPartiallyUntypedString("/%2fg;", cp, cp, Metric.class);
-        Assert.assertEquals("/t;t/f;f/m;%2Fg;", mp.toString());
+        Assert.assertEquals("/t;t/f;f/m;%2Fg%3B", mp.toString());
     }
 
     @Test

--- a/hawkular-inventory-itest/src/test/groovy/org/hawkular/inventory/rest/test/InventoryITest.groovy
+++ b/hawkular-inventory-itest/src/test/groovy/org/hawkular/inventory/rest/test/InventoryITest.groovy
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue
 import static org.junit.Assert.fail
 
 import org.hawkular.inventory.api.model.CanonicalPath
+import org.hawkular.inventory.api.model.PathSegmentCodec
 import org.hawkular.inventory.api.model.Resource
 import org.junit.AfterClass
 import org.junit.Assert
@@ -273,8 +274,8 @@ class InventoryITest extends AbstractTestBase {
                 body: ["/e;" + environmentId + "/r;" + room1ResourceId + "/r;table/r;leg%2F1", "../" + room1ResourceId
                         + "/table/leg-4"])
         assertEquals(204, response.status)
-        pathsToDelete.put("$path/../table/leg%2F1", "$path/../table/leg%2F1")
-        pathsToDelete.put("$path/../table/leg-4", "$path/../table/leg-4")
+//        pathsToDelete.put("$path/../table/leg%2F1", "$path/../table/leg%2F1")
+//        pathsToDelete.put("$path/../table/leg-4", "$path/../table/leg-4")
 
         /* link the metric to resource */
         path = "$basePath/$environmentId/resources/$host1ResourceId/metrics"
@@ -468,7 +469,7 @@ class InventoryITest extends AbstractTestBase {
             String path = en.getKey();
             String getValidationPath = en.getValue();
             try {
-                def response = AbstractTestBase.client.delete(path: path)
+                def response = AbstractTestBase.client.delete(uri: baseURI + path)
                 assertEquals(204, response.status)
             } catch (groovyx.net.http.HttpResponseException e) {
                 println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
@@ -479,7 +480,7 @@ class InventoryITest extends AbstractTestBase {
 
             if (getValidationPath != null) {
                 try {
-                    def response = AbstractTestBase.client.get(path: getValidationPath)
+                    def response = AbstractTestBase.client.get(uri: baseURI + getValidationPath)
                     Assert.fail("The path '$getValidationPath' should not exist after the entity was deleted")
                 } catch (groovyx.net.http.HttpResponseException e) {
                     assertEquals("Error message for path '$path'", "Not Found", e.getMessage())
@@ -873,7 +874,7 @@ class InventoryITest extends AbstractTestBase {
         //this should fail
         rs.add("{\"id\": \"" + room1ResourceId + "\", \"resourceTypePath\": \"/rt;" + roomRTypeId + "\"}")
         //this should succeed
-        rs.add("{\"id\": \"" + bulkResourcePrefix + "+1\", \"resourceTypePath\": \"/rt;" + roomRTypeId + "\"}")
+        rs.add("{\"id\": \"" + bulkResourcePrefix + "-1\", \"resourceTypePath\": \"/rt;" + roomRTypeId + "\"}")
 
         payload += String.join(",", rs) + "]}}"
         def response = AbstractTestBase.client.post(path: "$basePath/bulk", body: payload)
@@ -883,18 +884,18 @@ class InventoryITest extends AbstractTestBase {
         assertEquals(2, codes.size())
 
         assertEquals(409, codes.get("/t;" + tenantId + "/e;" + environmentId + "/r;" + room1ResourceId))
-        assertEquals(201, codes.get("/t;" + tenantId + "/e;" + environmentId + "/r;" + bulkResourcePrefix + "+1"))
+        assertEquals(201, codes.get("/t;" + tenantId + "/e;" + environmentId + "/r;" + bulkResourcePrefix + "-1"))
 
-        AbstractTestBase.client.delete(path: "$basePath/$environmentId/resources/$bulkResourcePrefix+1")
+        AbstractTestBase.client.delete(path: "$basePath/$environmentId/resources/$bulkResourcePrefix-1")
     }
 
     @Test
     void testBulkCreateAndRelate() {
         def epath = "/t;$tenantId/e;$environmentId"
-        def rpath = "$epath/r;$bulkResourcePrefix" + "+1"
+        def rpath = "$epath/r;$bulkResourcePrefix" + "-1"
         def mpath = "$epath/m;$responseTimeMetricId"
         def payload = '{"' + epath + '": {"resource": [' +
-                '{"id": "' + bulkResourcePrefix + '+1", "resourceTypePath": "/rt;' + roomRTypeId + '"}]},' +
+                '{"id": "' + bulkResourcePrefix + '-1", "resourceTypePath": "/rt;' + roomRTypeId + '"}]},' +
                 '"' + rpath + '": {"relationship" : [' +
                 '{"name": "incorporates", "otherEnd": "' + mpath + '", "direction": "outgoing"}]}}'
 
@@ -910,8 +911,8 @@ class InventoryITest extends AbstractTestBase {
         assertEquals(1, relationshipCodes.size())
         assertEquals(201, relationshipCodes.entrySet().getAt(0).getValue())
 
-        AbstractTestBase.client.delete(path: "$basePath/$environmentId/resources/$bulkResourcePrefix+1/metrics/../$responseTimeMetricId")
-        AbstractTestBase.client.delete(path: "$basePath/$environmentId/resources/$bulkResourcePrefix+1")
+        client.delete(path: "$basePath/$environmentId/resources/$bulkResourcePrefix-1/metrics/../$responseTimeMetricId")
+        client.delete(path: "$basePath/$environmentId/resources/$bulkResourcePrefix-1")
     }
 
     @Test
@@ -1221,12 +1222,12 @@ class InventoryITest extends AbstractTestBase {
     /* Add the deletable path to {@link #pathsToDelete} and send a {@code POST} request using the given map of
      * arguments. */
     private static Object postDeletable(Map args) {
-        String getVerificationPath = args.path + "/" + args.body.id
+        String getVerificationPath = args.path + "/" + PathSegmentCodec.encode(args.body.id)
         postDeletable(args, getVerificationPath)
     }
     private static Object postDeletable(Map args, String getVerificationPath) {
         args.path = basePath + "/" + args.path
-        String path = args.path + "/" + args.body.id
+        String path = args.path + "/" + PathSegmentCodec.encode(args.body.id)
         pathsToDelete.put(path, basePath + "/" + getVerificationPath)
         println "posting $args"
         return AbstractTestBase.client.post(args)


### PR DESCRIPTION
so that RestEasy doesn't try to do clever things with the path segments like trying to
deduce matrix params where there are none.
