### PR TITLE
Mirror all the pre-0.17.0.Final endpoints under /deprecated.

### DIFF
--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestBulk.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestBulk.java
@@ -544,7 +544,7 @@ public class RestBulk extends RestBase {
         return status == 201 || status == 204;
     }
 
-    private enum ElementType {
+    public enum ElementType {
         environment(Environment.class, Environment.Blueprint.class, SegmentType.e),
         resourceType(ResourceType.class, ResourceType.Blueprint.class, SegmentType.rt),
         metricType(MetricType.class, MetricType.Blueprint.class, SegmentType.mt),
@@ -586,7 +586,7 @@ public class RestBulk extends RestBase {
         }
     }
 
-    private static class IdExtractor extends ElementBlueprintVisitor.Simple<String, Void> {
+    public static class IdExtractor extends ElementBlueprintVisitor.Simple<String, Void> {
         @Override
         protected String defaultAction(Object blueprint, Void parameter) {
             return ((Entity.Blueprint) blueprint).getId();

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestSync.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestSync.java
@@ -54,7 +54,7 @@ public class RestSync extends RestBase {
     }
 
     @POST
-    @Path("/{path}")
+    @Path("/{path:.+}")
     @ApiOperation("Make the inventory under given path match the provided inventory structure. Note that the " +
             "relationships specified in the provided entities will be ignored and will not be applied.")
     @ApiResponses({

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/deprecated/RestBulk.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/deprecated/RestBulk.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.rest.deprecated;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import io.swagger.annotations.Api;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.17.1
+ */
+@Path("/deprecated/bulk")
+@Produces(APPLICATION_JSON)
+@Consumes(APPLICATION_JSON)
+@Api(value = "/deprecated/bulk", description = "Endpoint for bulk operations on inventory entities", tags = "Deprecated")
+public class RestBulk extends org.hawkular.inventory.rest.RestBulk {
+}

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/deprecated/RestEvents.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/deprecated/RestEvents.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.rest.deprecated;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import io.swagger.annotations.Api;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.17.1
+ */
+@Path("/deprecated/events")
+@Produces(APPLICATION_JSON)
+@Consumes(APPLICATION_JSON)
+@Api(value = "/deprecatedevents", description = "Work with the events emitted by inventory", tags = "Deprecated")
+public class RestEvents extends org.hawkular.inventory.rest.RestEvents {
+}

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/deprecated/RestPing.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/deprecated/RestPing.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.rest.deprecated;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import io.swagger.annotations.Api;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.17.1
+ */
+@Path("/deprecated")
+@Produces(value = APPLICATION_JSON)
+@Consumes(value = APPLICATION_JSON)
+@Api(value = "/", tags = "Deprecated")
+public class RestPing extends org.hawkular.inventory.rest.RestPing {
+}

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/deprecated/RestSync.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/deprecated/RestSync.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.rest.deprecated;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import io.swagger.annotations.Api;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.17.1
+ */
+@Path("/deprecated/sync")
+@Produces(value = APPLICATION_JSON)
+@Consumes(value = APPLICATION_JSON)
+@Api(value = "/deprecated/sync", description = "Synchronization of entity trees", tags = "Deprecated")
+public class RestSync extends org.hawkular.inventory.rest.RestSync {
+}


### PR DESCRIPTION
Some of the endpoints that existed prior to 0.17.0 were not moved to `/deprecated`. Those actually weren't deprecated and thus stayed on their original places, but not having them under `/deprecated` creates confusion because it is no longer enough to just change the context root to be able to work with the old API.
