### PR TITLE
interpret .../traversal/recursive/... et al. in an expectable way.

### DIFF
--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestBase.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestBase.java
@@ -16,7 +16,6 @@
  */
 package org.hawkular.inventory.rest;
 
-import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
 import static org.hawkular.inventory.api.filters.With.path;
 import static org.hawkular.inventory.rest.Utils.createUnder;
 
@@ -35,7 +34,6 @@ import org.hawkular.inventory.api.Configuration;
 import org.hawkular.inventory.api.Inventory;
 import org.hawkular.inventory.api.Query;
 import org.hawkular.inventory.api.TransactionFrame;
-import org.hawkular.inventory.api.filters.Related;
 import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.json.DetypedPathDeserializer;
@@ -161,15 +159,6 @@ public class RestBase {
     }
 
     protected Traverser getTraverser(UriInfo ctx) {
-        Query.Builder queryPrefix = Query.builder().path().with(
-                path(CanonicalPath.of().tenant(getTenantId()).get()),
-                Related.by(contains));
-
-        return new Traverser(ctx.getBaseUri().getPath().length() + pathLength, queryPrefix,
-                str -> CanonicalPath.fromPartiallyUntypedString(str, getTenantPath(), (SegmentType) null));
-    }
-
-    protected Traverser getTraverserForTenant(UriInfo ctx) {
         Query.Builder queryPrefix = Query.builder().path().with(
                 path(CanonicalPath.of().tenant(getTenantId()).get()));
 

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestTenant.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestTenant.java
@@ -63,7 +63,7 @@ public class RestTenant extends RestBase {
     @GET
     @Path("/relationships")
     public Response getRelationships(@Context UriInfo uriInfo) {
-        Traverser traverser = getTraverserForTenant(uriInfo);
+        Traverser traverser = getTraverser(uriInfo);
         Query q = traverser.navigate(getPath(uriInfo));
 
         @SuppressWarnings("unchecked")

--- a/hawkular-inventory-rest-api/src/test/java/org/hawkular/inventory/rest/TraverserTest.java
+++ b/hawkular-inventory-rest-api/src/test/java/org/hawkular/inventory/rest/TraverserTest.java
@@ -110,9 +110,7 @@ public class TraverserTest {
 
     @Test
     public void testQueryPrefixUsedForURIsStartingWithEntity() throws Exception {
-        //this query is invalid, but that doesn't matter here... Query is untyped and doesn't enforce correctness
-        //The real REST API prefixes it with something meaningful
-        testVariant("/r;id/entities", path().with(id("eee"))
+        testVariant("/r;id/entities", path().with(id("eee"), Related.by(contains))
                 .path().with(type(Resource.class), id("id")).get(), Query.builder().path().with(id("eee")));
     }
 
@@ -308,6 +306,13 @@ public class TraverserTest {
         testVariant("/r;id/identical/name=Kachna/rl;contains/m;id", Query.path()
                 .with(type(r), id("id"), With.sameIdentityHash())
                 .filter().with(name("Kachna")).path().with(Related.by(contains), type(m), id("id")).get());
+    }
+
+    @Test
+    public void testRecursiveReturnsAllChildrenOfPrefix() throws Exception {
+        testVariant("/recursive",
+                Query.path().with(id("prefix"), RecurseFilter.builder().addChain(Related.by(contains)).build()).get(),
+                Query.path().with(id("prefix")).rawQueryBuilder());
     }
 
     private void testVariant(String uri, Query expected) throws Exception {


### PR DESCRIPTION
/traversal previously always applied only on children of the tenant (unless
tenant was explicitly specified at the start of the path).

So the query like .../traversal/recursive returned only grandchildren of the
tenant which is non-intuitive.
