### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <!-- keep in sync with the WF module modules/system/layers/base/org/apache/commons/beanutils/main/ -->
     <version.commons-beanutils>1.9.2</version.commons-beanutils>
     <!-- keep in sync with the WF module modules/system/layers/base/org/apache/commons/collections/main/ -->
-    <version.commons-collections>3.2.1</version.commons-collections>
+    <version.commons-collections>3.2.2</version.commons-collections>
     <!-- keep in sync with the WF module modules/system/layers/base/org/apache/commons/io/main/ -->
     <version.commons-io>2.4</version.commons-io>
     <!-- keep in sync with the WF module modules/system/layers/base/org/apache/commons/lang/main/ -->


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/

Also, do consider using Guava in the future.
