### PR TITLE
Bulk insert - duplicates

### DIFF
--- a/hawkular-inventory-itest/src/test/groovy/org/hawkular/inventory/rest/test/InventoryITest.groovy
+++ b/hawkular-inventory-itest/src/test/groovy/org/hawkular/inventory/rest/test/InventoryITest.groovy
@@ -69,6 +69,8 @@ class InventoryITest extends AbstractTestBase {
     private static final String responseStatusCodeMetricId = "itest-response-status-code-" + host1ResourceId;
     private static final String feedId = "itest-feed-" + UUID.randomUUID().toString();
     private static final String bulkResourcePrefix = "bulk-resource-" + UUID.randomUUID().toString();
+    private static final String bulkResourceTypePrefix = "bulk-resource-type-" + UUID.randomUUID().toString();
+    private static final String bulkMetricTypePrefix = "bulk-metric-type-" + UUID.randomUUID().toString();
     private static final String customRelationName = "inTheSameRoom";
 
     /* key is the path to delete while value is the path to GET to verify the deletion */
@@ -878,6 +880,101 @@ class InventoryITest extends AbstractTestBase {
             def rid = p.ids().getResourcePath().getSegment().getElementId()
             AbstractTestBase.client.delete(path: "$basePath/$env/resources/$rid")
         })
+    }
+
+    @Test
+    void testResourceBulkCreateUnderFeedWithDuplicates() {
+        def pathToResType = "/t;$tenantId/f;$feedId/rt;$bulkResourceTypePrefix.1";
+        def payload = """
+        {
+            "/t;$tenantId/f;$feedId": {
+                "resourceType": [
+                    {
+                        "id": "$bulkResourceTypePrefix.1"
+                    },
+                    {
+                        "id": "$bulkResourceTypePrefix.1"
+                    }
+                ],
+                "resource": [
+                    {
+                        "id"              : "$bulkResourcePrefix.1",
+                        "resourceTypePath": "$pathToResType"
+                    },
+                    {
+                        "id"              : "$bulkResourcePrefix.2",
+                        "resourceTypePath": "$pathToResType"
+                    }
+                ],
+                "metricType": [
+                    {
+                        "id"                : "$bulkMetricTypePrefix.1",
+                        "unit"              : "BYTES",
+                        "type"              : "GAUGE",
+                        "collectionInterval": "300"
+                    },
+                    {
+                        "id"                : "$bulkMetricTypePrefix.2",
+                        "unit"              : "BYTES",
+                        "type"              : "GAUGE",
+                        "collectionInterval": "300"
+                    }
+                ]
+            },
+            "$pathToResType": {
+                "relationship": [
+                    {
+                        "name"     : "incorporates",
+                        "otherEnd" : "/t;$tenantId/f;$feedId/mt;$bulkMetricTypePrefix.1",
+                        "direction": "outgoing"
+                    },
+                    {
+                        "name"     : "incorporates",
+                        "otherEnd" : "/t;$tenantId/f;$feedId/mt;$bulkMetricTypePrefix.1",
+                        "direction": "outgoing"
+                    },
+                    {
+                        "name"     : "incorporates",
+                        "otherEnd" : "/t;$tenantId/f;$feedId/mt;$bulkMetricTypePrefix.2",
+                        "direction": "outgoing"
+                    }
+                ]
+            }
+        }
+        """
+
+        def response = AbstractTestBase.client.post(path: "$basePath/bulk", body: payload)
+
+        assertEquals(201, response.status)
+        def resourceCodes = response.data.resource as Map<String, Integer>
+        def metricTypeCodes = response.data.metricType as Map<String, Integer>
+        def resourceTypeCodes = response.data.resourceType as Map<String, Integer>
+        def relationshipCodes = response.data.relationship as Map<String, Integer>
+
+        // check, there are no dupes
+        assertEquals(2, resourceCodes.size())
+        assertEquals(2, metricTypeCodes.size())
+        assertEquals(1, resourceTypeCodes.size())
+        assertEquals(2, relationshipCodes.size())
+
+        // check, no 409 was raised, because only the first status code is taken
+        assertEquals(201, resourceCodes.get("/t;" + tenantId + "/f;" + feedId + "/r;" + bulkResourcePrefix + ".1"))
+        assertEquals(201, resourceCodes.get("/t;" + tenantId + "/f;" + feedId + "/r;" + bulkResourcePrefix + ".2"))
+        assertEquals(201, resourceTypeCodes.get(pathToResType))
+        assertEquals(201, metricTypeCodes.get("/t;" + tenantId + "/f;" + feedId + "/mt;" + bulkMetricTypePrefix + ".1"))
+        assertEquals(201, metricTypeCodes.get("/t;" + tenantId + "/f;" + feedId + "/mt;" + bulkMetricTypePrefix + ".2"))
+
+        assertEquals(201, relationshipCodes.get("/rl;" + PathSegmentCodec.encode(pathToResType
+            + "-(incorporates)->"
+            + "/t;$tenantId/f;$feedId/mt;$bulkMetricTypePrefix" + ".1")))
+        assertEquals(201, relationshipCodes.get("/rl;" + PathSegmentCodec.encode(pathToResType
+            + "-(incorporates)->"
+            + "/t;$tenantId/f;$feedId/mt;$bulkMetricTypePrefix" + ".2")))
+
+        client.delete(path: "$basePath/feeds/$feedId/resources/$bulkResourcePrefix" + ".1")
+        client.delete(path: "$basePath/feeds/$feedId/metricTypes/$bulkMetricTypePrefix" + ".1")
+        client.delete(path: "$basePath/feeds/$feedId/metricTypes/$bulkMetricTypePrefix" + ".2")
+//        client.delete(path: "$basePath/feeds/$feedId/resourceTypes/$bulkResourceTypePrefix" + ".1")
     }
 
     @Test


### PR DESCRIPTION
Making the bulk insert more robust so that it can deal with duplicated elements.
This PR also fixes the load tests that has some duplicates in the "recorded" json from agent.

_With this change, the Hawkular is happy again. Without it, there is nothing in the inventory, except the feed, because whole bulk insert is rolled back._

Note: agent is still sending duplicate elements, but inventory is now immune to it.
