### PR TITLE
We now produce 3 kinds of hashes for different entities.

### DIFF
--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Action.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Action.java
@@ -17,9 +17,11 @@
 package org.hawkular.inventory.api;
 
 import org.hawkular.inventory.api.model.AbstractElement;
+import org.hawkular.inventory.api.model.ContentHashable;
 import org.hawkular.inventory.api.model.Environment;
 import org.hawkular.inventory.api.model.Feed;
 import org.hawkular.inventory.api.model.IdentityHashable;
+import org.hawkular.inventory.api.model.Syncable;
 
 /**
  * @author Lukas Krejci
@@ -32,7 +34,9 @@ public final class Action<C, E> {
     private static final Action<?, ?> _DELETED = new Action<>();
     private static final Action<EnvironmentCopy, Environment> _COPIED = new Action<>();
     private static final Action<Feed, Feed> _REGISTERED = new Action<>();
+    private static final Action<?, ?> _SYNC_HASH_CHANGED = new Action<>();
     private static final Action<?, ?> _IDENTITY_HASH_CHANGED = new Action<>();
+    private static final Action<?, ?> _CONTENT_HASH_CHANGED = new Action<>();
 
     public static <E> Action<E, E> created() {
         return (Action<E, E>) _CREATED;
@@ -55,8 +59,16 @@ public final class Action<C, E> {
         return _REGISTERED;
     }
 
+    public static <E extends Syncable> Action<E, E> syncHashChanged() {
+        return (Action<E, E>) _SYNC_HASH_CHANGED;
+    }
+
     public static <E extends IdentityHashable> Action<E, E> identityHashChanged() {
         return (Action<E, E>) _IDENTITY_HASH_CHANGED;
+    }
+
+    public static <E extends ContentHashable> Action<E, E> contentHashChanged() {
+        return (Action<E, E>) _CONTENT_HASH_CHANGED;
     }
 
     private Action() {
@@ -74,7 +86,8 @@ public final class Action<C, E> {
 
     public enum Enumerated {
         CREATED(_CREATED), UPDATED(_UPDATED), DELETED(_DELETED), COPIED(_COPIED), REGISTERED(_REGISTERED),
-        IDENTITY_HASH_CHANGED(_IDENTITY_HASH_CHANGED);
+        SYNC_HASH_CHANGED(_SYNC_HASH_CHANGED), IDENTITY_HASH_CHANGED(_IDENTITY_HASH_CHANGED),
+        CONTENT_HASH_CHANGED(_CONTENT_HASH_CHANGED);
 
         private final Action<?, ?> action;
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Data.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Data.java
@@ -60,7 +60,7 @@ public final class Data {
         void update(Role role, DataEntity.Update update) throws EntityNotFoundException, ValidationException;
     }
 
-    public interface Single extends IdentityHashed.Single<DataEntity, DataEntity.Blueprint<?>, DataEntity.Update> {
+    public interface Single extends Synced.Single<DataEntity, DataEntity.Blueprint<?>, DataEntity.Update> {
 
         /**
          * Loads the data entity on the current position in the inventory traversal along with its data.

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
@@ -29,7 +29,6 @@ import org.hawkular.inventory.api.model.DataEntity;
 import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.model.Environment;
 import org.hawkular.inventory.api.model.Feed;
-import org.hawkular.inventory.api.model.IdentityHash;
 import org.hawkular.inventory.api.model.InventoryStructure;
 import org.hawkular.inventory.api.model.MetadataPack;
 import org.hawkular.inventory.api.model.Metric;
@@ -39,6 +38,7 @@ import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.api.model.ResourceType;
 import org.hawkular.inventory.api.model.StructuredData;
+import org.hawkular.inventory.api.model.SyncHash;
 import org.hawkular.inventory.api.model.Tenant;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
@@ -153,7 +153,7 @@ public class EmptyInventory implements Inventory {
             throw entityNotFound(entityType);
         }
 
-        public IdentityHash.Tree treeHash() {
+        public SyncHash.Tree treeHash() {
             throw new UnsupportedOperationException();
         }
     }
@@ -1434,7 +1434,7 @@ public class EmptyInventory implements Inventory {
         @Override public void synchronize(InventoryStructure<DataEntity.Blueprint<?>> newStructure) {
         }
 
-        @Override public IdentityHash.Tree treeHash() {
+        @Override public SyncHash.Tree treeHash() {
             throw new UnsupportedOperationException();
         }
     }
@@ -1521,7 +1521,7 @@ public class EmptyInventory implements Inventory {
         @Override public void synchronize(InventoryStructure<OperationType.Blueprint> newStructure) {
         }
 
-        @Override public IdentityHash.Tree treeHash() {
+        @Override public SyncHash.Tree treeHash() {
             throw new UnsupportedOperationException();
         }
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Feeds.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Feeds.java
@@ -53,7 +53,7 @@ public final class Feeds {
         Metrics.Read metricsUnder(MetricParents... parents);
     }
 
-    public interface Single extends IdentityHashed.SingleWithRelationships<Feed, Feed.Blueprint, Feed.Update>,
+    public interface Single extends Synced.SingleWithRelationships<Feed, Feed.Blueprint, Feed.Update>,
             BrowserBase<Resources.ReadWrite, Metrics.ReadWrite, MetricTypes.ReadWrite, ResourceTypes.ReadWrite> {}
 
     public interface Multiple extends ResolvableToManyWithRelationships<Feed>,

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/MetricTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/MetricTypes.java
@@ -56,7 +56,7 @@ public final class MetricTypes {
      * Interface for accessing a single metric type in a writable manner.
      */
     public interface Single
-            extends IdentityHashed.SingleWithRelationships<MetricType, MetricType.Blueprint, MetricType.Update>,
+            extends Synced.SingleWithRelationships<MetricType, MetricType.Blueprint, MetricType.Update>,
             BrowserBase {
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Metrics.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Metrics.java
@@ -42,7 +42,7 @@ public final class Metrics {
     /**
      * Interface for accessing a single metric in a writable manner.
      */
-    public interface Single extends IdentityHashed.SingleWithRelationships<Metric, Metric.Blueprint, Metric.Update> {}
+    public interface Single extends Synced.SingleWithRelationships<Metric, Metric.Blueprint, Metric.Update> {}
 
     /**
      * Interface for traversing over a set of metrics.

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/OperationTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/OperationTypes.java
@@ -49,7 +49,7 @@ public final class OperationTypes {
     }
 
     public interface Single
-            extends IdentityHashed.SingleWithRelationships<OperationType, OperationType.Blueprint,
+            extends Synced.SingleWithRelationships<OperationType, OperationType.Blueprint,
             OperationType.Update>, BrowserBase<Data.ReadWrite<DataRole.OperationType>> {
 
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResourceTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResourceTypes.java
@@ -73,7 +73,7 @@ public final class ResourceTypes {
      * Interface for accessing a single resource type in a writable manner.
      */
     public interface Single
-            extends IdentityHashed.SingleWithRelationships<ResourceType, ResourceType.Blueprint, ResourceType.Update>,
+            extends Synced.SingleWithRelationships<ResourceType, ResourceType.Blueprint, ResourceType.Update>,
             BrowserBase<Resources.Read, MetricTypes.ReadAssociate, OperationTypes.ReadWrite,
                     Data.ReadWrite<DataRole.ResourceType>> {
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Resources.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Resources.java
@@ -98,7 +98,7 @@ public final class Resources {
      * Interface for accessing a single resource in a writable manner.
      */
     public interface Single
-            extends IdentityHashed.SingleWithRelationships<Resource, Resource.Blueprint, Resource.Update>,
+            extends Synced.SingleWithRelationships<Resource, Resource.Blueprint, Resource.Update>,
             BrowserBase<Metrics.ReadWrite, Metrics.ReadAssociate, Data.ReadWrite<DataRole.Resource>, ReadWrite,
                     ReadAssociate> {
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Synced.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Synced.java
@@ -17,8 +17,8 @@
 package org.hawkular.inventory.api;
 
 import org.hawkular.inventory.api.model.Entity;
-import org.hawkular.inventory.api.model.IdentityHash;
 import org.hawkular.inventory.api.model.InventoryStructure;
+import org.hawkular.inventory.api.model.SyncHash;
 
 /**
  * These interfaces are extended by accessor interfaces for {@link org.hawkular.inventory.api.model.IdentityHashable}
@@ -27,9 +27,9 @@ import org.hawkular.inventory.api.model.InventoryStructure;
  * @author Lukas Krejci
  * @since 0.15.0
  */
-public final class IdentityHashed {
+public final class Synced {
 
-    private IdentityHashed() {
+    private Synced() {
 
     }
 
@@ -44,7 +44,7 @@ public final class IdentityHashed {
          * This is useful for figuring out what changed about the structure of the entity
          * @return the hash of the entity together with the hashes of all contained entities
          */
-        IdentityHash.Tree treeHash();
+        SyncHash.Tree treeHash();
 
         /**
          * Synchronizes the entity and any of its children. The structure is considered to be complete - i.e.

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/AbstractHashTree.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/AbstractHashTree.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.model;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import org.hawkular.inventory.api.TreeTraversal;
+import org.hawkular.inventory.paths.Path;
+import org.hawkular.inventory.paths.RelativePath;
+
+/**
+ * An abstract base class for the various hash trees. This is not instantiable/subclassable by the users on purpose
+ * because only concrete subclasses defined in this package make sense for use. Nevertheless this class is public to
+ * enable abstracting over the different subclasses.
+ *
+ * @author Lukas Krejci
+ * @since 0.18.0
+ */
+public abstract class AbstractHashTree<This extends AbstractHashTree<This, H>, H extends Serializable>
+        implements Serializable {
+    protected final RelativePath path;
+    protected final H hash;
+    protected final Map<Path.Segment, This> children;
+
+    //jackson support
+    AbstractHashTree() {
+        this(null, null, null);
+    }
+
+    AbstractHashTree(RelativePath path, H hash, Map<Path.Segment, This> children) {
+        this.path = path;
+        this.hash = hash;
+        this.children = children;
+    }
+
+    public Collection<This> getChildren() {
+        return children.values();
+    }
+
+    public This getChild(Path.Segment path) {
+        return children.get(path);
+    }
+
+    public H getHash() {
+        return hash;
+    }
+
+    public RelativePath getPath() {
+        return path;
+    }
+
+    public TreeTraversal<This> traversal() {
+        return new TreeTraversal<>(t -> t.children.values().iterator());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AbstractHashTree<?, ?> tree = (AbstractHashTree<?, ?>) o;
+
+        return hash.equals(tree.hash);
+    }
+
+    @Override
+    public int hashCode() {
+        return hash.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "Tree[" + "path=" + path +
+                ", hash='" + hash + '\'' +
+                ",children=" + children.values() +
+                ']';
+    }
+
+    interface TreeConstructor<T extends AbstractHashTree<T, H>, H extends Serializable> {
+        T construct(RelativePath path, H hash, Map<Path.Segment, T> children);
+    }
+
+    /**
+     * An interface that is implemented by all tree hash builders. This is only made public for the cases where the
+     * users would like to abstract over different tree implementations.
+     *
+     * @param <This> the type of the concrete implementation
+     * @param <Child> the type of the tree child builder
+     * @param <Tree> the type of the tree being built
+     * @param <Hash> the type of the hash used in the tree
+     */
+    public interface Builder<This extends Builder<This, Child, Tree, Hash>,
+            Child extends ChildBuilder<Child, This, ?, Tree, Hash>,
+            Tree extends AbstractHashTree<Tree, Hash>, Hash extends Serializable> {
+
+        This withPath(RelativePath path);
+
+        This withHash(Hash hash);
+
+        Hash getHash();
+
+        RelativePath getPath();
+
+        boolean hasChildren();
+
+        Child startChild();
+
+        void addChild(Tree childTree);
+    }
+
+    /**
+     * Interface for top-level hash tree builders. I.e. only these actually have the build method that is used to
+     * produce the final tree.
+     *
+     * @param <This> the type of the concrete implementation
+     * @param <Child> the type of the tree child builder
+     * @param <Tree> the type of the tree being built
+     * @param <Hash> the type of the hash used in the tree
+     */
+    public interface TopBuilder<This extends TopBuilder<This, Child, Tree, Hash>,
+            Child extends ChildBuilder<Child, This, ?, Tree, Hash>,
+            Tree extends AbstractHashTree<Tree, Hash>, Hash extends Serializable>
+            extends Builder<This, Child, Tree, Hash> {
+
+        Tree build();
+    }
+
+    /**
+     * A builder used to build sub trees of some parent tree node.
+     *
+     * @param <This> the type of the concrete implementation of this interface
+     * @param <Parent> the type of the builder of the parent tree node
+     * @param <Child> the type of the builder used to build the subtrees of the tree node built by this builder
+     * @param <Tree> the type of the tree being built
+     * @param <Hash> the type of the hash used in the tree
+     */
+    public interface ChildBuilder<This extends ChildBuilder<This, Parent, Child, Tree, Hash>,
+            Parent extends Builder<?, This, Tree, Hash>,
+            Child extends ChildBuilder<Child, This, ?, Tree, Hash>,
+            Tree extends AbstractHashTree<Tree, Hash>,
+            Hash extends Serializable>
+
+            extends Builder<This, Child, Tree, Hash> {
+
+
+        Parent getParent();
+
+        Parent endChild();
+    }
+
+    static class AbstractBuilder<This extends Builder<This, Child, T, H>,
+            Child extends ChildBuilder<Child, This, ?, T, H>,
+            T extends AbstractHashTree<T, H>, H extends Serializable>
+            implements Builder<This, Child, T, H> {
+        private final TreeConstructor<T, H> tctor;
+        private final BiFunction<TreeConstructor<T, H>, This, Child> cctor;
+        private RelativePath path;
+        private H hash;
+        private Map<Path.Segment, T> children;
+
+        AbstractBuilder(TreeConstructor<T, H> tctor,
+                        BiFunction<TreeConstructor<T, H>, This, Child> cctor) {
+            this.tctor = tctor;
+            this.cctor = cctor;
+        }
+
+        public This withPath(RelativePath path) {
+            this.path = path;
+            return castThis();
+        }
+
+        public This withHash(H hash) {
+            this.hash = hash;
+            return castThis();
+        }
+
+        public H getHash() {
+            return hash;
+        }
+
+        public RelativePath getPath() {
+            return path;
+        }
+
+        public boolean hasChildren() {
+            return children != null && !children.isEmpty();
+        }
+
+        public void addChild(T childTree) {
+            getChildren().put(childTree.getPath().getSegment(), childTree);
+        }
+
+        public Child startChild() {
+            return cctor.apply(tctor, castThis());
+        }
+
+        protected T build() {
+            if ((path == null || hash == null) && (children != null && !children.isEmpty())) {
+                throw new IllegalStateException("Cannot construct a tree hash node without a path or " +
+                        "hash and with children. While empty tree without a hash or path is OK, having children " +
+                        "assumes the parent to be fully established.");
+            }
+
+            if (path != null) {
+                int myDepth = path.getDepth();
+
+                for (T child : getChildren().values()) {
+                    int childDepth = child.getPath().getDepth();
+                    if (!path.isParentOf(child.getPath()) || childDepth != myDepth + 1) {
+                        throw new IllegalStateException(
+                                "When building a tree node with path " + path + " an attempt " +
+                                        "to add a child on path " + child.getPath() +
+                                        " was made. The child's path must extend the parent's path by exactly" +
+                                        " one segment, which is not true in this case.");
+                    }
+                }
+            }
+
+            return tctor.construct(path, hash, Collections.unmodifiableMap(getChildren()));
+        }
+
+        private Map<Path.Segment, T> getChildren() {
+            if (children == null) {
+                children = new HashMap<>();
+            }
+
+            return children;
+        }
+
+        @SuppressWarnings("unchecked")
+        private This castThis() {
+            return (This) this;
+        }
+    }
+
+    abstract static class AbstractChildBuilder<
+            This extends AbstractChildBuilder<This, Parent, Child, T, H>,
+            Parent extends Builder<?, This, T, H>,
+            Child extends AbstractChildBuilder<Child, This, ?, T, H>,
+            T extends AbstractHashTree<T, H>,
+            H extends Serializable>
+
+            extends AbstractBuilder<This, Child, T, H>
+            implements ChildBuilder<This, Parent, Child, T, H> {
+        private final Parent parent;
+
+        AbstractChildBuilder(TreeConstructor<T, H> tctor, Parent parent,
+                             BiFunction<TreeConstructor<T, H>, This, Child> cctor) {
+            super(tctor, cctor);
+            this.parent = parent;
+        }
+
+        public Parent getParent() {
+            return parent;
+        }
+
+        @SuppressWarnings("unchecked")
+        public Parent endChild() {
+            T tree = build();
+            parent.addChild(tree);
+            return parent;
+        }
+    }
+}

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ComputeHash.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ComputeHash.java
@@ -1,0 +1,954 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.model;
+
+import static java.util.stream.Collectors.toList;
+
+import static org.hawkular.inventory.paths.DataRole.OperationType.parameterTypes;
+import static org.hawkular.inventory.paths.DataRole.OperationType.returnType;
+import static org.hawkular.inventory.paths.DataRole.Resource.configuration;
+import static org.hawkular.inventory.paths.DataRole.Resource.connectionConfiguration;
+import static org.hawkular.inventory.paths.DataRole.ResourceType.configurationSchema;
+import static org.hawkular.inventory.paths.DataRole.ResourceType.connectionConfigurationSchema;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.hawkular.inventory.api.Inventory;
+import org.hawkular.inventory.api.paging.Page;
+import org.hawkular.inventory.api.paging.Pager;
+import org.hawkular.inventory.paths.CanonicalPath;
+import org.hawkular.inventory.paths.DataRole;
+import org.hawkular.inventory.paths.Path;
+import org.hawkular.inventory.paths.RelativePath;
+import org.hawkular.inventory.paths.SegmentType;
+
+/**
+ * Contains common utilities for computing the different kinds of hashes.
+ *
+ * @author Lukas Krejci
+ * @since 0.18.0
+ */
+final class ComputeHash {
+    static final Comparator<Entity<?, ?>> ENTITY_COMPARATOR = (a, b) -> {
+        if (a == null) return b == null ? 0 : -1;
+        if (b == null) return 1;
+
+        if (!a.getClass().equals(b.getClass())) {
+            return a.getClass().getName().compareTo(b.getClass().getName());
+        } else {
+            return a.getId().compareTo(b.getId());
+        }
+    };
+
+    static final Comparator<Entity.Blueprint> BLUEPRINT_COMPARATOR = (a, b) -> {
+        if (a == null) return b == null ? 0 : -1;
+        if (b == null) return 1;
+
+        Class<? extends Entity<Entity.Blueprint, ?>> ac = Blueprint.getEntityTypeOf(a);
+        Class<? extends Entity<Entity.Blueprint, ?>> bc = Blueprint.getEntityTypeOf(b);
+
+        if (!ac.equals(bc)) {
+            return ac.getName().compareTo(bc.getName());
+        } else {
+            return a.getId().compareTo(b.getId());
+        }
+    };
+
+    private ComputeHash() {
+
+    }
+
+    /**
+     * @return a new message digest to use for hash computation.
+     */
+    static MessageDigest newDigest() {
+        try {
+            return MessageDigest.getInstance("SHA-1");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("Could not instantiate SHA-1 digest algorithm.", e);
+        }
+    }
+
+    private static <R extends DataRole> DataEntity.Blueprint<R> dummyDataBlueprint(R role) {
+        return DataEntity.Blueprint.<R>builder().withRole(role).withValue(StructuredData.get().undefined()).build();
+    }
+
+    static Hashes of(InventoryStructure<?> inventory, CanonicalPath rootPath, boolean computeIdentity,
+                     boolean computeContent, boolean computeSync) {
+        ComputeHash.HashConstructor ctor = new ComputeHash.HashConstructor(new ComputeHash.DigestComputingWriter(
+                ComputeHash.newDigest()));
+
+        IntermediateHashResult res =
+                ComputeHash.computeHash(rootPath, inventory.getRoot(), ComputeHash.HashableView.of(inventory), ctor,
+                        computeIdentity, computeContent, computeSync, (rp) -> null);
+
+        return new Hashes(res.identityHash, res.contentHash, res.syncHash);
+    }
+
+    static IntermediateHashResult treeOf(InventoryStructure<?> inventory, CanonicalPath rootPath,
+                                         boolean computeIdentity,
+                                         boolean computeContent, boolean computeSync,
+                                         Consumer<IntermediateHashContext> onStartChild,
+                                         BiConsumer<IntermediateHashContext, IntermediateHashResult> onEndChild) {
+        ComputeHash.DigestComputingWriter wrt = new ComputeHash.DigestComputingWriter(ComputeHash.newDigest());
+
+        ComputeHash.HashConstructor ctor = new ComputeHash.HashConstructor(wrt) {
+            @Override public void startChild(ComputeHash.IntermediateHashContext context) {
+                super.startChild(context);
+                onStartChild.accept(context);
+            }
+
+            @Override
+            public void endChild(ComputeHash.IntermediateHashContext ctx, ComputeHash.IntermediateHashResult result) {
+                super.endChild(ctx, result);
+                onEndChild.accept(ctx, result);
+            }
+        };
+
+        return computeHash(rootPath, inventory.getRoot(), ComputeHash.HashableView.of(inventory), ctor, computeIdentity,
+                computeContent, computeSync,
+                //we don't want the root element in the relative paths of the children so that they are easily
+                //appendable to the root.
+                (rp) -> rp.slide(1, 0)
+        );
+
+    }
+
+    static IntermediateHashResult computeHash(CanonicalPath entityPath, Blueprint entity, HashableView structure,
+                                              HashConstructor bld, boolean compIdentity, boolean compContent,
+                                              boolean compSync, Function<RelativePath, RelativePath> pathCompleter) {
+
+        Class<?> entityType = Inventory.types().byBlueprint(entity.getClass()).getElementType();
+
+        boolean syncable = Syncable.class.isAssignableFrom(entityType);
+        boolean identityHashable = IdentityHashable.class.isAssignableFrom(entityType);
+        boolean contentHashable = ContentHashable.class.isAssignableFrom(entityType);
+
+        compIdentity = compIdentity || compSync;
+        compContent = compContent || compSync;
+
+        boolean computeIdentity = compIdentity && identityHashable;
+        boolean computeContent = compContent && contentHashable;
+        boolean computeSync = compSync && syncable;
+
+        return entity.accept(new ElementBlueprintVisitor.Simple<IntermediateHashResult, IntermediateHashContext>() {
+            @Override
+            public IntermediateHashResult visitData(DataEntity.Blueprint<?> data, IntermediateHashContext ctx) {
+                return wrap(data, ctx, (childContext) -> {
+                    try {
+                        StringBuilder json = new StringBuilder();
+                        data.getValue().writeJSON(json);
+
+                        if (computeIdentity) {
+                            appendIdentity(data.getId(), childContext);
+                            appendIdentity(json.toString(), childContext);
+                        }
+
+                        if (computeContent) {
+                            appendContent(json.toString(), childContext);
+                            appendCommonContent(data, childContext);
+                        }
+
+                        if (computeSync) {
+                            appendCommonSync(data, childContext);
+                        }
+                    } catch (IOException e) {
+                        throw new IllegalStateException("Could not write out JSON for hash computation purposes.", e);
+                    }
+                });
+            }
+
+            @Override
+            public IntermediateHashResult visitMetricType(MetricType.Blueprint mt, IntermediateHashContext ctx) {
+                return wrap(mt, ctx, (childContext) -> {
+                    if (computeIdentity) {
+                        appendIdentity(mt.getId(), childContext);
+                        appendIdentity(mt.getType().name(), childContext);
+                        appendIdentity(mt.getUnit().name(), childContext);
+                    }
+
+                    if (computeContent) {
+                        appendContent(mt.getType().name(), childContext);
+                        appendContent(mt.getUnit().name(), childContext);
+                        appendContent(Objects.toString(mt.getCollectionInterval(), ""), childContext);
+                        appendCommonContent(mt, childContext);
+                    }
+
+                    if (computeSync) {
+                        appendCommonSync(mt, childContext);
+                    }
+                });
+            }
+
+            @Override
+            public IntermediateHashResult visitOperationType(OperationType.Blueprint operationType,
+                                                             IntermediateHashContext ctx) {
+                return wrap(operationType, ctx, (childContext) -> {
+                    if (computeIdentity) {
+                        appendEntityIdentity(structure.getReturnType(ctx.root, operationType), childContext);
+                        appendEntityIdentity(structure.getParameterTypes(ctx.root, operationType), childContext);
+                        appendIdentity(operationType.getId(), childContext);
+                    }
+
+                    if (computeContent) {
+                        appendCommonContent(operationType, childContext);
+                    }
+
+                    if (computeSync) {
+                        appendCommonSync(operationType, childContext);
+                    }
+                });
+            }
+
+            @Override
+            public IntermediateHashResult visitResourceType(ResourceType.Blueprint type,
+                                                            IntermediateHashContext ctx) {
+                return wrap(type, ctx, (childContext) -> {
+                    if (computeIdentity) {
+                        appendEntityIdentity(structure.getConfigurationSchema(type), childContext);
+                        appendEntityIdentity(structure.getConnectionConfigurationSchema(type), childContext);
+                        structure.getOperationTypes(type).forEach(b -> appendEntityIdentity(b, childContext));
+                        appendIdentity(type.getId(), childContext);
+                    }
+
+                    if (computeContent) {
+                        appendCommonContent(type, childContext);
+                    }
+
+                    if (computeSync) {
+                        appendCommonSync(type, childContext);
+                    }
+                });
+            }
+
+            @Override
+            public IntermediateHashResult visitFeed(Feed.Blueprint feed, IntermediateHashContext ctx) {
+                return wrap(feed, ctx, (childContext) -> {
+                    if (computeIdentity) {
+                        structure.getResourceTypes().forEach(b -> appendEntityIdentity(b, childContext));
+                        structure.getMetricTypes().forEach(b -> appendEntityIdentity(b, childContext));
+                        structure.getFeedResources().forEach(b -> appendEntityIdentity(b, childContext));
+                        structure.getFeedMetrics().forEach(b -> appendEntityIdentity(b, childContext));
+                        appendIdentity(feed.getId(), childContext);
+                    }
+
+                    if (computeContent) {
+                        appendCommonContent(feed, childContext);
+                    }
+
+                    if (computeSync) {
+                        appendCommonSync(feed, childContext);
+                    }
+                });
+            }
+
+            @Override
+            public IntermediateHashResult visitMetric(Metric.Blueprint metric, IntermediateHashContext ctx) {
+                return wrap(metric, ctx, (childContext) -> {
+                    if (computeIdentity) {
+                        appendIdentity(metric.getId(), childContext);
+                    }
+
+                    if (computeContent) {
+                        RelativePath mtPath = relativize(metric.getMetricTypePath(), SegmentType.mt, childContext);
+                        appendContent(mtPath.toString(), childContext);
+                        appendContent(Objects.toString(metric.getCollectionInterval(), ""), childContext);
+                        appendCommonContent(metric, childContext);
+                    }
+
+                    if (computeSync) {
+                        appendCommonSync(metric, childContext);
+                    }
+                });
+            }
+
+            @Override
+            public IntermediateHashResult visitResource(Resource.Blueprint resource,
+                                                        IntermediateHashContext context) {
+                return wrap(resource, context, (childContext) -> {
+                    if (computeIdentity) {
+                        appendEntityIdentity(structure.getConfiguration(context.root, resource), childContext);
+                        appendEntityIdentity(structure.getConnectionConfiguration(context.root, resource),
+                                childContext);
+                        structure.getResources(context.root, resource)
+                                .forEach(b -> appendEntityIdentity(b, childContext));
+                        structure.getResourceMetrics(context.root, resource)
+                                .forEach(b -> appendEntityIdentity(b, childContext));
+                        appendIdentity(resource.getId(), childContext);
+                    }
+
+                    if (computeContent) {
+                        RelativePath rtPath = relativize(resource.getResourceTypePath(), SegmentType.rt, childContext);
+                        appendContent(rtPath.toString(), childContext);
+                        appendCommonContent(resource, childContext);
+                    }
+
+                    if (computeSync) {
+                        appendCommonSync(resource, childContext);
+                    }
+                });
+            }
+
+            @Override
+            public IntermediateHashResult visitTenant(Tenant.Blueprint tenant, IntermediateHashContext context) {
+                return wrap(tenant, context, childContext -> {
+                    if (computeContent) {
+                        appendCommonContent(tenant, childContext);
+                    }
+                });
+            }
+
+            @Override
+            public IntermediateHashResult visitEnvironment(Environment.Blueprint environment,
+                                                           IntermediateHashContext context) {
+                return wrap(environment, context, childContext -> {
+                    if (computeContent) {
+                        appendCommonContent(environment, childContext);
+                    }
+                });
+            }
+
+            private RelativePath relativize(String relativePath, SegmentType targetType, IntermediateHashContext ctx) {
+                Path targetPath = Path.fromPartiallyUntypedString(relativePath,
+                        CanonicalPath.of().tenant(entityPath.ids().getTenantId()).get(), entityPath,
+                        targetType);
+
+                if (targetPath.isCanonical()) {
+                    targetPath = targetPath.toCanonicalPath().relativeTo(entityPath);
+                }
+
+                return targetPath.toRelativePath();
+            }
+
+            private IntermediateHashResult wrap(Entity.Blueprint root, IntermediateHashContext context,
+                                                Consumer<IntermediateHashContext> hashComputation) {
+                IntermediateHashContext childCtx = context.progress(root);
+                bld.startChild(childCtx);
+                hashComputation.accept(childCtx);
+
+                String identityHash = null;
+                String contentHash = null;
+                String syncHash = null;
+
+                DigestComputingWriter digestor = bld.getDigestor();
+                if (computeIdentity) {
+                    digestor.reset();
+                    digestor.append(childCtx.identity);
+                    digestor.close();
+                    identityHash = digestor.digest();
+                }
+
+                if (computeContent) {
+                    digestor.reset();
+                    digestor.append(childCtx.content);
+                    digestor.close();
+                    contentHash = digestor.digest();
+                }
+
+                if (computeSync) {
+                    digestor.reset();
+                    digestor.append(identityHash);
+                    digestor.append(contentHash);
+                    digestor.append(childCtx.sync);
+                    digestor.close();
+                    syncHash = digestor.digest();
+                }
+
+                IntermediateHashResult ret;
+                if (pathCompleter == null) {
+                    ret = new IntermediateHashResult(null, identityHash, contentHash, syncHash);
+                } else {
+                    ret = new IntermediateHashResult(pathCompleter.apply(childCtx.root), identityHash, contentHash,
+                            syncHash);
+                }
+
+                bld.endChild(childCtx, ret);
+
+                return ret;
+            }
+
+            private void appendEntityIdentity(Entity.Blueprint child, IntermediateHashContext ctx) {
+                ctx.identity.append(child.accept(this, ctx).identityHash);
+            }
+        }, new IntermediateHashContext(RelativePath.empty().get()));
+    }
+
+    static void appendIdentity(String data, IntermediateHashContext ctx) {
+        if (data != null) {
+            ctx.identity.append(data);
+        }
+    }
+
+    static void appendContent(String data, IntermediateHashContext ctx) {
+        if (data != null) {
+            ctx.content.append(data);
+        }
+    }
+
+    static void appendContent(Map<String, Object> props, IntermediateHashContext ctx) {
+        if (props == null) {
+            return;
+        }
+
+        SortedMap<String, Object> sorted = new TreeMap<>(Comparator.naturalOrder());
+        sorted.putAll(props);
+
+        for (Map.Entry<String, Object> e : sorted.entrySet()) {
+            ctx.content.append(e.getKey()).append(e.getValue());
+        }
+    }
+
+    static void appendCommonContent(Entity.Blueprint b, IntermediateHashContext ctx) {
+        appendContent(b.getName(), ctx);
+        appendContent(b.getProperties(), ctx);
+    }
+
+    static void appendSync(String data, IntermediateHashContext ctx) {
+        if (data != null) {
+            ctx.sync.append(data);
+        }
+    }
+
+    static void appendCommonSync(Entity.Blueprint bl, IntermediateHashContext ctx) {
+//The code below would cause relationships to influence the sync hash... After some consideration, this is not
+//advisable because it would imply that sync will also synchronize the relationships going in/out of entities. This
+//should not be done, though, because it would erase all the possible custom relationships that were defined out of
+//control and unbeknownst to the sync-caller (i.e. the agent).
+//        Comparator<Map.Entry<String, List<String>>> sortRelationships = (a, b) -> {
+//            int names = a.getKey().compareTo(b.getKey());
+//            if (names != 0) {
+//                return names;
+//            }
+//
+//            List<String> aPaths = a.getValue();
+//            List<String> bPaths = b.getValue();
+//
+//            int lenDiff = aPaths.size() - bPaths.size();
+//            if (lenDiff != 0) {
+//                return lenDiff;
+//            }
+//
+//            for (int i = 0; i < aPaths.size(); ++i) {
+//                String ap = aPaths.get(i);
+//                String bp = bPaths.get(i);
+//
+//                int comp = ap.compareTo(bp);
+//
+//                if (comp != 0) {
+//                    return comp;
+//                }
+//            }
+//
+//            return 0;
+//        };
+//
+//        Function<Map.Entry<String, Set<CanonicalPath>>, Map.Entry<String, List<String>>> sortTargets =
+//                e -> new AbstractMap.SimpleEntry<>(e.getKey(),
+//                        e.getValue().stream().map(Object::toString).sorted().collect(toList()));
+//
+//        Consumer<Map.Entry<String, List<String>>> append = e -> {
+//            appendSync(e.getKey(), ctx);
+//            e.getValue().forEach(p -> appendSync(p, ctx));
+//        };
+//
+//        bl.getIncomingRelationships().entrySet().stream()
+//                .map(sortTargets)
+//                .sorted(sortRelationships)
+//                .forEach(append);
+//
+//        bl.getOutgoingRelationships().entrySet().stream()
+//                .map(sortTargets)
+//                .sorted(sortRelationships)
+//                .forEach(append);
+    }
+
+    @SuppressWarnings("unchecked")
+    static <B extends Blueprint> B asBlueprint(Entity<B, ?> entity, Inventory inventory) {
+        if (entity == null) {
+            return null;
+        }
+        return entity.accept(new ElementVisitor<B, Void>() {
+
+            @Override public B visitData(DataEntity data, Void parameter) {
+                return (B) fillCommon(data, new DataEntity.Blueprint.Builder<>()).withRole(data.getRole())
+                        .withValue(data.getValue()).build();
+            }
+
+            @Override public B visitTenant(Tenant tenant, Void parameter) {
+                return (B) fillCommon(tenant, new Tenant.Blueprint.Builder()).build();
+            }
+
+            @Override public B visitEnvironment(Environment environment, Void parameter) {
+                return (B) fillCommon(environment, new Environment.Blueprint.Builder()).build();
+            }
+
+            @Override public B visitFeed(Feed feed, Void parameter) {
+                return (B) fillCommon(feed, Feed.Blueprint.builder()).build();
+            }
+
+            @Override public B visitMetric(Metric metric, Void parameter) {
+                //we don't want to have tenant ID and all that jazz influencing the hash, so always use
+                //a relative path
+                RelativePath metricTypePath = metric.getType().getPath().relativeTo(metric.getPath());
+
+                return (B) fillCommon(metric, Metric.Blueprint.builder())
+                        .withInterval(metric.getCollectionInterval())
+                        .withMetricTypePath(metricTypePath.toString()).build();
+            }
+
+            @Override public B visitMetricType(MetricType type, Void parameter) {
+                return (B) fillCommon(type, MetricType.Blueprint.builder(type.getType()))
+                        .withInterval(type.getCollectionInterval()).withUnit(type.getUnit()).build();
+            }
+
+            @Override public B visitOperationType(OperationType operationType, Void parameter) {
+                return (B) fillCommon(operationType, OperationType.Blueprint.builder()).build();
+            }
+
+            @Override public B visitMetadataPack(MetadataPack metadataPack, Void parameter) {
+                MetadataPack.Blueprint.Builder bld = MetadataPack.Blueprint.builder()
+                        .withName(metadataPack.getName()).withProperties(metadataPack.getProperties());
+
+                try (Page<MetricType> p = inventory.inspect(metadataPack).metricTypes().getAll()
+                        .entities(Pager.none())) {
+                    p.forEachRemaining(e -> bld.withMember(e.getPath()));
+                }
+
+                try (Page<ResourceType> p = inventory.inspect(metadataPack).resourceTypes().getAll()
+                        .entities(Pager.none())) {
+                    p.forEachRemaining(e -> bld.withMember(e.getPath()));
+                }
+
+                return (B) bld.build();
+            }
+
+            @Override public B visitUnknown(Object entity1, Void parameter) {
+                throw new IllegalStateException("Unhandled entity type during conversion to blueprint: " +
+                        entity1.getClass());
+            }
+
+            @Override public B visitResource(Resource resource, Void parameter) {
+                //we don't want to have tenant ID and all that jazz influencing the hash, so always use
+                //a relative path
+                RelativePath resourceTypePath = resource.getType().getPath().relativeTo(resource.getPath());
+
+                return (B) fillCommon(resource, Resource.Blueprint.builder())
+                        .withResourceTypePath(resourceTypePath.toString()).build();
+            }
+
+            @Override public B visitResourceType(ResourceType type, Void parameter) {
+                return (B) fillCommon(type, ResourceType.Blueprint.builder()).build();
+            }
+
+            @Override public B visitRelationship(Relationship relationship,
+                                                 Void parameter) {
+                throw new IllegalArgumentException("Inventory structure blueprint conversion does not handle " +
+                        "relationships.");
+            }
+
+            private <X extends Entity<? extends XB, ?>, XB extends Entity.Blueprint,
+                    XBB extends Entity.Blueprint.Builder<XB, XBB>>
+            XBB fillCommon(X entity1, XBB bld) {
+                return bld.withId(entity1.getId()).withName(entity1.getName())
+                        .withProperties(entity1.getProperties());
+            }
+        }, null);
+    }
+
+    interface HashableView {
+        static HashableView of(MetadataPack.Members members) {
+            return new HashableView() {
+                @Override public List<ResourceType.Blueprint> getResourceTypes() {
+                    return members.getResourceTypes();
+                }
+
+                @Override public List<MetricType.Blueprint> getMetricTypes() {
+                    return members.getMetricTypes();
+                }
+
+                @Override public List<OperationType.Blueprint> getOperationTypes(ResourceType.Blueprint resourceType) {
+                    List<OperationType.Blueprint> ret = new ArrayList<>(members.getOperationTypes(resourceType));
+                    Collections.sort(ret, BLUEPRINT_COMPARATOR);
+
+                    return ret;
+                }
+
+                @Override public DataEntity.Blueprint<?> getReturnType(RelativePath resourceType,
+                                                                       OperationType.Blueprint operationType) {
+                    return members.getReturnType(operationType);
+                }
+
+                @Override public DataEntity.Blueprint<?> getParameterTypes(RelativePath resourceType,
+                                                                           OperationType.Blueprint operationType) {
+                    return members.getParameterTypes(operationType);
+                }
+
+                @Override public DataEntity.Blueprint<?> getConfigurationSchema(ResourceType.Blueprint rt) {
+                    return members.getConfigurationSchema(rt);
+                }
+
+                @Override public DataEntity.Blueprint<?> getConnectionConfigurationSchema(ResourceType.Blueprint rt) {
+                    return members.getConnectionConfigurationSchema(rt);
+                }
+            };
+        }
+
+        static HashableView of(InventoryStructure<?> structure) {
+            return new HashableView() {
+                @Override
+                public DataEntity.Blueprint<?> getConfiguration(RelativePath rootPath,
+                                                                Resource.Blueprint parentResource) {
+                    RelativePath resourcePath = rootPath.modified().extend(SegmentType.r, parentResource.getId())
+                            .get().slide(1, 0);
+
+                    try (Stream<DataEntity.Blueprint<?>> s = structure.getChildren(resourcePath, DataEntity.class)) {
+                        return s.filter(d -> configuration.equals(d.getRole()))
+                                .findFirst().orElse(dummyDataBlueprint(configuration));
+                    }
+                }
+
+                @Override public DataEntity.Blueprint<?> getConfigurationSchema(ResourceType.Blueprint rt) {
+                    RelativePath p = rt.equals(structure.getRoot()) ? RelativePath.empty().get()
+                            : RelativePath.to().resourceType(rt.getId()).get();
+
+                    try (Stream<DataEntity.Blueprint<?>> s = structure.getChildren(p, DataEntity.class)
+                            .filter(d -> configurationSchema.equals(d.getRole()))) {
+                        return s.findFirst().orElse(dummyDataBlueprint(configurationSchema));
+                    }
+                }
+
+                @Override
+                public DataEntity.Blueprint<?> getConnectionConfiguration(RelativePath root,
+                                                                          Resource.Blueprint parentResource) {
+                    RelativePath resourcePath = root.modified().extend(SegmentType.r, parentResource.getId())
+                            .get().slide(1, 0);
+
+                    try (Stream<DataEntity.Blueprint<?>> s = structure.getChildren(resourcePath, DataEntity.class)
+                            .filter(d -> connectionConfiguration.equals(d.getRole()))) {
+                        return s.findFirst().orElse(dummyDataBlueprint(connectionConfiguration));
+                    }
+                }
+
+                @Override public DataEntity.Blueprint<?> getConnectionConfigurationSchema(ResourceType.Blueprint rt) {
+                    RelativePath p = rt.equals(structure.getRoot()) ? RelativePath.empty().get()
+                            : RelativePath.to().resourceType(rt.getId()).get();
+
+                    try (Stream<DataEntity.Blueprint<?>> s = structure.getChildren(p, DataEntity.class)
+                            .filter(d -> connectionConfigurationSchema.equals(d.getRole()))) {
+                        return s.findFirst().orElse(dummyDataBlueprint(connectionConfigurationSchema));
+                    }
+                }
+
+                @Override public List<Metric.Blueprint> getFeedMetrics() {
+                    try (Stream<Metric.Blueprint> s = structure.getChildren(RelativePath.empty().get(), Metric.class)) {
+                        return s.collect(toList());
+                    }
+                }
+
+                @Override public List<Resource.Blueprint> getFeedResources() {
+                    try (Stream<Resource.Blueprint> s = structure.getChildren(RelativePath.empty().get(),
+                            Resource.class)) {
+                        return s.collect(toList());
+                    }
+                }
+
+                @Override public List<MetricType.Blueprint> getMetricTypes() {
+                    try (Stream<MetricType.Blueprint> s = structure.getChildren(RelativePath.empty().get(),
+                            MetricType.class)) {
+                        return s.collect(toList());
+                    }
+                }
+
+                @Override public List<OperationType.Blueprint> getOperationTypes(ResourceType.Blueprint rt) {
+                    RelativePath p = rt.equals(structure.getRoot()) ? RelativePath.empty().get()
+                            : RelativePath.to().resourceType(rt.getId()).get();
+
+                    try (Stream<OperationType.Blueprint> s = structure.getChildren(p, OperationType.class)) {
+                        return s.collect(toList());
+                    }
+                }
+
+                @Override
+                public DataEntity.Blueprint<?> getParameterTypes(RelativePath rootResourceType,
+                                                                 OperationType.Blueprint ot) {
+                    RelativePath p = rootResourceType.modified().extend(SegmentType.ot, ot.getId()).get()
+                            .slide(1, 0);
+
+                    try (Stream<DataEntity.Blueprint<?>> s = structure.getChildren(p, DataEntity.class)
+                            .filter(d -> parameterTypes.equals(d.getRole()))) {
+                        return s.findFirst().orElse(dummyDataBlueprint(parameterTypes));
+                    }
+                }
+
+                @Override
+                public List<Metric.Blueprint> getResourceMetrics(RelativePath rootPath,
+                                                                 Resource.Blueprint parentResource) {
+                    RelativePath p = rootPath.modified().extend(SegmentType.r, parentResource.getId()).get()
+                            .slide(1, 0);
+
+                    try (Stream<Metric.Blueprint> s = structure.getChildren(p, Metric.class)) {
+                        return s.collect(toList());
+                    }
+                }
+
+                @Override
+                public List<Resource.Blueprint> getResources(RelativePath rootPath, Resource.Blueprint parentResource) {
+                    RelativePath p = rootPath.modified().extend(SegmentType.r, parentResource.getId()).get()
+                            .slide(1, 0);
+
+                    try (Stream<Resource.Blueprint> s = structure.getChildren(p, Resource.class)) {
+                        return s.collect(toList());
+                    }
+                }
+
+                @Override public List<ResourceType.Blueprint> getResourceTypes() {
+                    try (Stream<ResourceType.Blueprint> s = structure.getChildren(RelativePath.empty().get(),
+                            ResourceType.class)) {
+                        return s.collect(toList());
+                    }
+                }
+
+                @Override public DataEntity.Blueprint<?> getReturnType(RelativePath rootResourceType,
+                                                                       OperationType.Blueprint ot) {
+                    RelativePath p = rootResourceType.modified().extend(SegmentType.ot, ot.getId()).get()
+                            .slide(1, 0);
+
+                    try (Stream<DataEntity.Blueprint<?>> s = structure.getChildren(p, DataEntity.class)
+                            .filter(d -> returnType.equals(d.getRole()))) {
+                        return s.findFirst().orElse(dummyDataBlueprint(returnType));
+                    }
+                }
+            };
+        }
+
+        default List<ResourceType.Blueprint> getResourceTypes() {
+            return Collections.emptyList();
+        }
+
+        default List<MetricType.Blueprint> getMetricTypes() {
+            return Collections.emptyList();
+        }
+
+        default List<OperationType.Blueprint> getOperationTypes(ResourceType.Blueprint rt) {
+            return Collections.emptyList();
+        }
+
+        default DataEntity.Blueprint<?> getReturnType(RelativePath rootResourceType, OperationType.Blueprint ot) {
+            return dummyDataBlueprint(returnType);
+        }
+
+        default DataEntity.Blueprint<?> getParameterTypes(RelativePath rootResourceType, OperationType.Blueprint ot) {
+            return dummyDataBlueprint(parameterTypes);
+        }
+
+        default DataEntity.Blueprint<?> getConfigurationSchema(ResourceType.Blueprint rt) {
+            return dummyDataBlueprint(configurationSchema);
+        }
+
+        default DataEntity.Blueprint<?> getConnectionConfigurationSchema(ResourceType.Blueprint rt) {
+            return dummyDataBlueprint(connectionConfigurationSchema);
+        }
+
+        default List<Resource.Blueprint> getResources(RelativePath rootPath, Resource.Blueprint parentResource) {
+            return Collections.emptyList();
+        }
+
+        default List<Resource.Blueprint> getFeedResources() {
+            return Collections.emptyList();
+        }
+
+        default List<Metric.Blueprint> getFeedMetrics() {
+            return Collections.emptyList();
+        }
+
+        default List<Metric.Blueprint> getResourceMetrics(RelativePath rootPath, Resource.Blueprint parentResource) {
+            return Collections.emptyList();
+        }
+
+        default DataEntity.Blueprint<?> getConfiguration(RelativePath rootPath, Resource.Blueprint parentResource) {
+            return dummyDataBlueprint(configuration);
+        }
+
+        default DataEntity.Blueprint<?> getConnectionConfiguration(RelativePath root, Resource.Blueprint
+                parentResource) {
+            return dummyDataBlueprint(connectionConfiguration);
+        }
+    }
+
+    public static final class Tree {
+        private Tree() {
+
+        }
+
+    }
+
+    static class DigestComputingWriter implements Appendable, Closeable {
+        private final MessageDigest digester;
+        private final CharsetEncoder enc = Charset.forName("UTF-8").newEncoder().onMalformedInput(CodingErrorAction
+                .REPLACE).onUnmappableCharacter(CodingErrorAction.REPLACE);
+
+        private final ByteBuffer buffer = ByteBuffer.allocate(512);
+        private String digest;
+
+        DigestComputingWriter(MessageDigest digester) {
+            this.digester = digester;
+        }
+
+        @Override
+        public DigestComputingWriter append(CharSequence csq) {
+            consumeBuffer(CharBuffer.wrap(csq));
+            return this;
+        }
+
+        @Override
+        public DigestComputingWriter append(CharSequence csq, int start, int end) {
+            consumeBuffer(CharBuffer.wrap(csq, start, end));
+            return this;
+        }
+
+        @Override
+        public DigestComputingWriter append(char c) {
+            consumeBuffer(CharBuffer.wrap(new char[]{c}));
+            return this;
+        }
+
+        @Override
+        public void close() {
+            this.digest = runningDigest();
+        }
+
+        /**
+         * Computes the digest of the data appended so far. Notice that this is recomputed every time this method
+         * is called.
+         *
+         * @return the freshly computed digest of the data obtained so far
+         */
+        String runningDigest() {
+            byte[] digest = digester.digest();
+
+            StringBuilder bld = new StringBuilder();
+            for (byte b : digest) {
+                bld.append(Integer.toHexString(Byte.toUnsignedInt(b)));
+            }
+
+            return bld.toString();
+        }
+
+        /**
+         * Obtains the final digest from the entirety of the data. Contrast this with {@link #runningDigest()}.
+         * <p>This method does not do any computation and is therefore very quick.
+         * <p>Note that this writer MUST BE {@link #close() CLOSED} for this method to return successfully.
+         *
+         * @return the computed digest of the data
+         */
+        String digest() {
+            if (digest == null) {
+                throw new IllegalStateException("digest computing writer not closed.");
+            }
+
+            return digest;
+        }
+
+        public void reset() {
+            digester.reset();
+            digest = null;
+        }
+
+        private void consumeBuffer(CharBuffer chars) {
+            CoderResult res;
+            do {
+                res = enc.encode(chars, buffer, true);
+                buffer.flip();
+                digester.update(buffer);
+                buffer.clear();
+            } while (res == CoderResult.OVERFLOW);
+        }
+    }
+
+    static class IntermediateHashContext {
+        final RelativePath root;
+        final StringBuilder identity = new StringBuilder();
+        final StringBuilder content = new StringBuilder();
+        final StringBuilder sync = new StringBuilder();
+
+        IntermediateHashContext(RelativePath root) {
+            this.root = root;
+        }
+
+        IntermediateHashContext progress(Entity.Blueprint bl) {
+            return new IntermediateHashContext(root.modified().extend(Blueprint.getSegmentTypeOf(bl),
+                    bl.getId()).get());
+        }
+    }
+
+    static class IntermediateHashResult {
+        final RelativePath path;
+        final String identityHash;
+        final String contentHash;
+        final String syncHash;
+
+        private IntermediateHashResult(RelativePath path, String identityHash, String contentHash, String syncHash) {
+            this.path = path;
+            this.identityHash = identityHash;
+            this.contentHash = contentHash;
+            this.syncHash = syncHash;
+        }
+    }
+
+    static class HashConstructor {
+        private final DigestComputingWriter digestor;
+
+        HashConstructor(DigestComputingWriter digestor) {
+            this.digestor = digestor;
+        }
+
+        public DigestComputingWriter getDigestor() {
+            return digestor;
+        }
+
+        public void startChild(IntermediateHashContext context) {
+//            System.out.println("start: " + context.root);
+        }
+
+        public void endChild(IntermediateHashContext ctx, IntermediateHashResult result) {
+//            System.out.println("Intermediate result: path: " + result.path + ", hash: " + result.hash + ", content: "
+//                    + ctx.content);
+        }
+    }
+}
+

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ContentHash.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ContentHash.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.model;
+
+import org.hawkular.inventory.paths.CanonicalPath;
+
+/**
+ * Utility class to compute the content hash of entities. Content hash is not hierarchical nor it is "identifying".
+ * It merely hashes the contents of an entity without its ID. I.e. it includes the name, generic properties and any
+ * other properties on the entities.
+ * <p>
+ * Note that {@link MetadataPack} does not have a content hash.
+ *
+ * @author Lukas Krejci
+ * @since 0.18.0
+ */
+public final class ContentHash {
+
+    private ContentHash() {
+
+    }
+
+    public static String of(Entity<? extends Entity.Blueprint, ?> entity) {
+        //the only entity that requires the inventory to convert to its blueprint is the metadatapack.
+        //but metadatapacks do not have a content hash, so we're good passing in null here.
+        Entity.Blueprint bl = ComputeHash.asBlueprint(entity, null);
+        return of(bl, entity.getPath());
+    }
+
+    /**
+     * The entity path is currently only required for resources, which base their content hash on the resource type
+     * path which can be specified using a relative or canonical path in the blueprint. For the content hash to be
+     * consistent we need to convert to just a single representation of the path.
+     *
+     * @param entity the entity to produce the hash of
+     * @param entityPath the canonical path of the entity (can be null for all but resources)
+     * @return the content hash of the entity
+     */
+    public static String of(Entity.Blueprint entity, CanonicalPath entityPath) {
+        return ComputeHash.of(InventoryStructure.of(entity).build(), entityPath, false, true, false).getContentHash();
+    }
+}

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ContentHashable.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ContentHashable.java
@@ -14,28 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.inventory.api.test;
-
-import org.hawkular.inventory.api.model.Environment;
-import org.hawkular.inventory.paths.CanonicalPath;
-import org.junit.Assert;
-import org.junit.Test;
+package org.hawkular.inventory.api.model;
 
 /**
+ * Interface of entities with a content hash.
+ *
  * @author Lukas Krejci
- * @since 0.2.0
+ * @since 0.18.0
  */
-public class CanonicalPathTest {
+public interface ContentHashable {
 
-    @Test
-    public void testEntityInstantiationWithWrongPath() throws Exception {
-        try {
-            new Environment(CanonicalPath.of().tenant("t").get(), null);
-            Assert.fail("Creating an entity with a path pointing to a different entity type should not be possible.");
-        } catch (IllegalArgumentException e) {
-            //good
-        }
-    }
-
-    // other tests moved to org.hawkular.inventory.paths.CanonicalPathTest
+    String getContentHash();
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ContentHashedEntity.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ContentHashedEntity.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.model;
+
+import java.util.Map;
+
+import org.hawkular.inventory.paths.CanonicalPath;
+
+/**
+ * Base class for entities with a content hash.
+ *
+ * @author Lukas Krejci
+ * @since 0.18.0
+ */
+public abstract class ContentHashedEntity<B extends Blueprint, U extends Entity.Update> extends Entity<B, U>
+    implements ContentHashable {
+
+    private final String contentHash;
+
+    protected ContentHashedEntity() {
+        this.contentHash = null;
+    }
+
+    protected ContentHashedEntity(CanonicalPath path, String contentHash) {
+        super(path);
+        this.contentHash = contentHash;
+    }
+
+    protected ContentHashedEntity(CanonicalPath path,
+                                  String contentHash, Map<String, Object> properties) {
+        super(path, properties);
+        this.contentHash = contentHash;
+    }
+
+    protected ContentHashedEntity(String name, CanonicalPath path, String contentHash) {
+        super(name, path);
+        this.contentHash = contentHash;
+    }
+
+    protected ContentHashedEntity(String name, CanonicalPath path,
+                                  String contentHash, Map<String, Object> properties) {
+        super(name, path, properties);
+        this.contentHash = contentHash;
+    }
+
+    @Override public String getContentHash() {
+        return contentHash;
+    }
+}

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Entity.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Entity.java
@@ -35,7 +35,7 @@ import io.swagger.annotations.ApiModel;
  * @since 0.0.1
  */
 @ApiModel(description = "Defines the basic properties of all entity types in inventory",
-        subTypes = {Environment.class, IdentityHashedEntity.class, MetadataPack.class, Tenant.class})
+        subTypes = {Environment.class, SyncedEntity.class, MetadataPack.class, Tenant.class})
 public abstract class Entity<B extends Blueprint, U extends Entity.Update> extends AbstractElement<B, U> {
 
     public static Class<?> typeFromSegmentType(SegmentType segmentType) {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Environment.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Environment.java
@@ -38,7 +38,7 @@ import io.swagger.annotations.ApiModel;
  */
 @ApiModel(description = "Environment can incorporate feeds and can contain resources and metrics.",
         parent = Entity.class)
-public final class Environment extends Entity<Environment.Blueprint, Environment.Update> {
+public final class Environment extends ContentHashedEntity<Environment.Blueprint, Environment.Update> {
 
     public static final SegmentType SEGMENT_TYPE = SegmentType.e;
 
@@ -46,25 +46,25 @@ public final class Environment extends Entity<Environment.Blueprint, Environment
     private Environment() {
     }
 
-    public Environment(CanonicalPath path) {
-        this(path, null);
+    public Environment(CanonicalPath path, String contentHash) {
+        super(path, contentHash);
     }
 
-    public Environment(String name, CanonicalPath path) {
-        super(name, path);
+    public Environment(String name, CanonicalPath path, String contentHash) {
+        super(name, path, contentHash);
     }
 
-    public Environment(CanonicalPath path, Map<String, Object> properties) {
-        this(null, path, properties);
+    public Environment(CanonicalPath path, String contentHash, Map<String, Object> properties) {
+        this(null, path, contentHash, properties);
     }
 
-    public Environment(String name, CanonicalPath path, Map<String, Object> properties) {
-        super(name, path, properties);
+    public Environment(String name, CanonicalPath path, String contentHash, Map<String, Object> properties) {
+        super(name, path, contentHash, properties);
     }
 
     @Override
     public Updater<Update, Environment> update() {
-        return new Updater<>((u) -> new Environment(u.getName(), getPath(), u.getProperties()));
+        return new Updater<>((u) -> new Environment(u.getName(), getPath(), getContentHash(), u.getProperties()));
     }
 
     @Override

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Feed.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Feed.java
@@ -36,8 +36,8 @@ import io.swagger.annotations.ApiModel;
  * @since 0.1.0
  */
 @ApiModel(description = "A feed represents a remote \"agent\" that is reporting its data to Hawkular.",
-        parent = IdentityHashedEntity.class)
-public final class Feed extends IdentityHashedEntity<Feed.Blueprint, Feed.Update> {
+        parent = SyncedEntity.class)
+public final class Feed extends SyncedEntity<Feed.Blueprint, Feed.Update> {
 
     public static final SegmentType SEGMENT_TYPE = SegmentType.f;
 
@@ -48,25 +48,28 @@ public final class Feed extends IdentityHashedEntity<Feed.Blueprint, Feed.Update
     private Feed() {
     }
 
-    public Feed(CanonicalPath path, String identityHash) {
-        this(path, identityHash, null);
+    public Feed(CanonicalPath path, String identityHash, String contentHash, String syncHash) {
+        this(path, identityHash, contentHash, syncHash, null);
     }
 
-    public Feed(String name, CanonicalPath path, String identityHash) {
-        super(name, path, identityHash);
+    public Feed(String name, CanonicalPath path, String identityHash, String contentHash, String syncHash) {
+        super(name, path, identityHash, contentHash, syncHash);
     }
 
-    public Feed(CanonicalPath path, String identityHash, Map<String, Object> properties) {
-        super(path, identityHash, properties);
+    public Feed(CanonicalPath path, String identityHash, String contentHash, String syncHash,
+                Map<String, Object> properties) {
+        super(path, identityHash, contentHash, syncHash, properties);
     }
 
-    public Feed(String name, CanonicalPath path, String identityHash, Map<String, Object> properties) {
-        super(name, path, identityHash, properties);
+    public Feed(String name, CanonicalPath path, String identityHash, String contentHash, String syncHash,
+                Map<String, Object> properties) {
+        super(name, path, identityHash, contentHash, syncHash, properties);
     }
 
     @Override
     public Updater<Update, Feed> update() {
-        return new Updater<>((u) -> new Feed(u.getName(), getPath(), getIdentityHash(), u.getProperties()));
+        return new Updater<>((u) -> new Feed(u.getName(), getPath(), getIdentityHash(), getContentHash(), getSyncHash(),
+                u.getProperties()));
     }
 
     @Override

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Hashes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Hashes.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.model;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.hawkular.inventory.api.model.ComputeHash.IntermediateHashContext;
+import org.hawkular.inventory.api.model.ComputeHash.IntermediateHashResult;
+import org.hawkular.inventory.paths.CanonicalPath;
+import org.hawkular.inventory.paths.Path;
+import org.hawkular.inventory.paths.RelativePath;
+
+/**
+ * A container for all type of hashes computed on an entity. Depending on what kind of hashes have been computed, some
+ * properties of this class might be null. The caller is responsible to keep track of what's been computed and hence
+ * what hashes are held in instances of this class.
+ *
+ * @author Lukas Krejci
+ * @since 0.18.0
+ */
+public final class Hashes implements Serializable {
+
+    private final String identityHash;
+    private final String contentHash;
+    private final String syncHash;
+
+    public static Hashes of(InventoryStructure<?> root, CanonicalPath rootPath) {
+        return ComputeHash.of(root, rootPath, true, true, true);
+    }
+
+    public static Tree treeOf(InventoryStructure<?> root, CanonicalPath rootPath) {
+        Tree.AbstractBuilder<?>[] tbld =
+                new Tree.AbstractBuilder[1];
+
+        Consumer<IntermediateHashContext> startChild = context -> {
+            if (tbld[0] == null) {
+                tbld[0] = Tree.builder();
+            } else {
+                tbld[0] = tbld[0].startChild();
+            }
+        };
+
+        BiConsumer<IntermediateHashContext, IntermediateHashResult> endChild = (ctx, result) -> {
+            if (tbld[0] instanceof Tree.ChildBuilder) {
+                tbld[0].withHash(new Hashes(result)).withPath(result.path);
+                @SuppressWarnings("unchecked")
+                Tree.AbstractBuilder<?> parent =
+                        ((Tree.ChildBuilder<?>) tbld[0]).getParent();
+                parent.addChild(((Tree.ChildBuilder<?>) tbld[0]).build());
+                tbld[0] = parent;
+            }
+        };
+
+        IntermediateHashResult res = ComputeHash.treeOf(root, rootPath, true, true, true, startChild, endChild);
+
+        tbld[0].withPath(res.path).withHash(new Hashes(res));
+
+        return ((Tree.Builder)tbld[0]).build();
+    }
+
+    public Hashes(String identityHash, String contentHash, String syncHash) {
+        this.identityHash = identityHash;
+        this.contentHash = contentHash;
+        this.syncHash = syncHash;
+    }
+
+    Hashes(IntermediateHashResult res) {
+        this(res.identityHash, res.contentHash, res.syncHash);
+    }
+
+    public String getIdentityHash() {
+        return identityHash;
+    }
+
+    public String getContentHash() {
+        return contentHash;
+    }
+
+    public String getSyncHash() {
+        return syncHash;
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Hashes hashes = (Hashes) o;
+
+        if (identityHash != null ? !identityHash.equals(hashes.identityHash) : hashes.identityHash != null) {
+            return false;
+        } else if (contentHash != null ? !contentHash.equals(hashes.contentHash) : hashes.contentHash != null) {
+            return false;
+        } else {
+            return syncHash != null ? syncHash.equals(hashes.syncHash) : hashes.syncHash == null;
+        }
+    }
+
+    @Override public int hashCode() {
+        int result = identityHash != null ? identityHash.hashCode() : 0;
+        result = 31 * result + (contentHash != null ? contentHash.hashCode() : 0);
+        result = 31 * result + (syncHash != null ? syncHash.hashCode() : 0);
+        return result;
+    }
+
+    public static final class Tree extends AbstractHashTree<Tree, Hashes> {
+        //jackson support
+        private Tree() {
+            this(null, null, null);
+        }
+
+        private Tree(RelativePath path, Hashes hash, Map<Path.Segment, Tree> children) {
+            super(path, hash == null ? new Hashes(null, null, null) : hash, children);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public interface AbstractBuilder<This extends AbstractHashTree.Builder<This, ChildBuilder<This>, Tree, Hashes>
+                & AbstractBuilder<This>>
+                extends AbstractHashTree.Builder<This, ChildBuilder<This>, Tree, Hashes> {
+        }
+
+        public static final class Builder
+                extends AbstractHashTree.AbstractBuilder<Builder, ChildBuilder<Builder>, Tree, Hashes>
+                implements AbstractBuilder<Builder>, TopBuilder<Builder, ChildBuilder<Builder>, Tree, Hashes> {
+
+            private Builder() {
+                super(Tree::new, ChildBuilder<Builder>::new);
+            }
+
+            @Override
+            public Tree build() {
+                return super.build();
+            }
+        }
+
+        public static final class ChildBuilder<
+                Parent extends AbstractHashTree.Builder<Parent, ChildBuilder<Parent>, Tree, Hashes>
+                        & AbstractBuilder<Parent>>
+                extends AbstractChildBuilder<ChildBuilder<Parent>, Parent, ChildBuilder<ChildBuilder<Parent>>,
+                Tree, Hashes>
+                implements AbstractBuilder<ChildBuilder<Parent>>,
+                AbstractHashTree.ChildBuilder<ChildBuilder<Parent>, Parent, ChildBuilder<ChildBuilder<Parent>>, Tree,
+                                        Hashes> {
+
+            ChildBuilder(TreeConstructor<Tree, Hashes> tctor, Parent p) {
+                super(tctor, p, ChildBuilder<ChildBuilder<Parent>>::new);
+            }
+        }
+    }
+}

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/IdentityHash.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/IdentityHash.java
@@ -16,46 +16,19 @@
  */
 package org.hawkular.inventory.api.model;
 
-import static java.util.stream.Collectors.toList;
-
-import static org.hawkular.inventory.paths.DataRole.OperationType.parameterTypes;
-import static org.hawkular.inventory.paths.DataRole.OperationType.returnType;
-import static org.hawkular.inventory.paths.DataRole.Resource.configuration;
-import static org.hawkular.inventory.paths.DataRole.Resource.connectionConfiguration;
-import static org.hawkular.inventory.paths.DataRole.ResourceType.configurationSchema;
-import static org.hawkular.inventory.paths.DataRole.ResourceType.connectionConfigurationSchema;
-
-import java.io.Closeable;
-import java.io.IOException;
 import java.io.Serializable;
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.CharsetEncoder;
-import java.nio.charset.CoderResult;
-import java.nio.charset.CodingErrorAction;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Stream;
 
 import org.hawkular.inventory.api.Inventory;
-import org.hawkular.inventory.api.TreeTraversal;
-import org.hawkular.inventory.paths.DataRole;
 import org.hawkular.inventory.paths.Path;
 import org.hawkular.inventory.paths.RelativePath;
-import org.hawkular.inventory.paths.SegmentType;
 
 import io.swagger.annotations.ApiModel;
 
@@ -88,52 +61,30 @@ import io.swagger.annotations.ApiModel;
  */
 public final class IdentityHash {
 
-    private static final Comparator<Entity<?, ?>> ENTITY_COMPARATOR = (a, b) -> {
-        if (a == null) return b == null ? 0 : -1;
-        if (b == null) return 1;
-
-        if (!a.getClass().equals(b.getClass())) {
-            return a.getClass().getName().compareTo(b.getClass().getName());
-        } else {
-            return a.getId().compareTo(b.getId());
-        }
-    };
-
-    private static final Comparator<Entity.Blueprint> BLUEPRINT_COMPARATOR = (a, b) -> {
-        if (a == null) return b == null ? 0 : -1;
-        if (b == null) return 1;
-
-        Class<? extends Entity<Entity.Blueprint, ?>> ac = Blueprint.getEntityTypeOf(a);
-        Class<? extends Entity<Entity.Blueprint, ?>> bc = Blueprint.getEntityTypeOf(b);
-
-        if (!ac.equals(bc)) {
-            return ac.getName().compareTo(bc.getName());
-        } else {
-            return a.getId().compareTo(b.getId());
-        }
-    };
-
     private IdentityHash() {
 
     }
 
     public static String of(MetadataPack.Members metadata) {
-        HashConstructor ctor = new HashConstructor(new DigestComputingWriter(newDigest()));
+        ComputeHash.HashConstructor ctor = new ComputeHash.HashConstructor(new ComputeHash.DigestComputingWriter(
+                ComputeHash.newDigest()));
 
-        HashableView metadataView = HashableView.of(metadata);
+        ComputeHash.HashableView metadataView = ComputeHash.HashableView.of(metadata);
 
-        SortedSet<Entity.Blueprint> all = new TreeSet<>(BLUEPRINT_COMPARATOR);
+        SortedSet<Entity.Blueprint> all = new TreeSet<>(ComputeHash.BLUEPRINT_COMPARATOR);
         all.addAll(metadata.getMetricTypes());
         all.addAll(metadata.getResourceTypes());
 
         StringBuilder result = new StringBuilder();
 
         for (Entity.Blueprint bl : all) {
-            IntermediateHashResult res = computeHash(bl, metadataView, ctor, (rp) -> null);
-            result.append(res.hash);
+            //identity hash not dependent on relative paths (if any) in the data, so null for entityPath is ok.
+            ComputeHash.IntermediateHashResult res = ComputeHash.computeHash(null, bl, metadataView, ctor, true, false,
+                    false, (rp) -> null);
+            result.append(res.identityHash);
         }
 
-        DigestComputingWriter digestor = ctor.getDigestor();
+        ComputeHash.DigestComputingWriter digestor = ctor.getDigestor();
         digestor.reset();
         digestor.append(result);
         digestor.close();
@@ -141,11 +92,9 @@ public final class IdentityHash {
     }
 
     public static String of(InventoryStructure<?> inventory) {
-        HashConstructor ctor = new HashConstructor(new DigestComputingWriter(newDigest()));
-
-        computeHash(inventory.getRoot(), HashableView.of(inventory), ctor, (rp) -> null);
-
-        return ctor.getDigestor().digest();
+        //identity hash is not dependent on the root path - I.e. no relative paths in the inventory structure are used
+        //to compute the identity hash...
+        return ComputeHash.of(inventory, null, true, false, false).getIdentityHash();
     }
 
     public static String of(Entity<? extends Entity.Blueprint, ?> entity, Inventory inventory) {
@@ -161,39 +110,37 @@ public final class IdentityHash {
     }
 
     public static Tree treeOf(InventoryStructure<?> inventory) {
-        Tree.AbstractBuilder<?>[] tbld = new Tree.AbstractBuilder[1];
+        @SuppressWarnings("unchecked")
+        Tree.AbstractBuilder<?>[] tbld =
+                new Tree.AbstractBuilder[1];
 
-        DigestComputingWriter wrt = new DigestComputingWriter(newDigest());
-
-        HashConstructor ctor = new HashConstructor(wrt) {
-            @Override public void startChild(IntermediateHashContext context) {
-                super.startChild(context);
-                if (tbld[0] == null) {
-                    tbld[0] = Tree.builder();
-                } else {
-                    tbld[0] = tbld[0].startChild();
-                }
-            }
-
-            @Override public void endChild(IntermediateHashContext ctx, IntermediateHashResult result) {
-                super.endChild(ctx, result);
-                if (tbld[0] instanceof Tree.ChildBuilder) {
-                    tbld[0].withHash(result.hash).withPath(result.path);
-                    Tree.AbstractBuilder<?> parent = ((Tree.ChildBuilder) tbld[0]).parent;
-                    parent.addChild(tbld[0].build());
-                    tbld[0] = parent;
-                }
+        Consumer<ComputeHash.IntermediateHashContext> startChild = context -> {
+            if (tbld[0] == null) {
+                tbld[0] = Tree.builder();
+            } else {
+                tbld[0] = tbld[0].startChild();
             }
         };
 
-        IntermediateHashResult res = computeHash(inventory.getRoot(), HashableView.of(inventory), ctor,
-                //we don't want the root element in the relative paths of the children so that they are easily
-                //appendable to the root.
-                (rp) -> rp.slide(1, 0));
+        BiConsumer<ComputeHash.IntermediateHashContext, ComputeHash.IntermediateHashResult> endChild = (ctx, result) -> {
+            if (tbld[0] instanceof Tree.ChildBuilder) {
+                tbld[0].withHash(result.identityHash).withPath(result.path);
+                @SuppressWarnings("unchecked")
+                Tree.AbstractBuilder<?> parent =
+                        ((Tree.ChildBuilder<?>) tbld[0]).getParent();
+                parent.addChild(((Tree.ChildBuilder<?>) tbld[0]).build());
+                tbld[0] = parent;
+            }
+        };
 
-        tbld[0].withPath(res.path).withHash(res.hash);
+        //identity hash is not computed using any relative paths, so we can pass null to the root path of the
+        //computation.
+        ComputeHash.IntermediateHashResult res = ComputeHash.treeOf(inventory, null, true, false, false, startChild,
+                endChild);
 
-        return tbld[0].build();
+        tbld[0].withPath(res.path).withHash(res.identityHash);
+
+        return ((Tree.Builder)tbld[0]).build();
     }
 
     public static String of(Iterable<? extends Entity<? extends Entity.Blueprint, ?>> entities, Inventory inventory) {
@@ -201,19 +148,22 @@ public final class IdentityHash {
     }
 
     public static String of(Iterator<? extends Entity<? extends Entity.Blueprint, ?>> entities, Inventory inventory) {
-        SortedSet<Entity<? extends Entity.Blueprint, ?>> sortedEntities = new TreeSet<>(ENTITY_COMPARATOR);
+        SortedSet<Entity<? extends Entity.Blueprint, ?>> sortedEntities = new TreeSet<>(ComputeHash.ENTITY_COMPARATOR);
 
         entities.forEachRemaining(sortedEntities::add);
 
-        HashConstructor ctor = new HashConstructor(new DigestComputingWriter(newDigest()));
+        ComputeHash.HashConstructor ctor = new ComputeHash.HashConstructor(new ComputeHash.DigestComputingWriter(
+                ComputeHash.newDigest()));
 
         StringBuilder resultHash = new StringBuilder();
 
         sortedEntities.forEach((e) -> {
             InventoryStructure<?> structure = InventoryStructure.of(e, inventory);
-            HashableView v = HashableView.of(structure);
-            IntermediateHashResult res = computeHash(structure.getRoot(), v, ctor, (rp) -> null);
-            resultHash.append(res.hash);
+            ComputeHash.HashableView v = ComputeHash.HashableView.of(structure);
+            ComputeHash.IntermediateHashResult res = ComputeHash
+                    .computeHash(e.getPath(), structure.getRoot(), v, ctor, true, false,
+                            false, (rp) -> null);
+            resultHash.append(res.identityHash);
         });
 
         ctor.getDigestor().reset();
@@ -223,619 +173,51 @@ public final class IdentityHash {
         return ctor.getDigestor().digest();
     }
 
-    private static IntermediateHashResult computeHash(Blueprint entity, HashableView structure,
-                                                      HashConstructor bld,
-                                                      Function<RelativePath, RelativePath> pathCompleter) {
-
-        return entity.accept(new ElementBlueprintVisitor.Simple<IntermediateHashResult, IntermediateHashContext>() {
-            @Override
-            public IntermediateHashResult visitData(DataEntity.Blueprint<?> data, IntermediateHashContext ctx) {
-                return wrap(data, ctx, (childContext) -> {
-                    try {
-                        childContext.content.append(data.getId());
-                        data.getValue().writeJSON(childContext.content);
-                    } catch (IOException e) {
-                        throw new IllegalStateException("Could not write out JSON for hash computation purposes.", e);
-                    }
-                });
-            }
-
-            @Override
-            public IntermediateHashResult visitMetricType(MetricType.Blueprint mt, IntermediateHashContext ctx) {
-                return wrap(mt, ctx, (childContext) -> {
-                    append(mt.getId(), childContext);
-                    append(mt.getType().name(), childContext);
-                    append(mt.getUnit().name(), childContext);
-                });
-            }
-
-            @Override
-            public IntermediateHashResult visitOperationType(OperationType.Blueprint operationType,
-                                                             IntermediateHashContext ctx) {
-                return wrap(operationType, ctx, (childContext) -> {
-                    append(structure.getReturnType(ctx.root, operationType), childContext);
-                    append(structure.getParameterTypes(ctx.root, operationType), childContext);
-                    append(operationType.getId(), childContext);
-                });
-            }
-
-            @Override
-            public IntermediateHashResult visitResourceType(ResourceType.Blueprint type,
-                                                            IntermediateHashContext ctx) {
-                return wrap(type, ctx, (childContext) -> {
-                    append(structure.getConfigurationSchema(type), childContext);
-                    append(structure.getConnectionConfigurationSchema(type), childContext);
-                    structure.getOperationTypes(type).forEach(b -> append(b, childContext));
-                    append(type.getId(), childContext);
-                });
-            }
-
-            @Override
-            public IntermediateHashResult visitFeed(Feed.Blueprint feed, IntermediateHashContext ctx) {
-                return wrap(feed, ctx, (childContext) -> {
-                    structure.getResourceTypes().forEach(b -> append(b, childContext));
-                    structure.getMetricTypes().forEach(b -> append(b, childContext));
-                    structure.getFeedResources().forEach(b -> append(b, childContext));
-                    structure.getFeedMetrics().forEach(b -> append(b, childContext));
-                    append(feed.getId(), childContext);
-                });
-            }
-
-            @Override
-            public IntermediateHashResult visitMetric(Metric.Blueprint metric, IntermediateHashContext ctx) {
-                return wrap(metric, ctx, (childContext) -> append(metric.getId(), childContext));
-            }
-
-            @Override
-            public IntermediateHashResult visitResource(Resource.Blueprint resource,
-                                                        IntermediateHashContext context) {
-                return wrap(resource, context, (childContext) -> {
-                    append(structure.getConfiguration(context.root, resource), childContext);
-                    append(structure.getConnectionConfiguration(context.root, resource), childContext);
-                    structure.getResources(context.root, resource).forEach(b -> append(b, childContext));
-                    structure.getResourceMetrics(context.root, resource).forEach(b -> append(b, childContext));
-                    append(resource.getId(), childContext);
-                });
-            }
-
-            private void append(String data, IntermediateHashContext ctx) {
-                ctx.content.append(data);
-            }
-
-            private void append(Entity.Blueprint child, IntermediateHashContext ctx) {
-                ctx.content.append(child.accept(this, ctx).hash);
-            }
-
-            private IntermediateHashResult wrap(Entity.Blueprint root, IntermediateHashContext context,
-                                                Consumer<IntermediateHashContext> hashComputation) {
-                IntermediateHashContext childCtx = context.progress(root);
-                bld.startChild(childCtx);
-                hashComputation.accept(childCtx);
-
-                DigestComputingWriter digestor = bld.getDigestor();
-                digestor.reset();
-                digestor.append(childCtx.content);
-                digestor.close();
-
-                IntermediateHashResult ret;
-                if (pathCompleter == null) {
-                    ret = new IntermediateHashResult(null, digestor.digest());
-                } else {
-                    ret = new IntermediateHashResult(pathCompleter.apply(childCtx.root), digestor.digest());
-                }
-
-                bld.endChild(childCtx, ret);
-
-                return ret;
-            }
-        }, new IntermediateHashContext(RelativePath.empty().get()));
-    }
-
-    private static MessageDigest newDigest() {
-        try {
-            return MessageDigest.getInstance("SHA-1");
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("Could not instantiate SHA-1 digest algorithm.", e);
-        }
-    }
-
-    private static <R extends DataRole> DataEntity.Blueprint<R> dummyDataBlueprint(R role) {
-        return DataEntity.Blueprint.<R>builder().withRole(role).withValue(StructuredData.get().undefined()).build();
-    }
-
-    private interface HashableView {
-        static HashableView of(MetadataPack.Members members) {
-            return new HashableView() {
-                @Override public List<ResourceType.Blueprint> getResourceTypes() {
-                    return members.getResourceTypes();
-                }
-
-                @Override public List<MetricType.Blueprint> getMetricTypes() {
-                    return members.getMetricTypes();
-                }
-
-                @Override public List<OperationType.Blueprint> getOperationTypes(ResourceType.Blueprint resourceType) {
-                    List<OperationType.Blueprint> ret = new ArrayList<>(members.getOperationTypes(resourceType));
-                    Collections.sort(ret, BLUEPRINT_COMPARATOR);
-
-                    return ret;
-                }
-
-                @Override public DataEntity.Blueprint<?> getReturnType(RelativePath resourceType,
-                                                                       OperationType.Blueprint operationType) {
-                    return members.getReturnType(operationType);
-                }
-
-                @Override public DataEntity.Blueprint<?> getParameterTypes(RelativePath resourceType,
-                                                                           OperationType.Blueprint operationType) {
-                    return members.getParameterTypes(operationType);
-                }
-
-                @Override public DataEntity.Blueprint<?> getConfigurationSchema(ResourceType.Blueprint rt) {
-                    return members.getConfigurationSchema(rt);
-                }
-
-                @Override public DataEntity.Blueprint<?> getConnectionConfigurationSchema(ResourceType.Blueprint rt) {
-                    return members.getConnectionConfigurationSchema(rt);
-                }
-            };
-        }
-
-        static HashableView of(InventoryStructure<?> structure) {
-            return new HashableView() {
-                @Override
-                public DataEntity.Blueprint<?> getConfiguration(RelativePath rootPath,
-                                                                Resource.Blueprint parentResource) {
-                    RelativePath resourcePath = rootPath.modified().extend(SegmentType.r, parentResource.getId())
-                            .get().slide(1, 0);
-
-                    try (Stream<DataEntity.Blueprint<?>> s = structure.getChildren(resourcePath, DataEntity.class)) {
-                        return s.filter(d -> configuration.equals(d.getRole()))
-                                .findFirst().orElse(dummyDataBlueprint(configuration));
-                    }
-                }
-
-                @Override public DataEntity.Blueprint<?> getConfigurationSchema(ResourceType.Blueprint rt) {
-                    RelativePath p = rt.equals(structure.getRoot()) ? RelativePath.empty().get()
-                            : RelativePath.to().resourceType(rt.getId()).get();
-
-                    try (Stream<DataEntity.Blueprint<?>> s = structure.getChildren(p, DataEntity.class)
-                            .filter(d -> configurationSchema.equals(d.getRole()))) {
-                        return s.findFirst().orElse(dummyDataBlueprint(configurationSchema));
-                    }
-                }
-
-                @Override
-                public DataEntity.Blueprint<?> getConnectionConfiguration(RelativePath root,
-                                                                          Resource.Blueprint parentResource) {
-                    RelativePath resourcePath = root.modified().extend(SegmentType.r, parentResource.getId())
-                            .get().slide(1, 0);
-
-                    try (Stream<DataEntity.Blueprint<?>>s = structure.getChildren(resourcePath, DataEntity.class)
-                            .filter(d -> connectionConfiguration.equals(d.getRole()))) {
-                        return s.findFirst().orElse(dummyDataBlueprint(connectionConfiguration));
-                    }
-                }
-
-                @Override public DataEntity.Blueprint<?> getConnectionConfigurationSchema(ResourceType.Blueprint rt) {
-                    RelativePath p = rt.equals(structure.getRoot()) ? RelativePath.empty().get()
-                            : RelativePath.to().resourceType(rt.getId()).get();
-
-                    try (Stream<DataEntity.Blueprint<?>> s = structure.getChildren(p, DataEntity.class)
-                            .filter(d -> connectionConfigurationSchema.equals(d.getRole()))) {
-                        return s.findFirst().orElse(dummyDataBlueprint(connectionConfigurationSchema));
-                    }
-                }
-
-                @Override public List<Metric.Blueprint> getFeedMetrics() {
-                    try (Stream<Metric.Blueprint> s = structure.getChildren(RelativePath.empty().get(), Metric.class)) {
-                        return s.collect(toList());
-                    }
-                }
-
-                @Override public List<Resource.Blueprint> getFeedResources() {
-                    try (Stream<Resource.Blueprint> s = structure.getChildren(RelativePath.empty().get(),
-                            Resource.class)) {
-                        return s.collect(toList());
-                    }
-                }
-
-                @Override public List<MetricType.Blueprint> getMetricTypes() {
-                    try (Stream<MetricType.Blueprint> s = structure.getChildren(RelativePath.empty().get(),
-                            MetricType.class)) {
-                        return s.collect(toList());
-                    }
-                }
-
-                @Override public List<OperationType.Blueprint> getOperationTypes(ResourceType.Blueprint rt) {
-                    RelativePath p = rt.equals(structure.getRoot()) ? RelativePath.empty().get()
-                            : RelativePath.to().resourceType(rt.getId()).get();
-
-                    try (Stream<OperationType.Blueprint> s = structure.getChildren(p, OperationType.class)) {
-                        return s.collect(toList());
-                    }
-                }
-
-                @Override
-                public DataEntity.Blueprint<?> getParameterTypes(RelativePath rootResourceType,
-                                                                 OperationType.Blueprint ot) {
-                    RelativePath p = rootResourceType.modified().extend(SegmentType.ot, ot.getId()).get()
-                            .slide(1, 0);
-
-                    try (Stream<DataEntity.Blueprint<?>> s = structure.getChildren(p, DataEntity.class)
-                            .filter(d -> parameterTypes.equals(d.getRole()))) {
-                        return s.findFirst().orElse(dummyDataBlueprint(parameterTypes));
-                    }
-                }
-
-                @Override
-                public List<Metric.Blueprint> getResourceMetrics(RelativePath rootPath,
-                                                                 Resource.Blueprint parentResource) {
-                    RelativePath p = rootPath.modified().extend(SegmentType.r, parentResource.getId()).get()
-                            .slide(1, 0);
-
-                    try (Stream<Metric.Blueprint> s = structure.getChildren(p, Metric.class)) {
-                        return s.collect(toList());
-                    }
-                }
-
-                @Override
-                public List<Resource.Blueprint> getResources(RelativePath rootPath, Resource.Blueprint parentResource) {
-                    RelativePath p = rootPath.modified().extend(SegmentType.r, parentResource.getId()).get()
-                            .slide(1, 0);
-
-                    try (Stream<Resource.Blueprint> s = structure.getChildren(p, Resource.class)) {
-                        return s.collect(toList());
-                    }
-                }
-
-                @Override public List<ResourceType.Blueprint> getResourceTypes() {
-                    try (Stream<ResourceType.Blueprint> s = structure.getChildren(RelativePath.empty().get(),
-                            ResourceType.class)) {
-                        return s.collect(toList());
-                    }
-                }
-
-                @Override public DataEntity.Blueprint<?> getReturnType(RelativePath rootResourceType,
-                                                                       OperationType.Blueprint ot) {
-                    RelativePath p = rootResourceType.modified().extend(SegmentType.ot, ot.getId()).get()
-                            .slide(1, 0);
-
-                    try (Stream<DataEntity.Blueprint<?>> s = structure.getChildren(p, DataEntity.class)
-                            .filter(d -> returnType.equals(d.getRole()))) {
-                        return s.findFirst().orElse(dummyDataBlueprint(returnType));
-                    }
-                }
-            };
-        }
-
-        default List<ResourceType.Blueprint> getResourceTypes() {
-            return Collections.emptyList();
-        }
-
-        default List<MetricType.Blueprint> getMetricTypes() {
-            return Collections.emptyList();
-        }
-
-        default List<OperationType.Blueprint> getOperationTypes(ResourceType.Blueprint rt) {
-            return Collections.emptyList();
-        }
-
-        default DataEntity.Blueprint<?> getReturnType(RelativePath rootResourceType, OperationType.Blueprint ot) {
-            return dummyDataBlueprint(returnType);
-        }
-
-        default DataEntity.Blueprint<?> getParameterTypes(RelativePath rootResourceType, OperationType.Blueprint ot) {
-            return dummyDataBlueprint(parameterTypes);
-        }
-
-        default DataEntity.Blueprint<?> getConfigurationSchema(ResourceType.Blueprint rt) {
-            return dummyDataBlueprint(configurationSchema);
-        }
-
-        default DataEntity.Blueprint<?> getConnectionConfigurationSchema(ResourceType.Blueprint rt) {
-            return dummyDataBlueprint(connectionConfigurationSchema);
-        }
-
-        default List<Resource.Blueprint> getResources(RelativePath rootPath, Resource.Blueprint parentResource) {
-            return Collections.emptyList();
-        }
-
-        default List<Resource.Blueprint> getFeedResources() {
-            return Collections.emptyList();
-        }
-
-        default List<Metric.Blueprint> getFeedMetrics() {
-            return Collections.emptyList();
-        }
-
-        default List<Metric.Blueprint> getResourceMetrics(RelativePath rootPath, Resource.Blueprint parentResource) {
-            return Collections.emptyList();
-        }
-
-        default DataEntity.Blueprint<?> getConfiguration(RelativePath rootPath, Resource.Blueprint parentResource) {
-            return dummyDataBlueprint(configuration);
-        }
-
-        default DataEntity.Blueprint<?> getConnectionConfiguration(RelativePath root, Resource.Blueprint
-                parentResource) {
-            return dummyDataBlueprint(connectionConfiguration);
-        }
-    }
-
-    private static class HashConstructor {
-        private final DigestComputingWriter digestor;
-
-        HashConstructor(DigestComputingWriter digestor) {
-            this.digestor = digestor;
-        }
-
-        public DigestComputingWriter getDigestor() {
-            return digestor;
-        }
-
-        public void startChild(IntermediateHashContext context) {
-//            System.out.println("start: " + context.root);
-        }
-
-        public void endChild(IntermediateHashContext ctx, IntermediateHashResult result) {
-//            System.out.println("Intermediate result: path: " + result.path + ", hash: " + result.hash + ", content: "
-//                    + ctx.content);
-        }
-    }
-
-    private static class IntermediateHashContext {
-        final RelativePath root;
-        final StringBuilder content = new StringBuilder();
-
-        public IntermediateHashContext progress(Entity.Blueprint bl) {
-            return new IntermediateHashContext(root.modified().extend(Blueprint.getSegmentTypeOf(bl),
-                    bl.getId()).get());
-        }
-
-        public IntermediateHashContext(RelativePath root) {
-            this.root = root;
-        }
-    }
-
-    private static class IntermediateHashResult {
-        private final RelativePath path;
-        private final String hash;
-
-        private IntermediateHashResult(RelativePath path, String hash) {
-            this.path = path;
-            this.hash = hash;
-        }
-    }
-
-    private static class DigestComputingWriter implements Appendable, Closeable {
-        private final MessageDigest digester;
-        private final CharsetEncoder enc = Charset.forName("UTF-8").newEncoder().onMalformedInput(CodingErrorAction
-                .REPLACE).onUnmappableCharacter(CodingErrorAction.REPLACE);
-
-        private final ByteBuffer buffer = ByteBuffer.allocate(512);
-        private String digest;
-
-        private DigestComputingWriter(MessageDigest digester) {
-            this.digester = digester;
-        }
-
-        @Override
-        public DigestComputingWriter append(CharSequence csq) {
-            consumeBuffer(CharBuffer.wrap(csq));
-            return this;
-        }
-
-        @Override
-        public DigestComputingWriter append(CharSequence csq, int start, int end) {
-            consumeBuffer(CharBuffer.wrap(csq, start, end));
-            return this;
-        }
-
-        @Override
-        public DigestComputingWriter append(char c) {
-            consumeBuffer(CharBuffer.wrap(new char[]{c}));
-            return this;
-        }
-
-        @Override
-        public void close() {
-            byte[] digest = digester.digest();
-
-            StringBuilder bld = new StringBuilder();
-            for (byte b : digest) {
-                bld.append(Integer.toHexString(Byte.toUnsignedInt(b)));
-            }
-
-            this.digest = bld.toString();
-        }
-
-        public String digest() {
-            if (digest == null) {
-                throw new IllegalStateException("digest computing writer not closed.");
-            }
-
-            return digest;
-        }
-
-        public void reset() {
-            digester.reset();
-            digest = null;
-        }
-
-        private void consumeBuffer(CharBuffer chars) {
-            CoderResult res;
-            do {
-                res = enc.encode(chars, buffer, true);
-                buffer.flip();
-                digester.update(buffer);
-                buffer.clear();
-            } while (res == CoderResult.OVERFLOW);
-        }
-    }
-
     @ApiModel("IdentityHashTree")
-    public static final class Tree implements Serializable {
-        private final RelativePath path;
-        private final String hash;
-        private final Map<Path.Segment, Tree> children;
-
+    public static final class Tree extends AbstractHashTree<Tree, String> implements Serializable {
         //jackson support
         private Tree() {
             this(null, null, null);
         }
 
         private Tree(RelativePath path, String hash, Map<Path.Segment, Tree> children) {
-            this.path = path;
-            this.hash = hash;
-            this.children = children;
+            super(path, hash, children);
         }
 
         public static Builder builder() {
             return new Builder();
         }
 
-        public Collection<Tree> getChildren() {
-            return children.values();
+        public interface AbstractBuilder<This extends AbstractHashTree.Builder<This, ChildBuilder<This>, Tree, String>
+                & AbstractBuilder<This>>
+                extends AbstractHashTree.Builder<This, ChildBuilder<This>, Tree, String> {
         }
 
-        public Tree getChild(Path.Segment path) {
-            return children.get(path);
-        }
+        public static final class Builder
+                extends AbstractHashTree.AbstractBuilder<Builder, ChildBuilder<Builder>, Tree, String>
+            implements AbstractBuilder<Builder>, TopBuilder<Builder, ChildBuilder<Builder>, Tree, String> {
 
-        public String getHash() {
-            return hash;
-        }
-
-        public RelativePath getPath() {
-            return path;
-        }
-
-        public TreeTraversal<Tree> traversal() {
-            return new TreeTraversal<>(t -> t.children.values().iterator());
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            Tree tree = (Tree) o;
-
-            return hash.equals(tree.hash);
-        }
-
-        @Override
-        public int hashCode() {
-            return hash.hashCode();
-        }
-
-        @Override
-        public String toString() {
-            return "Tree[" + "path=" + path +
-                    ", hash='" + hash + '\'' +
-                    ",children=" + children.values() +
-                    ']';
-        }
-
-        public abstract static class AbstractBuilder<This extends AbstractBuilder<?>> {
-            private RelativePath path;
-            private String hash;
-            private Map<Path.Segment, Tree> children;
-
-            public This withPath(RelativePath path) {
-                this.path = path;
-                return castThis();
-            }
-
-            public This withHash(String hash) {
-                this.hash = hash;
-                return castThis();
-            }
-
-            public String getHash() {
-                return hash;
-            }
-
-            public RelativePath getPath() {
-                return path;
-            }
-
-            public boolean hasChildren() {
-                return children != null && !children.isEmpty();
-            }
-
-            protected void addChild(Tree childTree) {
-                getChildren().put(childTree.getPath().getSegment(), childTree);
-            }
-
-            public ChildBuilder<This> startChild() {
-                ChildBuilder<This> childBuilder = new ChildBuilder<>();
-                childBuilder.parent = castThis();
-                return childBuilder;
-            }
-
-            protected Tree build() {
-                if ((path == null || hash == null) && (children != null && !children.isEmpty())) {
-                    throw new IllegalStateException("Cannot construct and IndentityHash.Tree node without a path or " +
-                            "hash and with children. While empty tree without a hash or path is OK, having children" +
-                            "assumes the parent to be fully established.");
-                }
-
-                if (path != null) {
-                    int myDepth = path.getDepth();
-
-                    for (Tree child : getChildren().values()) {
-                        int childDepth = child.getPath().getDepth();
-                        if (!path.isParentOf(child.getPath()) || childDepth != myDepth + 1) {
-                            throw new IllegalStateException(
-                                    "When building a tree node with path " + path + " an attempt " +
-                                            "to add a child on path " + child.getPath() +
-                                            " was made. The child's path must extend the parent's path by exactly" +
-                                            " one segment, which is not true in this case.");
-                        }
-                    }
-                }
-
-                return new Tree(path, hash, Collections.unmodifiableMap(getChildren()));
-            }
-
-            private Map<Path.Segment, Tree> getChildren() {
-                if (children == null) {
-                    children = new HashMap<>();
-                }
-
-                return children;
-            }
-
-            @SuppressWarnings("unchecked")
-            private This castThis() {
-                return (This) this;
-            }
-        }
-
-        public static final class Builder extends AbstractBuilder<Builder> {
             private Builder() {
-
+                super(Tree::new, ChildBuilder<Builder>::new);
             }
 
+            @Override
             public Tree build() {
                 return super.build();
             }
         }
 
-        public static final class ChildBuilder<Parent extends AbstractBuilder<?>>
-                extends AbstractBuilder<ChildBuilder<Parent>> {
-            private Parent parent;
+        public static final class ChildBuilder<
+                Parent extends AbstractHashTree.Builder<Parent, ChildBuilder<Parent>, Tree, String>
+                        & AbstractBuilder<Parent>>
+                extends AbstractChildBuilder<ChildBuilder<Parent>, Parent, ChildBuilder<ChildBuilder<Parent>>,
+                Tree, String>
+                implements AbstractBuilder<ChildBuilder<Parent>>,
+                AbstractHashTree.ChildBuilder<ChildBuilder<Parent>, Parent, ChildBuilder<ChildBuilder<Parent>>, Tree,
+                                        String> {
 
-            private ChildBuilder() {
-
-            }
-
-            public Parent endChild() {
-                Tree tree = build();
-                parent.addChild(tree);
-                return parent;
+            ChildBuilder(TreeConstructor<Tree, String> tctor, Parent p) {
+                super(tctor, p, ChildBuilder<ChildBuilder<Parent>>::new);
             }
         }
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Metric.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Metric.java
@@ -36,8 +36,8 @@ import io.swagger.annotations.ApiModel;
 @ApiModel(description = "A metric represents a monitored \"quality\". Its metric type specifies the unit in which" +
         " the metric reports its values and the collection interval specifies how often the feed should be collecting" +
         " the metric for changes in value.",
-        parent = IdentityHashedEntity.class)
-public final class Metric extends IdentityHashedEntity<Metric.Blueprint, Metric.Update> {
+        parent = SyncedEntity.class)
+public final class Metric extends SyncedEntity<Metric.Blueprint, Metric.Update> {
 
     public static final SegmentType SEGMENT_TYPE = SegmentType.m;
 
@@ -53,33 +53,36 @@ public final class Metric extends IdentityHashedEntity<Metric.Blueprint, Metric.
         collectionInterval = null;
     }
 
-    public Metric(CanonicalPath path, String identityHash, MetricType type) {
-        this(null, path, identityHash, type, null, null);
+    public Metric(CanonicalPath path, String identityHash, String contentHash, String syncHash, MetricType type) {
+        this(null, path, identityHash, contentHash, syncHash, type, null, null);
     }
 
-    public Metric(String name, CanonicalPath path, String identityHash, MetricType type) {
-        this(name, path, identityHash, type, null ,null);
+    public Metric(String name, CanonicalPath path, String identityHash, String contentHash, String syncHash,
+                  MetricType type) {
+        this(name, path, identityHash, contentHash, syncHash, type, null ,null);
     }
 
-    public Metric(CanonicalPath path, String identityHash, MetricType type, Long collectionInterval) {
-        this(null, path, identityHash, type, collectionInterval, null);
+    public Metric(CanonicalPath path, String identityHash, String contentHash, String syncHash, MetricType type,
+                  Long collectionInterval) {
+        this(null, path, identityHash, contentHash, syncHash, type, collectionInterval, null);
     }
 
-    public Metric(CanonicalPath path, String identityHash, MetricType type, Map<String, Object> properties) {
-        this(null, path, identityHash, type, null, properties);
-    }
-
-    public Metric(String name, CanonicalPath path, String identityHash, MetricType type, Long collectionInterval,
+    public Metric(CanonicalPath path, String identityHash, String contentHash, String syncHash, MetricType type,
                   Map<String, Object> properties) {
-        super(name, path, identityHash, properties);
+        this(null, path, identityHash, contentHash, syncHash, type, null, properties);
+    }
+
+    public Metric(String name, CanonicalPath path, String identityHash, String contentHash, String syncHash,
+                  MetricType type, Long collectionInterval, Map<String, Object> properties) {
+        super(name, path, identityHash, contentHash, syncHash, properties);
         this.type = type;
         this.collectionInterval = collectionInterval;
     }
 
     @Override
     public Updater<Update, Metric> update() {
-        return new Updater<>((u) -> new Metric(u.getName(), getPath(), getIdentityHash(), getType(),
-                u.getCollectionInterval(), u.getProperties()));
+        return new Updater<>((u) -> new Metric(u.getName(), getPath(), getIdentityHash(), getContentHash(),
+                getSyncHash(), getType(), u.getCollectionInterval(), u.getProperties()));
     }
 
     public MetricType getType() {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/MetricType.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/MetricType.java
@@ -36,8 +36,8 @@ import io.swagger.annotations.ApiModel;
  */
 @ApiModel(description = "Metric type defines the unit and data type of a metric. It also specifies the default " +
         " collection interval as a guideline for the feed on how often to collect the metric values.",
-        parent = IdentityHashedEntity.class)
-public final class MetricType extends IdentityHashedEntity<MetricType.Blueprint, MetricType.Update> {
+        parent = SyncedEntity.class)
+public final class MetricType extends SyncedEntity<MetricType.Blueprint, MetricType.Update> {
 
     public static final SegmentType SEGMENT_TYPE = SegmentType.mt;
 
@@ -57,26 +57,31 @@ public final class MetricType extends IdentityHashedEntity<MetricType.Blueprint,
         collectionInterval = null;
     }
 
-    public MetricType(CanonicalPath path, String identityHash) {
-        this(path, identityHash, MetricUnit.NONE, MetricDataType.GAUGE, null, null);
+    public MetricType(CanonicalPath path, String identityHash, String contentHash, String syncHash) {
+        this(path, identityHash, contentHash, syncHash, MetricUnit.NONE, MetricDataType.GAUGE, null, null);
     }
 
-    public MetricType(CanonicalPath path, String identityHash, MetricUnit unit, MetricDataType type) {
-        this(path, identityHash, unit, type, null, null);
+    public MetricType(CanonicalPath path, String identityHash, String contentHash, String syncHash, MetricUnit unit,
+                      MetricDataType type) {
+        this(path, identityHash, contentHash, syncHash, unit, type, null, null);
     }
 
-    public MetricType(CanonicalPath path, String identityHash, MetricUnit unit, MetricDataType type,
+    public MetricType(CanonicalPath path, String identityHash, String contentHash, String syncHash, MetricUnit unit,
+                      MetricDataType type,
                       Long collectionInterval) {
-        this(path, identityHash, unit, type, null, collectionInterval);
+        this(path, identityHash, contentHash, syncHash, unit, type, null, collectionInterval);
     }
 
-    public MetricType(String name, CanonicalPath path, String identityHash, MetricUnit unit, MetricDataType type) {
-        this(name, path, identityHash, unit, type, null, null);
+    public MetricType(String name, CanonicalPath path, String identityHash, String contentHash,
+                      java.lang.String syncHash,
+                      MetricUnit unit,
+                      MetricDataType type) {
+        this(name, path, identityHash, contentHash, syncHash, unit, type, null, null);
     }
 
-    public MetricType(CanonicalPath path, String identityHash, MetricUnit unit, MetricDataType type,
-                      Map<String, Object> properties, Long collectionInterval) {
-        super(path, identityHash, properties);
+    public MetricType(CanonicalPath path, String identityHash, java.lang.String contentHash, java.lang.String syncHash,
+                      MetricUnit unit, MetricDataType type, Map<String, Object> properties, Long collectionInterval) {
+        super(null, path, identityHash, contentHash, syncHash, properties);
         if (type == null) {
             throw new IllegalArgumentException("metricDataType == null");
         }
@@ -85,9 +90,10 @@ public final class MetricType extends IdentityHashedEntity<MetricType.Blueprint,
         this.collectionInterval = collectionInterval;
     }
 
-    public MetricType(String name, CanonicalPath path, String identityHash, MetricUnit unit, MetricDataType type,
+    public MetricType(String name, CanonicalPath path, String identityHash, java.lang.String contentHash,
+                      java.lang.String syncHash, MetricUnit unit, MetricDataType type,
                       Map<String, Object> properties, Long collectionInterval) {
-        super(name, path, identityHash, properties);
+        super(name, path, identityHash, contentHash, syncHash, properties);
         this.type = type;
         this.unit = unit;
         this.collectionInterval = collectionInterval;
@@ -107,8 +113,8 @@ public final class MetricType extends IdentityHashedEntity<MetricType.Blueprint,
 
     @Override
     public Updater<Update, MetricType> update() {
-        return new Updater<>((u) -> new MetricType(u.getName(), getPath(), getIdentityHash(),
-                valueOrDefault(u.unit, this.unit), type, u.getProperties(),
+        return new Updater<>((u) -> new MetricType(u.getName(), getPath(), getIdentityHash(), getContentHash(),
+                getSyncHash(), valueOrDefault(u.unit, this.unit), type, u.getProperties(),
                 valueOrDefault(u.getCollectionInterval(), collectionInterval)));
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/OperationType.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/OperationType.java
@@ -31,8 +31,8 @@ import io.swagger.annotations.ApiModel;
 @ApiModel(description = "Defines an type of operation that can be executed on resources of a resource type" +
         " that contains this operation type. The operation type contains \"returnType\" and \"parameterTypes\"" +
         " data entities which correspond to JSON schemas of values expected during the operation execution.",
-        parent = IdentityHashedEntity.class)
-public final class OperationType extends IdentityHashedEntity<OperationType.Blueprint, OperationType.Update> {
+        parent = SyncedEntity.class)
+public final class OperationType extends SyncedEntity<OperationType.Blueprint, OperationType.Update> {
 
     public static final SegmentType SEGMENT_TYPE = SegmentType.ot;
 
@@ -40,20 +40,22 @@ public final class OperationType extends IdentityHashedEntity<OperationType.Blue
     private OperationType() {
     }
 
-    public OperationType(CanonicalPath path, String identityHash) {
-        super(path, identityHash);
+    public OperationType(CanonicalPath path, String identityHash, String contentHash, String syncHash) {
+        super(path, identityHash, contentHash, syncHash);
     }
 
-    public OperationType(String name, CanonicalPath path, String identityHash) {
-        super(name, path, identityHash);
+    public OperationType(String name, CanonicalPath path, String identityHash, String contentHash, String syncHash) {
+        super(name, path, identityHash, contentHash, syncHash);
     }
 
-    public OperationType(CanonicalPath path, String identityHash, Map<String, Object> properties) {
-        super(path, identityHash, properties);
+    public OperationType(CanonicalPath path, String identityHash, String contentHash, String syncHash,
+                         Map<String, Object> properties) {
+        super(path, identityHash, contentHash, syncHash, properties);
     }
 
-    public OperationType(String name, CanonicalPath path, String identityHash, Map<String, Object> properties) {
-        super(name, path, identityHash, properties);
+    public OperationType(String name, CanonicalPath path, String identityHash, String contentHash,
+                         String syncHash, Map<String, Object> properties) {
+        super(name, path, identityHash, contentHash, syncHash, properties);
     }
 
     @Override
@@ -63,7 +65,8 @@ public final class OperationType extends IdentityHashedEntity<OperationType.Blue
 
     @Override
     public Updater<Update, OperationType> update() {
-        return new Updater<>((u) -> new OperationType(u.getName(), getPath(), getIdentityHash(), u.getProperties()));
+        return new Updater<>((u) -> new OperationType(u.getName(), getPath(), getIdentityHash(), getContentHash(),
+                getSyncHash(), u.getProperties()));
     }
 
     @ApiModel("OperationTypeBlueprint")

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Resource.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Resource.java
@@ -34,8 +34,8 @@ import io.swagger.annotations.ApiModel;
  * @author Lukas Krejci
  */
 @ApiModel(description = "A resource has a type, can have configuration and connection configuration and can" +
-        " incorporate metrics.", parent = IdentityHashedEntity.class)
-public final class Resource extends IdentityHashedEntity<Resource.Blueprint, Resource.Update> {
+        " incorporate metrics.", parent = SyncedEntity.class)
+public final class Resource extends SyncedEntity<Resource.Blueprint, Resource.Update> {
 
     public static final SegmentType SEGMENT_TYPE = SegmentType.r;
 
@@ -49,28 +49,32 @@ public final class Resource extends IdentityHashedEntity<Resource.Blueprint, Res
         type = null;
     }
 
-    public Resource(CanonicalPath path, String identityHash, ResourceType type) {
-        this(path, identityHash, type, null);
+    public Resource(CanonicalPath path, String identityHash, String contentHash, String syncHash, ResourceType type) {
+        this(path, identityHash, contentHash, syncHash, type, null);
     }
 
-    public Resource(String name, CanonicalPath path, String identityHash, ResourceType type) {
-        this(name, path, identityHash, type, null);
+    public Resource(String name, CanonicalPath path, String identityHash, String contentHash, String syncHash,
+                    ResourceType type) {
+        this(name, path, identityHash, contentHash, syncHash, type, null);
     }
 
-    public Resource(CanonicalPath path, String identityHash, ResourceType type, Map<String, Object> properties) {
-        super(path, identityHash, properties);
+    public Resource(CanonicalPath path, String identityHash, String contentHash, String syncHash, ResourceType type,
+                    Map<String, Object> properties) {
+        super(path, identityHash, contentHash, syncHash, properties);
         this.type = type;
     }
 
-    public Resource(String name, CanonicalPath path, String identityHash, ResourceType type,
+    public Resource(String name, CanonicalPath path, String identityHash, String contentHash, String syncHash,
+                    ResourceType type,
                     Map<String, Object> properties) {
-        super(name, path, identityHash, properties);
+        super(name, path, identityHash, contentHash, syncHash, properties);
         this.type = type;
     }
 
     @Override
     public Updater<Update, Resource> update() {
-        return new Updater<>((u) -> new Resource(u.getName(), getPath(), getIdentityHash(), getType(),
+        return new Updater<>((u) -> new Resource(u.getName(), getPath(), getIdentityHash(), getContentHash(),
+                getSyncHash(), getType(),
                 u.getProperties()));
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ResourceType.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ResourceType.java
@@ -34,8 +34,8 @@ import io.swagger.annotations.ApiModel;
 @ApiModel(description = "A resource type contains metadata about resources it defines. It contains" +
         " \"configurationSchema\" and \"connectionConfigurationSchema\" data entities that can prescribe a JSON" +
         " schema to which the configurations of the resources should conform.",
-        parent = IdentityHashedEntity.class)
-public final class ResourceType extends IdentityHashedEntity<ResourceType.Blueprint, ResourceType.Update> {
+        parent = SyncedEntity.class)
+public final class ResourceType extends SyncedEntity<ResourceType.Blueprint, ResourceType.Update> {
 
     public static final SegmentType SEGMENT_TYPE = SegmentType.rt;
 
@@ -46,25 +46,28 @@ public final class ResourceType extends IdentityHashedEntity<ResourceType.Bluepr
     private ResourceType() {
     }
 
-    public ResourceType(CanonicalPath path, String identityHash) {
-        this(path, identityHash, null);
+    public ResourceType(CanonicalPath path, String identityHash, String contentHash, String syncHash) {
+        super(path, identityHash, contentHash, syncHash);
     }
 
-    public ResourceType(String name, CanonicalPath path, String identityHash) {
-        super(name, path, identityHash);
+    public ResourceType(String name, CanonicalPath path, String identityHash, String contentHash, String syncHash) {
+        super(name, path, identityHash, contentHash, syncHash);
     }
 
-    public ResourceType(CanonicalPath path, String identityHash, Map<String, Object> properties) {
-        super(path, identityHash, properties);
+    public ResourceType(CanonicalPath path, String identityHash, String contentHash, String syncHash,
+                        Map<String, Object> properties) {
+        super(path, identityHash, contentHash, syncHash, properties);
     }
 
-    public ResourceType(String name, CanonicalPath path, String identityHash, Map<String, Object> properties) {
-        super(name, path, identityHash, properties);
+    public ResourceType(String name, CanonicalPath path, String identityHash, String contentHash,
+                        String syncHash, Map<String, Object> properties) {
+        super(name, path, identityHash, contentHash, syncHash, properties);
     }
 
     @Override
     public Updater<Update, ResourceType> update() {
-        return new Updater<>((u) -> new ResourceType(u.getName(), getPath(), getIdentityHash(), u.getProperties()));
+        return new Updater<>((u) -> new ResourceType(u.getName(), getPath(), getIdentityHash(), getContentHash(),
+                getSyncHash(), u.getProperties()));
     }
 
     @Override

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/SyncHash.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/SyncHash.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.model;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.hawkular.inventory.paths.CanonicalPath;
+import org.hawkular.inventory.paths.Path;
+import org.hawkular.inventory.paths.RelativePath;
+
+/**
+ * Utility class for computing sync hashes or tree hashes of entities.
+ *
+ * @author Lukas Krejci
+ * @since 0.18.0
+ */
+public final class SyncHash {
+
+    private SyncHash() {
+
+    }
+
+    /**
+     * The root path is required so that paths in the blueprints can be correctly relativized.
+     *
+     * @param structure the structure to compute the root hash of.
+     * @param rootPath the canonical path of the root of the inventory structure
+     * @return the sync hash of the root of the structure
+     */
+    public static String of(InventoryStructure<?> structure, CanonicalPath rootPath) {
+        return ComputeHash.of(structure, rootPath, true, true, true).getSyncHash();
+    }
+
+    /**
+     * Computes the complete sync tree hash of the provided inventory structure. As with
+     * {@link #of(InventoryStructure, CanonicalPath)}, the root path is required for relativizing the paths in the
+     * blueprints in the structure.
+     *
+     * @param structure the inventory structure to compute the tree hash of
+     * @param rootPath the canonical path of the root of the inventory structure
+     * @return the sync tree hash of the provided inventory structure
+     */
+    public static Tree treeOf(InventoryStructure<?> structure, CanonicalPath rootPath) {
+        @SuppressWarnings("unchecked")
+        Tree.AbstractBuilder<?>[] tbld =
+                new Tree.AbstractBuilder[1];
+
+        Consumer<ComputeHash.IntermediateHashContext> startChild = context -> {
+            if (tbld[0] == null) {
+                tbld[0] = Tree.builder();
+            } else {
+                tbld[0] = tbld[0].startChild();
+            }
+        };
+
+        BiConsumer<ComputeHash.IntermediateHashContext, ComputeHash.IntermediateHashResult> endChild = (ctx, result) -> {
+            if (tbld[0] instanceof Tree.ChildBuilder) {
+                tbld[0].withHash(result.syncHash).withPath(result.path);
+                @SuppressWarnings("unchecked")
+                Tree.AbstractBuilder<?> parent = ((Tree.ChildBuilder<?>) tbld[0]).getParent();
+                parent.addChild(((Tree.ChildBuilder<?>) tbld[0]).build());
+                tbld[0] = parent;
+            }
+        };
+
+        ComputeHash.IntermediateHashResult res = ComputeHash
+                .treeOf(structure, rootPath, true, true, true, startChild, endChild);
+
+        tbld[0].withPath(res.path).withHash(res.syncHash);
+
+        return ((Tree.Builder)tbld[0]).build();
+    }
+
+    public static final class Tree extends AbstractHashTree<Tree, String> {
+        //jackson support
+        private Tree() {
+            this(null, null, null);
+        }
+
+        private Tree(RelativePath path, String hash, Map<Path.Segment, Tree> children) {
+            super(path, hash, children);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public interface AbstractBuilder<This extends AbstractHashTree.Builder<This, ChildBuilder<This>, Tree, String>
+                & AbstractBuilder<This>>
+                extends AbstractHashTree.Builder<This, ChildBuilder<This>, Tree, String> {
+        }
+
+        public static final class Builder
+                extends AbstractHashTree.AbstractBuilder<Builder, ChildBuilder<Builder>, Tree, String>
+                implements AbstractBuilder<Builder>, TopBuilder<Builder, ChildBuilder<Builder>, Tree, String> {
+
+            private Builder() {
+                super(Tree::new, ChildBuilder<Builder>::new);
+            }
+
+            @Override
+            public Tree build() {
+                return super.build();
+            }
+        }
+
+        public static final class ChildBuilder<
+                Parent extends AbstractHashTree.Builder<Parent, ChildBuilder<Parent>, Tree, String>
+                        & AbstractBuilder<Parent>>
+                extends AbstractChildBuilder<ChildBuilder<Parent>, Parent, ChildBuilder<ChildBuilder<Parent>>,
+                Tree, String>
+                implements AbstractBuilder<ChildBuilder<Parent>>,
+                AbstractHashTree.ChildBuilder<ChildBuilder<Parent>, Parent, ChildBuilder<ChildBuilder<Parent>>, Tree,
+                                        String> {
+
+            ChildBuilder(TreeConstructor<Tree, String> tctor, Parent p) {
+                super(tctor, p, ChildBuilder<ChildBuilder<Parent>>::new);
+            }
+        }
+    }
+}

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Syncable.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Syncable.java
@@ -14,28 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.inventory.api.test;
-
-import org.hawkular.inventory.api.model.Environment;
-import org.hawkular.inventory.paths.CanonicalPath;
-import org.junit.Assert;
-import org.junit.Test;
+package org.hawkular.inventory.api.model;
 
 /**
+ * Interface implemented by all entities that can be synchronized.
+ *
  * @author Lukas Krejci
- * @since 0.2.0
+ * @since 0.18.0
  */
-public class CanonicalPathTest {
-
-    @Test
-    public void testEntityInstantiationWithWrongPath() throws Exception {
-        try {
-            new Environment(CanonicalPath.of().tenant("t").get(), null);
-            Assert.fail("Creating an entity with a path pointing to a different entity type should not be possible.");
-        } catch (IllegalArgumentException e) {
-            //good
-        }
-    }
-
-    // other tests moved to org.hawkular.inventory.paths.CanonicalPathTest
+public interface Syncable extends IdentityHashable, ContentHashable {
+    /**
+     * A sync hash is a hash used to compare entities during the sync operation. This hash depends both on the
+     * identity hash and content hash of entities.
+     *
+     * @return the sync hash of the entity
+     */
+    String getSyncHash();
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/SyncedEntity.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/SyncedEntity.java
@@ -23,45 +23,67 @@ import org.hawkular.inventory.paths.CanonicalPath;
 import io.swagger.annotations.ApiModel;
 
 /**
+ * Abstract base class for all syncable entities.
+ *
  * @author Lukas Krejci
- * @since 0.11.0
+ * @since 0.18.0
  */
 @ApiModel(description = "A super type of all entities that support identity hashing",
         subTypes = {Feed.class, MetricType.class, Metric.class, Resource.class, DataEntity.class, OperationType.class,
         ResourceType.class}, parent = Entity.class)
-public abstract class IdentityHashedEntity<B extends Entity.Blueprint, U extends Entity.Update> extends Entity<B, U>
-    implements IdentityHashable {
+public abstract class SyncedEntity<B extends Entity.Blueprint, U extends Entity.Update> extends Entity<B, U>
+    implements Syncable {
 
     private final String identityHash;
+    private final String contentHash;
+    private final String syncHash;
 
-    @SuppressWarnings("unused")
-    IdentityHashedEntity() {
+    @SuppressWarnings("unused") SyncedEntity() {
         identityHash = null;
+        contentHash = null;
+        syncHash = null;
     }
 
-    IdentityHashedEntity(String name, CanonicalPath path, String identityHash) {
+    SyncedEntity(String name, CanonicalPath path, String identityHash, String contentHash, String syncHash) {
         super(name, path);
         this.identityHash = identityHash;
+        this.contentHash = contentHash;
+        this.syncHash = syncHash;
     }
 
-    IdentityHashedEntity(String name, CanonicalPath path,
-                         String identityHash, Map<String, Object> properties) {
+    SyncedEntity(String name, CanonicalPath path,
+                 String identityHash, String contentHash, String syncHash, Map<String, Object> properties) {
         super(name, path, properties);
         this.identityHash = identityHash;
+        this.contentHash = contentHash;
+        this.syncHash = syncHash;
     }
 
-    IdentityHashedEntity(CanonicalPath path, String identityHash) {
+    SyncedEntity(CanonicalPath path, String identityHash, String contentHash, String syncHash) {
         super(path);
         this.identityHash = identityHash;
+        this.contentHash = contentHash;
+        this.syncHash = syncHash;
     }
 
-    IdentityHashedEntity(CanonicalPath path, String identityHash, Map<String, Object> properties) {
+    SyncedEntity(CanonicalPath path, String identityHash, String contentHash, String syncHash,
+                 Map<String, Object> properties) {
         super(path, properties);
         this.identityHash = identityHash;
+        this.contentHash = contentHash;
+        this.syncHash = syncHash;
     }
 
     @Override
     public String getIdentityHash() {
         return identityHash;
+    }
+
+    @Override public String getContentHash() {
+        return contentHash;
+    }
+
+    @Override public String getSyncHash() {
+        return syncHash;
     }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Tenant.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Tenant.java
@@ -39,32 +39,32 @@ import io.swagger.annotations.ApiModel;
 @ApiModel(description = "The tenants partition the data in the inventory graph." +
         " No relationships between entities from 2 different tenants can exist.",
         parent = Entity.class)
-public final class Tenant extends Entity<Tenant.Blueprint, Tenant.Update> {
+public final class Tenant extends ContentHashedEntity<Tenant.Blueprint, Tenant.Update> {
 
     public static final SegmentType SEGMENT_TYPE = SegmentType.t;
 
     private Tenant() {
     }
 
-    public Tenant(CanonicalPath path) {
-        this(path, null);
+    public Tenant(CanonicalPath path, String contentHash) {
+        super(path, contentHash);
     }
 
-    public Tenant(String name, CanonicalPath path) {
-        super(name, path);
+    public Tenant(String name, CanonicalPath path, String contentHash) {
+        super(name, path, contentHash);
     }
 
-    public Tenant(CanonicalPath path, Map<String, Object> properties) {
-        super(path, properties);
+    public Tenant(CanonicalPath path, String contentHash, Map<String, Object> properties) {
+        super(path, contentHash, properties);
     }
 
-    public Tenant(String name, CanonicalPath path, Map<String, Object> properties) {
-        super(name, path, properties);
+    public Tenant(String name, CanonicalPath path, String contentHash, Map<String, Object> properties) {
+        super(name, path, contentHash, properties);
     }
 
     @Override
     public Updater<Update, Tenant> update() {
-        return new Updater<>((u) -> new Tenant(u.getName(), getPath(), u.getProperties()));
+        return new Updater<>((u) -> new Tenant(u.getName(), getPath(), getContentHash(), u.getProperties()));
     }
 
     @Override

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BackendTransaction.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BackendTransaction.java
@@ -27,6 +27,7 @@ import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.model.AbstractElement;
 import org.hawkular.inventory.api.model.Blueprint;
 import org.hawkular.inventory.api.model.Entity;
+import org.hawkular.inventory.api.model.Hashes;
 import org.hawkular.inventory.api.model.StructuredData;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
@@ -87,6 +88,14 @@ public class BackendTransaction<E> implements Transaction<E> {
 
     @Override public String extractIdentityHash(E entityRepresentation) {
         return backend.extractIdentityHash(entityRepresentation);
+    }
+
+    @Override public String extractContentHash(E entityRepresentation) {
+        return backend.extractContentHash(entityRepresentation);
+    }
+
+    @Override public String extractSyncHash(E entityRepresentation) {
+        return backend.extractSyncHash(entityRepresentation);
     }
 
     @Override public String extractRelationshipName(E relationship) {
@@ -195,8 +204,8 @@ public class BackendTransaction<E> implements Transaction<E> {
         backend.update(entity, update);
     }
 
-    @Override public void updateIdentityHash(E entity, String identityHash) {
-        backend.updateIdentityHash(entity, identityHash);
+    @Override public void updateHashes(E entity, Hashes hashes) {
+        backend.updateHashes(entity, hashes);
     }
 
     @Override public boolean requiresRollbackAfterFailure(Throwable t) {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseData.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseData.java
@@ -132,7 +132,7 @@ public final class BaseData {
             tx.relate(entity, value, hasData.name(), null);
 
             DataEntity data = new DataEntity(parentPath, blueprint.getRole(), blueprint.getValue(), null,
-                    blueprint.getProperties());
+                    null, null, blueprint.getProperties());
 
             return new EntityAndPendingNotifications<>(entity, data, emptyList());
         }
@@ -230,8 +230,8 @@ public final class BaseData {
         }
     }
 
-    public static final class Single<BE> extends SingleIdentityHashedFetcher<BE, DataEntity, DataEntity.Blueprint<?>,
-            DataEntity.Update> implements Data.Single {
+    public static final class Single<BE> extends SingleSyncedFetcher<BE, DataEntity, DataEntity.Blueprint<?>,
+                DataEntity.Update> implements Data.Single {
 
         private final DataModificationChecks<BE> checks;
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseEnvironments.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseEnvironments.java
@@ -129,7 +129,7 @@ public final class BaseEnvironments {
                         Transaction<BE> tx) {
             return new EntityAndPendingNotifications<>(entity, new Environment(blueprint.getName(),
                     parentPath.extend(Environment.SEGMENT_TYPE, tx.extractId(entity)).get(),
-                    blueprint.getProperties()), emptyList());
+                    null, blueprint.getProperties()), emptyList());
         }
 
         @Override

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseFeeds.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseFeeds.java
@@ -73,7 +73,7 @@ public final class BaseFeeds {
                     .extend(Feed.SEGMENT_TYPE, blueprint.getId()).get();
 
             return context.configuration.getFeedIdStrategy().generate(context.inventory.keepTransaction(tx),
-                    new Feed(feedPath, null));
+                    new Feed(feedPath, null, null, null));
         }
 
         @Override
@@ -82,7 +82,7 @@ public final class BaseFeeds {
                         Transaction<BE> transaction) {
             return new EntityAndPendingNotifications<>(entity, new Feed(blueprint.getName(),
                     parentPath.extend(Feed.SEGMENT_TYPE, transaction.extractId(entity)).get(), null,
-                    blueprint.getProperties()), emptyList());
+                    null, null, blueprint.getProperties()), emptyList());
         }
 
         @Override
@@ -152,7 +152,7 @@ public final class BaseFeeds {
         }
     }
 
-    public static class Single<BE> extends SingleIdentityHashedFetcher<BE, Feed, Feed.Blueprint, Feed.Update>
+    public static class Single<BE> extends SingleSyncedFetcher<BE, Feed, Feed.Blueprint, Feed.Update>
             implements Feeds.Single {
 
         public Single(TraversalContext<BE, Feed> context) {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetricTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetricTypes.java
@@ -67,7 +67,7 @@ public final class BaseMetricTypes {
             tx.update(entity, MetricType.Update.builder().withUnit(blueprint.getUnit()).build());
 
             MetricType metricType = new MetricType(blueprint.getName(),
-                    parentPath.extend(MetricType.SEGMENT_TYPE, tx.extractId(entity)).get(), null,
+                    parentPath.extend(MetricType.SEGMENT_TYPE, tx.extractId(entity)).get(), null, null, null,
                     blueprint.getUnit(), blueprint.getType(), blueprint.getProperties(),
                     blueprint.getCollectionInterval());
 
@@ -209,8 +209,8 @@ public final class BaseMetricTypes {
         }
     }
 
-    public static class Single<BE> extends SingleIdentityHashedFetcher<BE, MetricType, MetricType.Blueprint,
-            MetricType.Update> implements MetricTypes.Single {
+    public static class Single<BE> extends SingleSyncedFetcher<BE, MetricType, MetricType.Blueprint,
+                MetricType.Update> implements MetricTypes.Single {
 
         public Single(TraversalContext<BE, MetricType> context) {
             super(context);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetrics.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetrics.java
@@ -88,7 +88,7 @@ public final class BaseMetrics {
             MetricType metricType = tx.convert(metricTypeObject, MetricType.class);
 
             Metric ret = new Metric(blueprint.getName(), parentPath.extend(Metric.SEGMENT_TYPE,
-                    tx.extractId(entity)).get(), null, metricType, blueprint.getCollectionInterval(),
+                    tx.extractId(entity)).get(), null, null, null, metricType, blueprint.getCollectionInterval(),
                     blueprint.getProperties());
 
             Relationship rel = new Relationship(tx.extractId(r), defines.name(), parentPath, entityPath);
@@ -172,7 +172,7 @@ public final class BaseMetrics {
         }
     }
 
-    public static class Single<BE> extends SingleIdentityHashedFetcher<BE, Metric, Metric.Blueprint, Metric.Update>
+    public static class Single<BE> extends SingleSyncedFetcher<BE, Metric, Metric.Blueprint, Metric.Update>
             implements Metrics.Single {
 
         public Single(TraversalContext<BE, Metric> context) {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseOperationTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseOperationTypes.java
@@ -65,7 +65,7 @@ public final class BaseOperationTypes {
                         Transaction<BE> tx) {
             return new EntityAndPendingNotifications<>(entity, new OperationType(blueprint.getName(),
                     parentPath.extend(OperationType.SEGMENT_TYPE, tx.extractId(entity)).get(), null,
-                    blueprint.getProperties()), emptyList());
+                    null, null, blueprint.getProperties()), emptyList());
         }
 
         @Override public OperationTypes.Multiple getAll(Filter[][] filters) {
@@ -123,8 +123,8 @@ public final class BaseOperationTypes {
         }
     }
 
-    public static class Single<BE> extends SingleIdentityHashedFetcher<BE, OperationType, OperationType.Blueprint,
-            OperationType.Update> implements OperationTypes.Single {
+    public static class Single<BE> extends SingleSyncedFetcher<BE, OperationType, OperationType.Blueprint,
+                OperationType.Update> implements OperationTypes.Single {
 
         public Single(TraversalContext<BE, OperationType> context) {
             super(context);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BasePreCommit.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BasePreCommit.java
@@ -18,8 +18,10 @@ package org.hawkular.inventory.base;
 
 import static java.util.stream.Collectors.toList;
 
+import static org.hawkular.inventory.api.Action.contentHashChanged;
 import static org.hawkular.inventory.api.Action.created;
 import static org.hawkular.inventory.api.Action.identityHashChanged;
+import static org.hawkular.inventory.api.Action.syncHashChanged;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,21 +39,25 @@ import org.hawkular.inventory.api.Inventory;
 import org.hawkular.inventory.api.Query;
 import org.hawkular.inventory.api.TreeTraversal;
 import org.hawkular.inventory.api.model.AbstractElement;
+import org.hawkular.inventory.api.model.ContentHashable;
 import org.hawkular.inventory.api.model.DataEntity;
 import org.hawkular.inventory.api.model.ElementVisitor;
 import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.model.Feed;
-import org.hawkular.inventory.api.model.IdentityHash;
+import org.hawkular.inventory.api.model.Hashes;
 import org.hawkular.inventory.api.model.IdentityHashable;
 import org.hawkular.inventory.api.model.InventoryStructure;
 import org.hawkular.inventory.api.model.Metric;
 import org.hawkular.inventory.api.model.MetricType;
 import org.hawkular.inventory.api.model.OperationType;
+import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.api.model.ResourceType;
+import org.hawkular.inventory.api.model.Syncable;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.Path;
+import org.hawkular.inventory.paths.SegmentType;
 
 /**
  * Takes care of defining the pre-commit actions based on the set of entities modified within a single transaction.
@@ -70,14 +76,17 @@ public class BasePreCommit<BE> implements Transaction.PreCommit<BE> {
      * Notifications about entities that are not hashable and therefore need no processing
      */
     private final List<EntityAndPendingNotifications<BE, ?>> nonHashedChanges = new ArrayList<>();
+
     /**
      * Pre-commit actions explicitly requested by callers
      */
     private final List<Consumer<Transaction<BE>>> explicitActions = new ArrayList<>();
+
     /**
      * The notifications of the processed changes
      */
     private final List<EntityAndPendingNotifications<BE, ?>> correctedChanges = new ArrayList<>();
+
     /**
      * Keeps track of the work needed to be done.
      */
@@ -143,144 +152,247 @@ public class BasePreCommit<BE> implements Transaction.PreCommit<BE> {
     }
 
     private boolean needsProcessing(EntityAndPendingNotifications<?, ?> element) {
-        return element.getEntity() instanceof IdentityHashable;
+        if (element.getEntity() instanceof Relationship) {
+            return false;
+//Including relationship changes in hash computations would lead to the loss custom relationships
+//created out of the control of the syncing party. E.g. custom relationships created by the glue code
+//or users of inventory. Thus this is kept here only for reference if we revisit this requirement in the future.
+//            //relationships need processing if they involve syncable entities.
+//
+//            Relationship rl = (Relationship) element.getEntity();
+//
+//            if (isSyncable(rl.getSource()) || isSyncable(rl.getTarget())) {
+//                //we only need processing if the relationship is created or deleted. Updates of a relationship don't
+//                //affect the hashes of the related entities
+//                return element.getNotifications().stream()
+//                        .filter(n -> n.getAction() == Action.created() || n.getAction() == Action.deleted())
+//                        .findAny().isPresent();
+//            }
+        }
+
+        return true;
     }
 
     private void process() {
         //walk the processing tree and process the top most
-        List<ProcessingTree<BE>> identityHashRoots = new ArrayList<>();
+        List<ProcessingTree<BE>> syncHashRoots = new ArrayList<>();
 
         processingTree.dfsTraversal(t -> {
-            if (t.needsResolution()) {
-                identityHashRoots.add(t);
-                return false;
-            } else {
-                //look for resolution-needing children
-                return true;
-            }
+            syncHashRoots.add(t);
+            //we stop the filling the roots if we find a identity-hashable entity - all its children will be part
+            //of the hash tree, so we don't need to explicitly look for them...
+            return !t.canBeIdentityRoot();
         });
 
-        if (identityHashRoots.isEmpty()) {
+        if (syncHashRoots.isEmpty()) {
             correctiveAction = null;
             return;
         }
 
         correctiveAction = t -> {
-            for (ProcessingTree<BE> root : identityHashRoots) {
-                try {
-                    root.loadFrom(tx);
-                } catch (ElementNotFoundException e) {
-                    //ok, we're inside a delete and the root entity no longer exists... bail out quickly...
-                    processDeletion(root, root.notifications);
-                    break;
-                }
-                @SuppressWarnings("unchecked")
-                Entity<? extends Entity.Blueprint, ?> e = (Entity<? extends Entity.Blueprint, ?>) root.element;
-
-                IdentityHash.Tree treeHash = IdentityHash.treeOf(InventoryStructure.of(e, inventory));
-
-                correctChanges(treeHash, root);
-            }
+            processingTree.children.forEach(c -> correctChanges(c, true));
         };
     }
 
-    private void correctChanges(IdentityHash.Tree treeHash, ProcessingTree<BE> changesTree) {
-        if (changesTree.needsResolution()) {
-            try {
-                changesTree.loadFrom(tx);
-            } catch (ElementNotFoundException ex) {
-                //this can happen depending on the mode of the backend. If it is not preferring big transactions,
-                //the element might actually be deleted prior to the notifications being sent out.
-                if (processDeletion(changesTree, changesTree.notifications)) {
-                    return;
+    private void correctChanges(ProcessingTree<BE> changedEntity, boolean computeHashes) {
+        if (__correctChangesPrologue(changedEntity)) {
+            return;
+        }
+
+        @SuppressWarnings("unchecked")
+        Entity<? extends Entity.Blueprint, ?> e = (Entity<? extends Entity.Blueprint, ?>) changedEntity.element;
+        Hashes.Tree treeHash = computeHashes
+                ? Hashes.treeOf(InventoryStructure.of(e, inventory), e.getPath())
+                : Hashes.Tree.builder().build();
+
+        __correctChangesNoPrologue(changedEntity, treeHash);
+    }
+
+    private void correctChanges(ProcessingTree<BE> changedEntity, Hashes.Tree newHash) {
+        if (__correctChangesPrologue(changedEntity)) {
+            return;
+        }
+        __correctChangesNoPrologue(changedEntity, newHash);
+    }
+
+    private void __correctChangesNoPrologue(ProcessingTree<BE> changedEntity, Hashes.Tree newHash) {
+        if (changedEntity.element instanceof Syncable || changedEntity.element instanceof IdentityHashable) {
+            correctHierarchicalHashChanges(newHash, changedEntity);
+        } else {
+            correctNonHierarchicalHashChanges(newHash.getHash(), changedEntity);
+        }
+    }
+
+    private boolean __correctChangesPrologue(ProcessingTree<BE> changedEntity) {
+        if (changedEntity.cp == null) {
+            return false;
+        }
+
+        if (!(Entity.Blueprint.class.isAssignableFrom(
+                Inventory.types().bySegment(changedEntity.cp.getSegment().getElementType()).getBlueprintType()))) {
+            //this is currently the case for metadata packs, which do not have their IDs assigned by the user.
+            //we therefore mark them as processed.
+            return true;
+        }
+
+        try {
+            changedEntity.loadFrom(tx);
+        } catch (ElementNotFoundException e) {
+            //ok, we're inside a delete and the root entity no longer exists... bail out quickly...
+            if (processDeletion(changedEntity, changedEntity.notifications)) {
+                return true;
+            } else {
+                throw new EntityNotFoundException(Query.filters(Query.to(changedEntity.cp)));
+            }
+        }
+
+        return processDeletion(changedEntity, changedEntity.notifications);
+    }
+
+    private void correctNonHierarchicalHashChanges(Hashes hashes, ProcessingTree<BE> changedEntity) {
+        @SuppressWarnings("unchecked")
+        Entity<? extends Entity.Blueprint, ?> e = (Entity<? extends Entity.Blueprint, ?>) changedEntity.element;
+        addHashChangeNotifications(changedEntity.element, hashes, changedEntity.notifications);
+        tx.updateHashes(changedEntity.representation, hashes);
+        correctedChanges.add(new EntityAndPendingNotifications<BE, AbstractElement<?, ?>>(
+                changedEntity.representation, e, changedEntity.notifications));
+
+        changedEntity.children.forEach(c -> correctChanges(c, true));
+    }
+
+    private void correctHierarchicalHashChanges(Hashes.Tree treeHash, ProcessingTree<BE> changesTree) {
+        Entity<?, ?> e = cloneWithHash((Entity<?, ?>) changesTree.element, treeHash.getHash());
+
+        List<Notification<?, ?>> ns = changesTree.notifications.stream().map(n -> cloneWithNewEntity(n, e))
+                .collect(toList());
+
+        //check if there is a create or update notification if necessary
+        Hashes origHash = hashesOf(changesTree.element);
+        if (!Objects.equals(origHash, treeHash.getHash())) {
+            //check if the notifications contain an update or create
+            Optional<Notification<?, ?>> createNotif = ns.stream()
+                    .filter(n -> n.getAction() == created() && n.getValue().equals(changesTree.element))
+                    .findAny();
+
+            if (!createNotif.isPresent()) {
+                if (origHash == null) {
+                    ns.add(new Notification<>(changesTree.element, changesTree.element, created()));
                 } else {
-                    throw new EntityNotFoundException(Query.filters(Query.to(changesTree.cp)));
+                    addHashChangeNotifications(changesTree.element, treeHash.getHash(), ns);
                 }
             }
 
-            if (processDeletion(changesTree, changesTree.notifications)) {
-                return;
-            }
+            //now also actually update the element in inventory with the new hashes
+            tx.updateHashes(changesTree.representation, treeHash.getHash());
+        }
 
-            Entity<?, ?> e = cloneWithHash((Entity<?, ?>) changesTree.element, treeHash.getHash());
+        //set the notifications to emit
+        correctedChanges.add(new EntityAndPendingNotifications<BE, AbstractElement<?, ?>>(
+                changesTree.representation, e, ns));
 
-            List<Notification<?, ?>> ns = changesTree.notifications.stream().map(n -> cloneWithNewEntity(n, e))
-                    .collect(toList());
+        //traverse the children to reset their identity hashes
+        ArrayList<Hashes.Tree> treeChildren = new ArrayList<>(treeHash.getChildren());
+        Collections.sort(treeChildren, (a, b) ->
+                a.getPath().getSegment().getElementId().compareTo(b.getPath().getSegment().getElementId()));
 
-            //check if there is a create or update notification if necessary
-            String origIdentityHash = ((IdentityHashable) changesTree.element).getIdentityHash();
-            if (!Objects.equals(origIdentityHash, treeHash.getHash())) {
-                //check if the notifications contain an update or create
-                Optional<Notification<?, ?>> createNotif = ns.stream()
-                        .filter(n -> n.getAction() == created() && n.getValue().equals(changesTree.element))
-                        .findAny();
-
-                if (!createNotif.isPresent()) {
-                    if (origIdentityHash == null) {
-                        ns.add(new Notification<>(changesTree.element, changesTree.element, created()));
-                    } else {
-                        IdentityHashable el = (IdentityHashable) changesTree.element;
-                        ns.add(new Notification<>(el, el, identityHashChanged()));
-                    }
-                }
-
-                //now also actually update the element in inventory with the new hash
-                tx.updateIdentityHash(changesTree.representation, treeHash.getHash());
-            }
-
-            //set the notifications to emit
-            correctedChanges.add(new EntityAndPendingNotifications<BE, AbstractElement<?, ?>>(
-                    changesTree.representation, e, ns));
-
-            //traverse the children to reset their identity hashes
-            ArrayList<IdentityHash.Tree> treeChildren = new ArrayList<>(treeHash.getChildren());
-            Collections.sort(treeChildren, (a, b) ->
-                    a.getPath().getSegment().getElementId().compareTo(b.getPath().getSegment().getElementId()));
-
-            ArrayList<ProcessingTree<BE>> processedChildren = new ArrayList<>(changesTree.children);
-            Collections.sort(processedChildren, (a, b) ->
-                    a.path.getElementId().compareTo(b.path.getElementId()));
+        ArrayList<ProcessingTree<BE>> processedChildren = new ArrayList<>(changesTree.children);
+        Collections.sort(processedChildren, (a, b) ->
+                a.path.getElementId().compareTo(b.path.getElementId()));
 
 
-            for (int i = 0, j = 0; i < processedChildren.size() && j < treeChildren.size();) {
-                ProcessingTree<BE> p = processedChildren.get(i);
-                IdentityHash.Tree h = treeChildren.get(j);
+        for (int i = 0, j = 0; i < processedChildren.size() && j < treeChildren.size();) {
+            ProcessingTree<BE> p = processedChildren.get(i);
+            Hashes.Tree h = treeChildren.get(j);
 
-                int cmp = p.path.getElementId().compareTo(h.getPath().getSegment().getElementId());
-                if (cmp == 0) {
-                    //we found 2 equal elements, let's compare and continue
-                    correctChanges(h, p);
-                    i++;
-                    j++;
-                } else if (cmp > 0) {
-                    //the processing tree element is "greater than" the tree hash element. This means that in our
-                    //processing tree we don't have all elements that contribute to the tree hash. This is ok - not
-                    //all children of an entity need to be updated for the tree hash to change.
-                    //
-                    //We don't do any comparisons here, just increase the index in the tree hash, but NOT our
-                    //processing tree index.
-                    j++;
-                } else {
-                    //the processing tree element is "less" than the tree hash element, which means that there can be
-                    //other processing tree elements after this one that are equal to the curent tree hash element.
-                    //
-                    //Let's just increment our processing tree index to try and find such element.
-                    i++;
+            int cmp = p.path.getElementId().compareTo(h.getPath().getSegment().getElementId());
+            if (cmp == 0) {
+                //we found 2 equal elements, let's compare and continue
+                correctChanges(p, h);
+                i++;
+                j++;
+            } else if (cmp > 0) {
+                //the processing tree element is "greater than" the tree hash element. This means that in our
+                //processing tree we don't have all elements that contribute to the tree hash. This is ok - not
+                //all children of an entity need to be updated for the tree hash to change.
+                //
+                //We don't do any comparisons here, just increase the index in the tree hash, but NOT our
+                //processing tree index.
+                j++;
+            } else {
+                //the processing tree element is "less" than the tree hash element, which means that there can be
+                //other processing tree elements after this one that are equal to the curent tree hash element.
+                //
+                //Let's just increment our processing tree index to try and find such element.
+                i++;
 
-                    if (p.needsResolution()) {
-                        //if p was deleted, it's ok, but if it wasn't we have a serious problem - we found a change
-                        //contributing to the identity hash of some parent, but the computed treeHash that should
-                        //reflect the current state of inventory doesn't have a reference to the changed entity
-                        if (!processDeletion(p, p.notifications)) {
-                            throw new IllegalStateException(
-                                    "Entity on path " + p.element.getPath() + " requires identity hash re-computation" +
-                                            " but was not found contributing to a tree hash of a parent. This is" +
-                                            " inconsistency in the inventory model and a bug.");
-                        }
+                if (p.canBeIdentityRoot()) {
+                    //if p was deleted, it's ok, but if it wasn't we have a serious problem - we found a change
+                    //contributing to the identity hash of some parent, but the computed treeHash that should
+                    //reflect the current state of inventory doesn't have a reference to the changed entity
+                    if (!processDeletion(p, p.notifications)) {
+                        throw new IllegalStateException(
+                                "Entity on path " + p.element.getPath() + " requires identity hash re-computation" +
+                                        " but was not found contributing to a tree hash of a parent. This is" +
+                                        " inconsistency in the inventory model and a bug.");
                     }
                 }
             }
         }
+
+        //now process all the children that were not part of the computed tree hash. This will happen if a child
+        //entity is not taken into account in the tree hash computation but is updated in the transaction.
+        for (int i = treeChildren.size(); i < processedChildren.size(); ++i) {
+            correctChanges(processedChildren.get(i), true);
+        }
+    }
+
+    private void addHashChangeNotifications(AbstractElement<?, ?> entity, Hashes newHashes,
+                                            List<Notification<?, ?>> notifications) {
+        if (entity instanceof Syncable) {
+            Syncable el = (Syncable) entity;
+
+            if (!Objects.equals(el.getSyncHash(), newHashes.getSyncHash())) {
+                notifications.add(new Notification<>(el, el, syncHashChanged()));
+            }
+        }
+
+        if (entity instanceof ContentHashable) {
+            ContentHashable el = (ContentHashable) entity;
+
+            if (!Objects.equals(el.getContentHash(), newHashes.getContentHash())) {
+                notifications.add(new Notification<>(el, el, contentHashChanged()));
+            }
+        }
+
+        if (entity instanceof IdentityHashable) {
+            IdentityHashable el = (IdentityHashable) entity;
+
+            if (!Objects.equals(el.getIdentityHash(), newHashes.getIdentityHash())) {
+                notifications.add(new Notification<>(el, el, identityHashChanged()));
+            }
+        }
+    }
+
+    private Hashes hashesOf(AbstractElement<?, ?> el) {
+        String contentHash = null;
+        String identityHash = null;
+        String syncHash = null;
+
+        if (el instanceof ContentHashable) {
+            contentHash = ((ContentHashable) el).getContentHash();
+        }
+
+        if (el instanceof IdentityHashable) {
+            identityHash = ((IdentityHashable) el).getIdentityHash();
+        }
+
+        if (el instanceof Syncable) {
+            syncHash = ((Syncable) el).getSyncHash();
+        }
+
+        return contentHash == null && identityHash == null && syncHash == null
+                ? null
+                : new Hashes(identityHash, contentHash, syncHash);
     }
 
     private boolean processDeletion(ProcessingTree<BE> changesTree, List<Notification<?, ?>> ns) {
@@ -297,9 +409,8 @@ public class BasePreCommit<BE> implements Transaction.PreCommit<BE> {
             correctedChanges.add(new EntityAndPendingNotifications<BE, AbstractElement<?, ?>>(
                     null, (AbstractElement<?, ?>) n.getValue(), ns));
 
-            IdentityHash.Tree emptyTree = IdentityHash.Tree.builder().build();
             changesTree.dfsTraversal(pt -> {
-                correctChanges(emptyTree, pt);
+                correctChanges(pt, false);
                 return true;
             });
 
@@ -308,7 +419,11 @@ public class BasePreCommit<BE> implements Transaction.PreCommit<BE> {
         return false;
     }
 
-    private Entity<?, ?> cloneWithHash(Entity<?, ?> entity, String identityHash) {
+    private Entity<?, ?> cloneWithHash(Entity<?, ?> entity, Hashes hashes) {
+        if (hashes == null) {
+            return entity;
+        }
+
         return entity.accept(new ElementVisitor.Simple<Entity<?, ?>, Void>() {
             @Override protected Entity<?, ?> defaultAction() {
                 if (entity instanceof IdentityHashable) {
@@ -319,35 +434,42 @@ public class BasePreCommit<BE> implements Transaction.PreCommit<BE> {
             }
 
             @Override public Entity<?, ?> visitData(DataEntity data, Void parameter) {
-                return new DataEntity(data.getPath(), data.getValue(), identityHash, data.getProperties());
+                return new DataEntity(data.getPath(), data.getValue(), hashes.getIdentityHash(),
+                        hashes.getContentHash(), hashes.getSyncHash(), data.getProperties());
             }
 
             @Override public Entity<?, ?> visitFeed(Feed feed, Void parameter) {
-                return new Feed(feed.getName(), feed.getPath(), identityHash, feed.getProperties());
+                return new Feed(feed.getName(), feed.getPath(), hashes.getIdentityHash(),
+                        hashes.getContentHash(), hashes.getSyncHash(), feed.getProperties());
             }
 
             @Override public Entity<?, ?> visitMetric(Metric metric, Void parameter) {
-                return new Metric(metric.getName(), metric.getPath(), identityHash, metric.getType(),
+                return new Metric(metric.getName(), metric.getPath(), hashes.getIdentityHash(), hashes.getContentHash(),
+                        hashes.getSyncHash(), metric.getType(),
                         metric.getCollectionInterval(), metric.getProperties());
             }
 
             @Override public Entity<?, ?> visitMetricType(MetricType type, Void parameter) {
-                return new MetricType(type.getName(), type.getPath(), identityHash, type.getUnit(),
-                        type.getType(), type.getProperties(), type.getCollectionInterval());
+                return new MetricType(type.getName(), type.getPath(), hashes.getIdentityHash(), hashes.getContentHash(),
+                        hashes.getSyncHash(), type.getUnit(), type.getType(), type.getProperties(),
+                        type.getCollectionInterval());
             }
 
             @Override public Entity<?, ?> visitOperationType(OperationType operationType, Void parameter) {
-                return new OperationType(operationType.getName(), operationType.getPath(), identityHash,
-                        operationType.getProperties());
+                return new OperationType(operationType.getName(), operationType.getPath(), hashes.getIdentityHash(),
+                        hashes.getContentHash(), hashes.getSyncHash(), operationType.getProperties());
             }
 
             @Override public Entity<?, ?> visitResource(Resource resource, Void parameter) {
-                return new Resource(resource.getName(), resource.getPath(), identityHash, resource.getType(),
+                return new Resource(resource.getName(), resource.getPath(), hashes.getIdentityHash(),
+                        hashes.getContentHash(), hashes.getSyncHash(),
+                        resource.getType(),
                         resource.getProperties());
             }
 
             @Override public Entity<?, ?> visitResourceType(ResourceType type, Void parameter) {
-                return new ResourceType(type.getName(), type.getPath(), identityHash, type.getProperties());
+                return new ResourceType(type.getName(), type.getPath(), hashes.getIdentityHash(),
+                        hashes.getContentHash(), hashes.getSyncHash(), type.getProperties());
             }
         }, null);
     }
@@ -399,11 +521,15 @@ public class BasePreCommit<BE> implements Transaction.PreCommit<BE> {
             children.clear();
         }
 
-        public boolean needsResolution() {
-            return InventoryStructure.EntityType.supports(path.getElementType());
+        private static boolean canBeIdentityRoot(SegmentType segmentType) {
+            return IdentityHashable.class.isAssignableFrom(Inventory.types().bySegment(segmentType).getElementType());
         }
 
-        public void loadFrom(Transaction<BE> tx) throws ElementNotFoundException {
+        boolean canBeIdentityRoot() {
+            return canBeIdentityRoot(path.getElementType());
+        }
+
+        void loadFrom(Transaction<BE> tx) throws ElementNotFoundException {
             if (element == null || loadingTx != tx) {
                 loadingTx = tx;
                 representation = tx.find(cp);
@@ -419,12 +545,20 @@ public class BasePreCommit<BE> implements Transaction.PreCommit<BE> {
                 throw new IllegalStateException("Cannot add element to partial results from a non-root segment.");
             }
 
+            ProcessingTree<BE> found = extendTreeTo(entity.getEntity().getPath());
+
+            found.representation = entity.getEntityRepresentation();
+            found.element = entity.getEntity();
+            found.notifications.addAll(entity.getNotifications());
+        }
+
+        private ProcessingTree<BE> extendTreeTo(CanonicalPath entityPath) {
             Set<ProcessingTree<BE>> children = this.children;
 
             CanonicalPath.Extender cp = CanonicalPath.empty();
 
             ProcessingTree<BE> found = null;
-            for (Path.Segment seg : entity.getEntity().getPath().getPath()) {
+            for (Path.Segment seg : entityPath.getPath()) {
                 cp.extend(seg);
 
                 found = null;
@@ -444,12 +578,11 @@ public class BasePreCommit<BE> implements Transaction.PreCommit<BE> {
             }
 
             if (found == null) {
-                throw new IllegalStateException("Could not figure out the processing tree element for entity.");
+                throw new IllegalStateException("Could not figure out the processing tree element for entity on path "
+                        + entityPath);
             }
 
-            found.representation = entity.getEntityRepresentation();
-            found.element = entity.getEntity();
-            found.notifications.addAll(entity.getNotifications());
+            return found;
         }
 
         void dfsTraversal(Function<ProcessingTree<BE>, Boolean> visitor) {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResourceTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResourceTypes.java
@@ -78,7 +78,7 @@ public final class BaseResourceTypes {
             tx.update(entity, ResourceType.Update.builder().build());
 
             ResourceType resourceType = new ResourceType(blueprint.getName(),
-                    parentPath.extend(ResourceType.SEGMENT_TYPE, tx.extractId(entity)).get(), null,
+                    parentPath.extend(ResourceType.SEGMENT_TYPE, tx.extractId(entity)).get(), null, null, null,
                     blueprint.getProperties());
 
             return new EntityAndPendingNotifications<>(entity, resourceType, emptyList());
@@ -155,8 +155,8 @@ public final class BaseResourceTypes {
         }
     }
 
-    public static class Single<BE> extends SingleIdentityHashedFetcher<BE, ResourceType, ResourceType.Blueprint,
-            ResourceType.Update> implements ResourceTypes.Single {
+    public static class Single<BE> extends SingleSyncedFetcher<BE, ResourceType, ResourceType.Blueprint,
+                ResourceType.Update> implements ResourceTypes.Single {
 
         public Single(TraversalContext<BE, ResourceType> context) {
             super(context);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
@@ -86,7 +86,8 @@ public final class BaseResources {
                 resourceTypeObject = tx.find(resourceTypePath);
             } catch (ElementNotFoundException e) {
                 throw new IllegalArgumentException("Resource type '" + blueprint.getResourceTypePath() + "' not found" +
-                        " when resolved to '" + resourceTypePath + "'.");
+                        " when resolved to '" + resourceTypePath + "' while trying to wire up new resource on path '" +
+                        parentPath.extend(SegmentType.r, blueprint.getId()) + "'.");
             }
 
             //specifically do NOT check relationship rules, here because defines cannot be created "manually".
@@ -100,7 +101,7 @@ public final class BaseResources {
             ResourceType resourceType = tx.convert(resourceTypeObject, ResourceType.class);
 
             Resource ret = new Resource(blueprint.getName(), parentPath.extend(Resource.SEGMENT_TYPE,
-                    tx.extractId(entity)).get(), null, resourceType, blueprint.getProperties());
+                    tx.extractId(entity)).get(), null, null, null, resourceType, blueprint.getProperties());
 
             Relationship definesRel = new Relationship(tx.extractId(r), defines.name(), resourceTypePath,
                     entityPath);
@@ -201,8 +202,8 @@ public final class BaseResources {
         }
     }
 
-    public static class Single<BE> extends SingleIdentityHashedFetcher<BE, Resource, Resource.Blueprint,
-            Resource.Update> implements Resources.Single {
+    public static class Single<BE> extends SingleSyncedFetcher<BE, Resource, Resource.Blueprint,
+                Resource.Update> implements Resources.Single {
 
         public Single(TraversalContext<BE, Resource> context) {
             super(context);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseTenants.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseTenants.java
@@ -70,7 +70,7 @@ public final class BaseTenants {
 
             return new EntityAndPendingNotifications<>(entity,
                     new Tenant(blueprint.getName(), CanonicalPath.of()
-                    .tenant(tx.extractId(entity)).get(), blueprint.getProperties()), emptyList());
+                    .tenant(tx.extractId(entity)).get(), null, blueprint.getProperties()), emptyList());
         }
 
         @Override

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingInventoryBackend.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingInventoryBackend.java
@@ -27,6 +27,7 @@ import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.model.AbstractElement;
 import org.hawkular.inventory.api.model.Blueprint;
 import org.hawkular.inventory.api.model.Entity;
+import org.hawkular.inventory.api.model.Hashes;
 import org.hawkular.inventory.api.model.StructuredData;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
@@ -92,6 +93,14 @@ public class DelegatingInventoryBackend<E> implements InventoryBackend<E> {
     @Override
     public String extractIdentityHash(E entityRepresentation) {
         return backend.extractIdentityHash(entityRepresentation);
+    }
+
+    @Override public String extractContentHash(E entityRepresentation) {
+        return backend.extractContentHash(entityRepresentation);
+    }
+
+    @Override public String extractSyncHash(E entityRepresentation) {
+        return backend.extractSyncHash(entityRepresentation);
     }
 
     @Override
@@ -231,9 +240,8 @@ public class DelegatingInventoryBackend<E> implements InventoryBackend<E> {
         backend.update(entity, update);
     }
 
-    @Override
-    public void updateIdentityHash(E entity, String identityHash) {
-        backend.updateIdentityHash(entity, identityHash);
+    @Override public void updateHashes(E entity, Hashes hashes) {
+        backend.updateHashes(entity, hashes);
     }
 
     @Override

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingTransaction.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingTransaction.java
@@ -27,6 +27,7 @@ import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.model.AbstractElement;
 import org.hawkular.inventory.api.model.Blueprint;
 import org.hawkular.inventory.api.model.Entity;
+import org.hawkular.inventory.api.model.Hashes;
 import org.hawkular.inventory.api.model.StructuredData;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
@@ -76,6 +77,14 @@ public class DelegatingTransaction<E> implements Transaction<E> {
 
     @Override public String extractIdentityHash(E entityRepresentation) {
         return tx.extractIdentityHash(entityRepresentation);
+    }
+
+    @Override public String extractContentHash(E entityRepresentation) {
+        return tx.extractContentHash(entityRepresentation);
+    }
+
+    @Override public String extractSyncHash(E entityRepresentation) {
+        return tx.extractSyncHash(entityRepresentation);
     }
 
     @Override public String extractRelationshipName(E relationship) {
@@ -192,8 +201,8 @@ public class DelegatingTransaction<E> implements Transaction<E> {
         tx.update(entity, update);
     }
 
-    @Override public void updateIdentityHash(E entity, String identityHash) {
-        tx.updateIdentityHash(entity, identityHash);
+    @Override public void updateHashes(E entity, Hashes hashes) {
+        tx.updateHashes(entity, hashes);
     }
 
     @Override public boolean requiresRollbackAfterFailure(Throwable t) {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Transaction.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Transaction.java
@@ -31,6 +31,7 @@ import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.model.AbstractElement;
 import org.hawkular.inventory.api.model.Blueprint;
 import org.hawkular.inventory.api.model.Entity;
+import org.hawkular.inventory.api.model.Hashes;
 import org.hawkular.inventory.api.model.StructuredData;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
@@ -89,6 +90,10 @@ public interface Transaction<E> {
     String extractId(E entityRepresentation);
 
     String extractIdentityHash(E entityRepresentation);
+
+    String extractContentHash(E entityRepresentation);
+
+    String extractSyncHash(E entityRepresentation);
 
     String extractRelationshipName(E relationship);
 
@@ -150,7 +155,7 @@ public interface Transaction<E> {
 
     void update(E entity, AbstractElement.Update update);
 
-    void updateIdentityHash(E entity, String identityHash);
+    void updateHashes(E entity, Hashes hashes);
 
     /**
      * Checks the exception thrown during the commit and returns true if the backend requires explicit rollback after

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InventoryBackend.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InventoryBackend.java
@@ -27,6 +27,7 @@ import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.model.AbstractElement;
 import org.hawkular.inventory.api.model.Blueprint;
 import org.hawkular.inventory.api.model.Entity;
+import org.hawkular.inventory.api.model.Hashes;
 import org.hawkular.inventory.api.model.StructuredData;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
@@ -231,6 +232,10 @@ public interface InventoryBackend<E> extends AutoCloseable {
      */
     String extractIdentityHash(E entityRepresentation);
 
+    String extractContentHash(E entityRepresentation);
+
+    String extractSyncHash(E entityRepresentation);
+
     /**
      * Converts the provided representation object to an inventory element of provided type.
      *
@@ -296,12 +301,11 @@ public interface InventoryBackend<E> extends AutoCloseable {
     void update(E entity, AbstractElement.Update update);
 
     /**
-     * Updates the identity hash of the entity.
-     *
-     * @param entity the entity to update
-     * @param identityHash the identity hash to set
+     * Updates the various hashes on the entity
+     * @param entity the entity to update the hashes of
+     * @param hashes the hashes to update
      */
-    void updateIdentityHash(E entity, String identityHash);
+    void updateHashes(E entity, Hashes hashes);
 
     /**
      * Simply deletes the entity from the storage.

--- a/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/ContentHashTest.java
+++ b/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/ContentHashTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api.test;
+
+import static org.hawkular.inventory.paths.ElementTypeVisitor.accept;
+
+import java.nio.charset.Charset;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.hawkular.inventory.api.model.ContentHash;
+import org.hawkular.inventory.api.model.DataEntity;
+import org.hawkular.inventory.api.model.Entity;
+import org.hawkular.inventory.api.model.Environment;
+import org.hawkular.inventory.api.model.Feed;
+import org.hawkular.inventory.api.model.Metric;
+import org.hawkular.inventory.api.model.MetricDataType;
+import org.hawkular.inventory.api.model.MetricType;
+import org.hawkular.inventory.api.model.MetricUnit;
+import org.hawkular.inventory.api.model.OperationType;
+import org.hawkular.inventory.api.model.Resource;
+import org.hawkular.inventory.api.model.ResourceType;
+import org.hawkular.inventory.api.model.StructuredData;
+import org.hawkular.inventory.api.model.Tenant;
+import org.hawkular.inventory.paths.CanonicalPath;
+import org.hawkular.inventory.paths.ElementTypeVisitor;
+import org.hawkular.inventory.paths.SegmentType;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.18.0
+ */
+public class ContentHashTest {
+
+    @Test
+    public void testComputesForEveryEntityType() throws Exception {
+        Map<String, Object> props = new HashMap<>();
+        props.put("a", "b");
+        props.put("b", "c");
+        String name = "name";
+
+        ElementTypeVisitor<Entity.Blueprint, Void> generator = new ElementTypeVisitor<Entity.Blueprint, Void>() {
+            @Override public Entity.Blueprint visitTenant(Void parameter) {
+                return Tenant.Blueprint.builder().withId("id").withName(name).withProperties(props).build();
+            }
+
+            @Override public Entity.Blueprint visitEnvironment(Void parameter) {
+                return Environment.Blueprint.builder().withId("id").withName(name).withProperties(props).build();
+            }
+
+            @Override public Entity.Blueprint visitFeed(Void parameter) {
+                return Feed.Blueprint.builder().withId("id").withName(name).withProperties(props).build();
+            }
+
+            @Override public Entity.Blueprint visitMetric(Void parameter) {
+                return Metric.Blueprint.builder().withId("id").withName(name).withProperties(props)
+                        .withMetricTypePath("../../metricType").withInterval(1L).build();
+            }
+
+            @Override public Entity.Blueprint visitMetricType(Void parameter) {
+                return MetricType.Blueprint.builder(MetricDataType.GAUGE).withId("id").withName(name)
+                        .withProperties(props).withInterval(1L).withUnit(MetricUnit.BYTES).build();
+            }
+
+            @Override public Entity.Blueprint visitResource(Void parameter) {
+                return Resource.Blueprint.builder().withId("id").withName(name).withProperties(props)
+                        .withResourceTypePath("../../resourceType").build();
+            }
+
+            @Override public Entity.Blueprint visitResourceType(Void parameter) {
+                return ResourceType.Blueprint.builder().withId("id").withName(name).withProperties(props).build();
+            }
+
+            @Override public Entity.Blueprint visitRelationship(Void parameter) {
+                return null;
+            }
+
+            @Override public Entity.Blueprint visitData(Void parameter) {
+                return DataEntity.Blueprint.builder().withId("configuration").withName(name).withProperties(props)
+                        .withValue(StructuredData.get().bool(true)).build();
+            }
+
+            @Override public Entity.Blueprint visitOperationType(Void parameter) {
+                return OperationType.Blueprint.builder().withId("id").withName(name).withProperties(props).build();
+            }
+
+            @Override public Entity.Blueprint visitMetadataPack(Void parameter) {
+                return null;
+            }
+
+            @Override public Entity.Blueprint visitUnknown(Void parameter) {
+                return null;
+            }
+        };
+
+        String commonHash = hash(name, props);
+        String metricHash = hash("../../mt;metricType1" + name, props); //relative metric type path followed by the
+                                                                        //collection interval, followed by the name
+                                                                        //and props
+        String resourceHash = hash("../../rt;resourceType" + name, props);
+
+        String metricTypeHash = hash("" + MetricDataType.GAUGE + MetricUnit.BYTES + "1" + name, props);
+
+        String dataHash = hash(StructuredData.get().bool(true).toJSON() + "configuration", props);
+
+        for (SegmentType t : SegmentType.values()) {
+            Entity.Blueprint bl = accept(t, generator, null);
+
+            if (bl != null) {
+                //no other entity type but the resource needs the canonical path to compute the content hash.
+                //so we can safely just pass here the canonical path of the resource. It will be ignored in all other
+                //but correct cases.
+                String contentHash =
+                        ContentHash.of(bl, CanonicalPath.of().tenant("tnt").feed("fd").resource("id").get());
+
+                ElementTypeVisitor.accept(t, new ElementTypeVisitor.Simple<Void, Void>() {
+                    @Override protected Void defaultAction(SegmentType elementType, Void parameter) {
+                        Assert.assertEquals("Unexpected content hash for " + elementType.getSimpleName(),
+                                commonHash, contentHash);
+                        return null;
+                    }
+
+                    @Override public Void visitMetric(Void parameter) {
+                        Assert.assertEquals("Unexpected content hash for Metric", metricHash, contentHash);
+                        return null;
+                    }
+
+                    @Override public Void visitMetricType(Void parameter) {
+                        Assert.assertEquals("Unexpected content hash for MetricType", metricTypeHash, contentHash);
+                        return null;
+                    }
+
+                    @Override public Void visitResource(Void parameter) {
+                        Assert.assertEquals("Unexpected content hash for Resource", resourceHash, contentHash);
+                        return null;
+                    }
+
+                    @Override public Void visitData(Void parameter) {
+                        Assert.assertEquals("Unexpected content hash for DataEntity", dataHash, contentHash);
+                        return null;
+                    }
+                }, null);
+            }
+        }
+    }
+
+
+    private String digest(String content) throws NoSuchAlgorithmException {
+        byte[] digest = MessageDigest.getInstance("SHA-1").digest(content.getBytes(Charset.forName("UTF-8")));
+
+        StringBuilder bld = new StringBuilder();
+        for (byte b : digest) {
+            bld.append(Integer.toHexString(Byte.toUnsignedInt(b)));
+        }
+
+        return bld.toString();
+    }
+
+    private String hash(String name, Map<String, Object> properties) throws NoSuchAlgorithmException {
+        Map<String, Object> sorted = new TreeMap<>(Comparator.naturalOrder());
+        sorted.putAll(properties);
+
+        StringBuilder content = new StringBuilder(name);
+        sorted.forEach((k, v) -> content.append(k).append(v));
+
+        return digest(content.toString());
+    }
+}

--- a/hawkular-inventory-bus/src/test/java/org/hawkular/inventory/bus/BusTest.java
+++ b/hawkular-inventory-bus/src/test/java/org/hawkular/inventory/bus/BusTest.java
@@ -101,22 +101,24 @@ public class BusTest {
 
     @Test
     public void messagesSerializationTest() {
-        Tenant tenant = new Tenant(CanonicalPath.fromString("/t;c"), objectProperties);
-        MetricType metricType = new MetricType(CanonicalPath.fromString("/t;t/mt;mt"), null, MetricUnit.MINUTES,
+        Tenant tenant = new Tenant(CanonicalPath.fromString("/t;c"), "t", objectProperties);
+        MetricType metricType = new MetricType(CanonicalPath.fromString("/t;t/mt;mt"), null, null, null,
+                MetricUnit.MINUTES,
                 MetricDataType.GAUGE);
-        ResourceType resourceType = new ResourceType(CanonicalPath.fromString("/t;t/rt;rt"), null, objectProperties);
+        ResourceType resourceType = new ResourceType(CanonicalPath.fromString("/t;t/rt;rt"), null, null, null,
+                objectProperties);
 
-        Tenant tenant2 = new Tenant(CanonicalPath.fromString("/t;t"));
+        Tenant tenant2 = new Tenant(CanonicalPath.fromString("/t;t"), null);
         TenantEvent tenantEvent = new TenantEvent(Action.Enumerated.CREATED, tenant);
         EnvironmentEvent environmentEvent = new EnvironmentEvent(Action.Enumerated.CREATED,
                 tenant2,
-                new Environment(CanonicalPath.fromString("/t;t/e;e"), objectProperties));
+                new Environment(CanonicalPath.fromString("/t;t/e;e"), null, objectProperties));
         FeedEvent feedEvent = new FeedEvent(Action.Enumerated.UPDATED,
                 tenant2,
-                new Feed(CanonicalPath.fromString("/t;t/f;f"), null, objectProperties));
+                new Feed(CanonicalPath.fromString("/t;t/f;f"), null, null, null, objectProperties));
         MetricEvent metricEvent = new MetricEvent(Action.Enumerated.DELETED,
                 tenant2,
-                new Metric(CanonicalPath.fromString("/t;t/e;e/m;m"), null, metricType, objectProperties));
+                new Metric(CanonicalPath.fromString("/t;t/e;e/m;m"), null, null, null, metricType, objectProperties));
         MetricTypeEvent metricTypeEvent = new MetricTypeEvent(Action.Enumerated.COPIED, tenant2, metricType);
         RelationshipEvent relationshipEvent = new RelationshipEvent(Action.Enumerated.REGISTERED,
                 tenant2,
@@ -124,12 +126,12 @@ public class BusTest {
                         , objectProperties));
         ResourceEvent resourceEvent = new ResourceEvent(Action.Enumerated.UPDATED,
                 tenant2,
-                new Resource(CanonicalPath.fromString("/t;t/e;e/r;r"), null, resourceType));
+                new Resource(CanonicalPath.fromString("/t;t/e;e/r;r"), null, null, null, resourceType));
         ResourceTypeEvent resourceTypeEvent = new ResourceTypeEvent(Action.Enumerated.COPIED, tenant2, resourceType);
         DataEntityEvent dataEntityEvent = new DataEntityEvent(Action.Enumerated.DELETED,
                 tenant2,
                 new DataEntity(resourceType.getPath(), DataRole.ResourceType.configurationSchema,
-                        StructuredData.get().undefined(), "hash"));
+                        StructuredData.get().undefined(), "hash", null, null));
 
         String tenantJSON = tenantEvent.toJSON();
         String envJSON = environmentEvent.toJSON();
@@ -163,7 +165,7 @@ public class BusTest {
 
     @Test
     public void createTenantEventFromJSON() {
-        Tenant tenant = new Tenant(CanonicalPath.fromString("/t;c"), objectProperties);
+        Tenant tenant = new Tenant(CanonicalPath.fromString("/t;c"), null, objectProperties);
         TenantEvent tenantEvent = new TenantEvent(Action.Enumerated.CREATED, tenant);
 
         String tenantJSON = "{\"action\":\"CREATED\",\"object\":{\"path\":\"/t;c\",\"properties\":{\"p1\":\"prop1\"}}}";
@@ -174,12 +176,13 @@ public class BusTest {
 
     @Test
     public void createMetricEventFromJSON() {
-        Tenant tenant = new Tenant(CanonicalPath.fromString("/t;t"));
-        MetricType metricType = new MetricType(CanonicalPath.fromString("/t;t/mt;mt"), null, MetricUnit.MINUTES,
+        Tenant tenant = new Tenant(CanonicalPath.fromString("/t;t"), null);
+        MetricType metricType = new MetricType(CanonicalPath.fromString("/t;t/mt;mt"), null, null, null,
+                MetricUnit.MINUTES,
                 MetricDataType.GAUGE);
         MetricEvent metricEvent = new MetricEvent(Action.Enumerated.DELETED,
                 tenant,
-                new Metric(CanonicalPath.fromString("/t;t/e;e/m;m"), null, metricType, objectProperties));
+                new Metric(CanonicalPath.fromString("/t;t/e;e/m;m"), null, null, null, metricType, objectProperties));
 
         String metricJSON = "{\"action\":\"DELETED\",\"object\":{\"path\":\"/t;t/e;e/m;m\",\"type\"" +
                 ":{\"path\":\"/t;t/mt;mt\",\"properties\":null,\"unit\":\"MINUTES\",\"type\":\"GAUGE\"}," +
@@ -404,7 +407,7 @@ public class BusTest {
 
     @Test
     public void testQueryResponseSerialization() {
-        List<Tenant> tenantList = Arrays.asList(new Tenant("name", CanonicalPath.fromString("/t;tenant")));
+        List<Tenant> tenantList = Arrays.asList(new Tenant("name", CanonicalPath.fromString("/t;tenant"), null));
 
         ResultSet<Tenant> resultSet = new ResultSet<>(tenantList,  new PageContext(1, 15, Order.unspecified()), 156);
 

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/Constants.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/Constants.java
@@ -16,6 +16,7 @@
  */
 package org.hawkular.inventory.impl.tinkerpop;
 
+import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__contentHash;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__identityHash;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__metric_data_type;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__metric_interval;
@@ -26,6 +27,7 @@ import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__structu
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__structuredDataKey;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__structuredDataType;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__structuredDataValue;
+import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__syncHash;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__targetCp;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__targetEid;
 import static org.hawkular.inventory.impl.tinkerpop.Constants.Property.__targetType;
@@ -145,7 +147,11 @@ final class Constants {
 
         __identityHash,
 
-        __targetIdentityHash;
+        __targetIdentityHash,
+
+        __contentHash,
+
+        __syncHash;
 
         private final String sortName;
 
@@ -195,13 +201,19 @@ final class Constants {
      * The type of entities known to Hawkular.
      */
     enum Type {
-        tenant(Tenant.class, name), environment(Environment.class, name), feed(Feed.class, name),
-        resourceType(ResourceType.class, name, __identityHash),
-        metricType(MetricType.class, name, __unit, __metric_data_type, __metric_interval, __identityHash),
-        operationType(OperationType.class, name), resource(Resource.class, name),
-        metric(Metric.class, name, __metric_interval), metadatapack(MetadataPack.class, name),
+        tenant(Tenant.class, name, __contentHash),
+        environment(Environment.class, name, __contentHash),
+        feed(Feed.class, name, __identityHash, __contentHash, __syncHash),
+        resourceType(ResourceType.class, name, __identityHash, __contentHash, __syncHash),
+        metricType(MetricType.class, name, __unit, __metric_data_type, __metric_interval, __identityHash, __contentHash,
+                __syncHash),
+        operationType(OperationType.class, name, __identityHash, __contentHash, __syncHash),
+        resource(Resource.class, name, __identityHash, __contentHash, __syncHash),
+        metric(Metric.class, name, __metric_interval, __identityHash, __contentHash, __syncHash),
+        metadatapack(MetadataPack.class, name),
         relationship(Relationship.class, __sourceType, __targetType, __sourceCp, __targetCp, __sourceEid, __targetEid),
-        dataEntity(DataEntity.class, name), structuredData(StructuredData.class, __structuredDataType,
+        dataEntity(DataEntity.class, name, __identityHash, __contentHash, __syncHash),
+        structuredData(StructuredData.class, __structuredDataType,
                 __structuredDataValue, __structuredDataIndex, __structuredDataKey);
 
         private final String[] mappedProperties;

--- a/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/PathDeserializer.java
+++ b/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/PathDeserializer.java
@@ -19,6 +19,7 @@ package org.hawkular.inventory.json;
 import java.io.IOException;
 
 import org.hawkular.inventory.paths.Path;
+import org.hawkular.inventory.paths.RelativePath;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -31,6 +32,10 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 public final class PathDeserializer extends JsonDeserializer<Path> {
     @Override
     public Path deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        String val = jp.getValueAsString();
+        if (val.isEmpty()) {
+            return RelativePath.empty().get();
+        }
         return Path.fromString(jp.getValueAsString());
     }
 }

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestEntity.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestEntity.java
@@ -35,13 +35,13 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
-import org.hawkular.inventory.api.IdentityHashed;
 import org.hawkular.inventory.api.Inventory;
 import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.ResolvableToSingle;
+import org.hawkular.inventory.api.Synced;
 import org.hawkular.inventory.api.model.AbstractElement;
-import org.hawkular.inventory.api.model.IdentityHash;
 import org.hawkular.inventory.api.model.Relationship;
+import org.hawkular.inventory.api.model.SyncHash;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.SegmentType;
 
@@ -65,13 +65,13 @@ public class RestEntity extends RestBase {
     @GET
     @Path("{path:.+}/treeHash")
     @SuppressWarnings("unchecked")
-    public IdentityHash.Tree getTreeHash(@Context UriInfo uriInfo)
+    public SyncHash.Tree getTreeHash(@Context UriInfo uriInfo)
             throws Exception {
 
         CanonicalPath path = CanonicalPath.fromPartiallyUntypedString(getPath(uriInfo, "/treeHash".length()),
                 getTenantPath(), AbstractElement.class);
 
-        return inventory.inspect(path, IdentityHashed.Single.class).treeHash();
+        return inventory.inspect(path, Synced.Single.class).treeHash();
     }
 
     @GET

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestSync.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestSync.java
@@ -29,7 +29,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.Response;
 
-import org.hawkular.inventory.api.IdentityHashed;
+import org.hawkular.inventory.api.Synced;
 import org.hawkular.inventory.api.model.InventoryStructure;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.rest.json.ApiError;
@@ -73,7 +73,7 @@ public class RestSync extends RestBase {
                     + " are not synchronizable.");
         }
 
-        inventory.inspect(cp, IdentityHashed.SingleWithRelationships.class).synchronize(structure);
+        inventory.inspect(cp, Synced.SingleWithRelationships.class).synchronize(structure);
 
         return Response.noContent().build();
     }


### PR DESCRIPTION
- All entity types but metdatapack have a content hash - this is just a
  hash of its properties, generic properties and name and is not directly
  used in the API for anything. It is NOT hierarchical, i.e. when a content
  hash changes on a contained entity, the content hash of the containing
  entity doesn't change.
- Identity hash works the same as before and is used for locating the
  "identical" entities - the ones with the same structure, but potentially
  different name or generic properties.
- Sync hash is a new kind of hash that is the union of content and identity
  hashes. It is used as the basis for synchronization of inventory structure.
  I.e. even a changes in generic properties or name of an entity is now
  synchronized.
