### PR TITLE
Fix handling of ids with encoded characters while composing a traversal.

### DIFF
--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/Traverser.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/Traverser.java
@@ -218,7 +218,7 @@ public final class Traverser {
                 SegmentType segmentType = SegmentType.valueOf(entityTypeCtx.getText());
                 //path is important because this can be a continuation of a canonical path...
                 //this helps the query optimizer do its magic
-                getQueryBuilder().path().with(type(segmentType), id(idCtx.getText()));
+                getQueryBuilder().path().with(type(segmentType), id(PathSegmentCodec.decode(idCtx.getText())));
             }
 
             if (filterSpecCtxs != null && !filterSpecCtxs.isEmpty()) {

--- a/hawkular-inventory-rest-api/src/test/java/org/hawkular/inventory/rest/TraverserTest.java
+++ b/hawkular-inventory-rest-api/src/test/java/org/hawkular/inventory/rest/TraverserTest.java
@@ -120,6 +120,7 @@ public class TraverserTest {
     public void testSimpleEntityQuery() throws Exception {
         testVariant("/r;id", path().with(type(Resource.class), id("id")).get());
         testVariant("/r;id/entities", path().with(type(Resource.class), id("id")).get());
+        testVariant("/r;id%20with%20escapes", path().with(type(Resource.class), id("id with escapes")).get());
     }
 
     @Test


### PR DESCRIPTION
Handling of IDs with characters needing url encoding was broken. All other filters seem to already be treated correctly.
