### PR TITLE
Make sure to not spawn nested/overlapping transactions.

### DIFF
--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/IdentityHash.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/IdentityHash.java
@@ -48,6 +48,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import org.hawkular.inventory.api.Inventory;
 import org.hawkular.inventory.api.TreeTraversal;
@@ -388,18 +389,20 @@ public final class IdentityHash {
                     RelativePath resourcePath = rootPath.modified().extend(SegmentType.r, parentResource.getId())
                             .get().slide(1, 0);
 
-                    return structure.getChildren(resourcePath, DataEntity.class)
-                            .filter(d -> configuration.equals(d.getRole()))
-                            .findFirst().orElse(dummyDataBlueprint(configuration));
+                    try (Stream<DataEntity.Blueprint<?>> s = structure.getChildren(resourcePath, DataEntity.class)) {
+                        return s.filter(d -> configuration.equals(d.getRole()))
+                                .findFirst().orElse(dummyDataBlueprint(configuration));
+                    }
                 }
 
                 @Override public DataEntity.Blueprint<?> getConfigurationSchema(ResourceType.Blueprint rt) {
                     RelativePath p = rt.equals(structure.getRoot()) ? RelativePath.empty().get()
                             : RelativePath.to().resourceType(rt.getId()).get();
 
-                    return structure.getChildren(p, DataEntity.class)
-                            .filter(d -> configurationSchema.equals(d.getRole()))
-                            .findFirst().orElse(dummyDataBlueprint(configurationSchema));
+                    try (Stream<DataEntity.Blueprint<?>> s = structure.getChildren(p, DataEntity.class)
+                            .filter(d -> configurationSchema.equals(d.getRole()))) {
+                        return s.findFirst().orElse(dummyDataBlueprint(configurationSchema));
+                    }
                 }
 
                 @Override
@@ -408,37 +411,49 @@ public final class IdentityHash {
                     RelativePath resourcePath = root.modified().extend(SegmentType.r, parentResource.getId())
                             .get().slide(1, 0);
 
-                    return structure.getChildren(resourcePath, DataEntity.class)
-                            .filter(d -> connectionConfiguration.equals(d.getRole()))
-                            .findFirst().orElse(dummyDataBlueprint(connectionConfiguration));
+                    try (Stream<DataEntity.Blueprint<?>>s = structure.getChildren(resourcePath, DataEntity.class)
+                            .filter(d -> connectionConfiguration.equals(d.getRole()))) {
+                        return s.findFirst().orElse(dummyDataBlueprint(connectionConfiguration));
+                    }
                 }
 
                 @Override public DataEntity.Blueprint<?> getConnectionConfigurationSchema(ResourceType.Blueprint rt) {
                     RelativePath p = rt.equals(structure.getRoot()) ? RelativePath.empty().get()
                             : RelativePath.to().resourceType(rt.getId()).get();
 
-                    return structure.getChildren(p, DataEntity.class)
-                            .filter(d -> connectionConfigurationSchema.equals(d.getRole()))
-                            .findFirst().orElse(dummyDataBlueprint(connectionConfigurationSchema));
+                    try (Stream<DataEntity.Blueprint<?>> s = structure.getChildren(p, DataEntity.class)
+                            .filter(d -> connectionConfigurationSchema.equals(d.getRole()))) {
+                        return s.findFirst().orElse(dummyDataBlueprint(connectionConfigurationSchema));
+                    }
                 }
 
                 @Override public List<Metric.Blueprint> getFeedMetrics() {
-                    return structure.getChildren(RelativePath.empty().get(), Metric.class).collect(toList());
+                    try (Stream<Metric.Blueprint> s = structure.getChildren(RelativePath.empty().get(), Metric.class)) {
+                        return s.collect(toList());
+                    }
                 }
 
                 @Override public List<Resource.Blueprint> getFeedResources() {
-                    return structure.getChildren(RelativePath.empty().get(), Resource.class).collect(toList());
+                    try (Stream<Resource.Blueprint> s = structure.getChildren(RelativePath.empty().get(),
+                            Resource.class)) {
+                        return s.collect(toList());
+                    }
                 }
 
                 @Override public List<MetricType.Blueprint> getMetricTypes() {
-                    return structure.getChildren(RelativePath.empty().get(), MetricType.class).collect(toList());
+                    try (Stream<MetricType.Blueprint> s = structure.getChildren(RelativePath.empty().get(),
+                            MetricType.class)) {
+                        return s.collect(toList());
+                    }
                 }
 
                 @Override public List<OperationType.Blueprint> getOperationTypes(ResourceType.Blueprint rt) {
                     RelativePath p = rt.equals(structure.getRoot()) ? RelativePath.empty().get()
                             : RelativePath.to().resourceType(rt.getId()).get();
 
-                    return structure.getChildren(p, OperationType.class).collect(toList());
+                    try (Stream<OperationType.Blueprint> s = structure.getChildren(p, OperationType.class)) {
+                        return s.collect(toList());
+                    }
                 }
 
                 @Override
@@ -447,9 +462,10 @@ public final class IdentityHash {
                     RelativePath p = rootResourceType.modified().extend(SegmentType.ot, ot.getId()).get()
                             .slide(1, 0);
 
-                    return structure.getChildren(p, DataEntity.class)
-                            .filter(d -> parameterTypes.equals(d.getRole()))
-                            .findFirst().orElse(dummyDataBlueprint(parameterTypes));
+                    try (Stream<DataEntity.Blueprint<?>> s = structure.getChildren(p, DataEntity.class)
+                            .filter(d -> parameterTypes.equals(d.getRole()))) {
+                        return s.findFirst().orElse(dummyDataBlueprint(parameterTypes));
+                    }
                 }
 
                 @Override
@@ -458,7 +474,9 @@ public final class IdentityHash {
                     RelativePath p = rootPath.modified().extend(SegmentType.r, parentResource.getId()).get()
                             .slide(1, 0);
 
-                    return structure.getChildren(p, Metric.class).collect(toList());
+                    try (Stream<Metric.Blueprint> s = structure.getChildren(p, Metric.class)) {
+                        return s.collect(toList());
+                    }
                 }
 
                 @Override
@@ -466,11 +484,16 @@ public final class IdentityHash {
                     RelativePath p = rootPath.modified().extend(SegmentType.r, parentResource.getId()).get()
                             .slide(1, 0);
 
-                    return structure.getChildren(p, Resource.class).collect(toList());
+                    try (Stream<Resource.Blueprint> s = structure.getChildren(p, Resource.class)) {
+                        return s.collect(toList());
+                    }
                 }
 
                 @Override public List<ResourceType.Blueprint> getResourceTypes() {
-                    return structure.getChildren(RelativePath.empty().get(), ResourceType.class).collect(toList());
+                    try (Stream<ResourceType.Blueprint> s = structure.getChildren(RelativePath.empty().get(),
+                            ResourceType.class)) {
+                        return s.collect(toList());
+                    }
                 }
 
                 @Override public DataEntity.Blueprint<?> getReturnType(RelativePath rootResourceType,
@@ -478,9 +501,10 @@ public final class IdentityHash {
                     RelativePath p = rootResourceType.modified().extend(SegmentType.ot, ot.getId()).get()
                             .slide(1, 0);
 
-                    return structure.getChildren(p, DataEntity.class)
-                            .filter(d -> returnType.equals(d.getRole()))
-                            .findFirst().orElse(dummyDataBlueprint(returnType));
+                    try (Stream<DataEntity.Blueprint<?>> s = structure.getChildren(p, DataEntity.class)
+                            .filter(d -> returnType.equals(d.getRole()))) {
+                        return s.findFirst().orElse(dummyDataBlueprint(returnType));
+                    }
                 }
             };
         }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseFeeds.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseFeeds.java
@@ -72,7 +72,8 @@ public final class BaseFeeds {
             CanonicalPath feedPath = tx.extractCanonicalPath(tenant)
                     .extend(Feed.SEGMENT_TYPE, blueprint.getId()).get();
 
-            return context.configuration.getFeedIdStrategy().generate(context.inventory, new Feed(feedPath, null));
+            return context.configuration.getFeedIdStrategy().generate(context.inventory.keepTransaction(tx),
+                    new Feed(feedPath, null));
         }
 
         @Override

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetadataPacks.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetadataPacks.java
@@ -74,7 +74,7 @@ public final class BaseMetadataPacks {
                         }
                     }).iterator();
 
-            return IdentityHash.of(members, context.inventory);
+            return IdentityHash.of(members, context.inventory.keepTransaction(tx));
         }
 
         @Override

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
@@ -17,6 +17,7 @@
 package org.hawkular.inventory.base;
 
 import static org.hawkular.inventory.api.Action.created;
+import static org.hawkular.inventory.api.Relationships.Direction.outgoing;
 import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
 import static org.hawkular.inventory.api.Relationships.WellKnown.defines;
 import static org.hawkular.inventory.api.Relationships.WellKnown.incorporates;
@@ -111,7 +112,9 @@ public final class BaseResources {
                 //we're creating a child resource... need to also create the implicit isParentOf
                 //in here, we do use the relationship rules to check if the hierarchy we're introducing by this call
                 //conforms to the rules.
-                r = relate(parent, entity, isParentOf.name());
+                String relationshipName = isParentOf.name();
+                RelationshipRules.checkCreate(tx, parent, outgoing, relationshipName, entity);
+                r = tx.relate(parent, entity, relationshipName, null);
 
                 Relationship parentRel = new Relationship(tx.extractId(r), isParentOf.name(),
                         parentPath, entityPath);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Mutator.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Mutator.java
@@ -254,13 +254,6 @@ abstract class Mutator<BE, E extends Entity<?, U>, B extends Blueprint, U extend
                 }, null);
     }
 
-    protected BE relate(BE source, BE target, String relationshipName) {
-        return inTx(tx -> {
-            RelationshipRules.checkCreate(tx, source, outgoing, relationshipName, target);
-            return tx.relate(source, target, relationshipName, null);
-        });
-    }
-
     /**
      * Wires up the freshly created entity in the appropriate places in inventory. The "contains" relationship between
      * the parent and the new entity will already have been created so the implementations don't need to do that again.

--- a/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/InventoryStructureOfflineBuilderTest.java
+++ b/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/InventoryStructureOfflineBuilderTest.java
@@ -18,6 +18,7 @@ package org.hawkular.inventory.api.test;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.stream.Stream;
 
 import org.hawkular.inventory.api.model.Blueprint;
 import org.hawkular.inventory.api.model.Feed;
@@ -84,9 +85,12 @@ public class InventoryStructureOfflineBuilderTest {
         structure.getChild(Path.Segment.from("r;resource")).addChild(Resource.Blueprint.builder().withId("cr2")
                 .withResourceTypePath("../resourceType").build());
 
-        InventoryStructure s = structure.build();
+        InventoryStructure<?> s = structure.build();
 
-        Assert.assertEquals(2, s.getChildren(RelativePath.to().resource("resource").get(), Resource.class).count());
+        try (Stream<Resource.Blueprint> sm = s.getChildren(RelativePath.to().resource("resource").get(),
+                Resource.class)) {
+            Assert.assertEquals(2, sm.count());
+        }
     }
 
     @Test

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/pom.xml
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/pom.xml
@@ -43,6 +43,23 @@
       <version>${version.com.tinkerpop.gremlin}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/src/main/java/org/hawkular/inventory/impl/tinkerpop/spi/Log.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/src/main/java/org/hawkular/inventory/impl/tinkerpop/spi/Log.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.impl.tinkerpop.spi;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.logging.annotations.ValidIdRange;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.17.1
+ */
+@MessageLogger(projectCode = "HAWKINV")
+@ValidIdRange(min = 100000, max = 100099)
+public interface Log extends BasicLogger {
+    Log LOG = Logger.getMessageLogger(Log.class, "org.hawkular.inventory.impl.tinkerpop.spi");
+}

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-tinkergraph-provider/src/main/java/org/hawkular/inventory/impl/tinkerpop/provider/TinkerGraphProvider.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-tinkergraph-provider/src/main/java/org/hawkular/inventory/impl/tinkerpop/provider/TinkerGraphProvider.java
@@ -73,17 +73,20 @@ public final class TinkerGraphProvider implements GraphProvider {
 
     @Override
     public TransactionalGraph startTransaction(TransactionalGraph graph) {
+        GraphProvider.super.startTransaction(graph);
         lock.writeLock().lock();
         return graph;
     }
 
     @Override
     public void commit(TransactionalGraph graph) {
+        GraphProvider.super.commit(graph);
         lock.writeLock().unlock();
     }
 
     @Override
     public void rollback(TransactionalGraph graph) {
+        GraphProvider.super.rollback(graph);
         lock.writeLock().unlock();
     }
 

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-titan-provider/src/test/resources/log4j.properties
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-titan-provider/src/test/resources/log4j.properties
@@ -1,0 +1,28 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.rootLogger=INFO, stdout
+
+#debugging for transactional issues
+#log4j.logger.com.thinkaurelius.titan=debug
+#log4j.logger.org.hawkular.inventory.impl.tinkerpop=trace
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+

--- a/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/InventoryStructureSerializer.java
+++ b/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/InventoryStructureSerializer.java
@@ -20,6 +20,7 @@ import static java.util.stream.Collectors.toList;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.hawkular.inventory.api.model.Blueprint;
 import org.hawkular.inventory.api.model.Entity;
@@ -86,6 +87,8 @@ public final class InventoryStructureSerializer extends JsonSerializer<Inventory
 
     private <E extends Entity<B, ?>, B extends Blueprint> List<B> getChildren(InventoryStructure<?> structure,
                                                                       RelativePath path, Class<E> type) {
-        return structure.getChildren(path, type).collect(toList());
+        try (Stream<B> s = structure.getChildren(path, type)) {
+            return s.collect(toList());
+        }
     }
 }


### PR DESCRIPTION
- Properly close streams backed by a query
- Always close paged results
- Propagate the current transaction where possible (using .keepTransaction())
- Always commit the transaction previously started (d'oh ;) )
- Don't call methods spawning new transactions from within a transactional
  context
- Added trace logging for transaction boundaries
