### PR TITLE
Closing the txs properly during paging and generic query execution.

### DIFF
--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/paging/Page.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/paging/Page.java
@@ -76,10 +76,12 @@ public class Page<T> implements Iterator<T>, AutoCloseable, Iterable<T> {
      * @return results in a list form
      */
     public List<T> toList() {
-        List<T> ret = StreamSupport.stream(Spliterators.spliteratorUnknownSize(this, Spliterator.ORDERED), false)
-                .collect(Collectors.<T>toList());
-        close();
-        return ret;
+        try {
+            return StreamSupport.stream(Spliterators.spliteratorUnknownSize(this, Spliterator.ORDERED), false)
+                    .collect(Collectors.toList());
+        } finally {
+            close();
+        }
     }
 
     @Override public boolean hasNext() {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/paging/TransformingPage.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/paging/TransformingPage.java
@@ -78,10 +78,12 @@ public class TransformingPage<I, O> extends Page<O> {
 
     @Override
     public List<O> toList() {
-        List<O> ret = StreamSupport.stream(Spliterators.spliteratorUnknownSize(this, Spliterator.ORDERED), false)
-                .collect(Collectors.<O>toList());
-        close();
-        return ret;
+        try {
+            return StreamSupport.stream(Spliterators.spliteratorUnknownSize(this, Spliterator.ORDERED), false)
+                    .collect(Collectors.<O>toList());
+        } finally {
+            close();
+        }
     }
 
     @Override


### PR DESCRIPTION
Pages and query execution would not close transactions if an error occurred.
