### PR TITLE
[HWKINVENT-192] Rename MetricType.type to MetricType.metricDataType

### DIFF
--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Inventory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Inventory.java
@@ -556,7 +556,7 @@ public interface Inventory extends AutoCloseable, Tenants.Container<Tenants.Read
             }
 
             @Override public B visitMetricType(MetricType type, Void parameter) {
-                return (B) fillCommon(type, MetricType.Blueprint.builder(type.getType()))
+                return (B) fillCommon(type, MetricType.Blueprint.builder(type.getMetricDataType()))
                         .withInterval(type.getCollectionInterval()).withUnit(type.getUnit()).build();
             }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ComputeHash.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ComputeHash.java
@@ -196,12 +196,12 @@ final class ComputeHash {
                 return wrap(mt, ctx, (childContext) -> {
                     if (computeIdentity) {
                         appendIdentity(mt.getId(), childContext);
-                        appendIdentity(mt.getType().name(), childContext);
+                        appendIdentity(mt.getMetricDataType().name(), childContext);
                         appendIdentity(mt.getUnit().name(), childContext);
                     }
 
                     if (computeContent) {
-                        appendContent(mt.getType().name(), childContext);
+                        appendContent(mt.getMetricDataType().name(), childContext);
                         appendContent(mt.getUnit().name(), childContext);
                         appendContent(Objects.toString(mt.getCollectionInterval(), ""), childContext);
                         appendCommonContent(mt, childContext);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/MetricType.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/MetricType.java
@@ -43,7 +43,7 @@ public final class MetricType extends SyncedEntity<MetricType.Blueprint, MetricT
 
     private final MetricUnit unit;
 
-    private final MetricDataType type;
+    private final MetricDataType metricDataType;
 
     private final Long collectionInterval;
 
@@ -53,7 +53,7 @@ public final class MetricType extends SyncedEntity<MetricType.Blueprint, MetricT
     @SuppressWarnings("unused")
     private MetricType() {
         unit = null;
-        type = null;
+        metricDataType = null;
         collectionInterval = null;
     }
 
@@ -62,39 +62,40 @@ public final class MetricType extends SyncedEntity<MetricType.Blueprint, MetricT
     }
 
     public MetricType(CanonicalPath path, String identityHash, String contentHash, String syncHash, MetricUnit unit,
-                      MetricDataType type) {
-        this(path, identityHash, contentHash, syncHash, unit, type, null, null);
+                      MetricDataType metricDataType) {
+        this(path, identityHash, contentHash, syncHash, unit, metricDataType, null, null);
     }
 
     public MetricType(CanonicalPath path, String identityHash, String contentHash, String syncHash, MetricUnit unit,
-                      MetricDataType type,
+                      MetricDataType metricDataType,
                       Long collectionInterval) {
-        this(path, identityHash, contentHash, syncHash, unit, type, null, collectionInterval);
+        this(path, identityHash, contentHash, syncHash, unit, metricDataType, null, collectionInterval);
     }
 
     public MetricType(String name, CanonicalPath path, String identityHash, String contentHash,
                       java.lang.String syncHash,
                       MetricUnit unit,
-                      MetricDataType type) {
-        this(name, path, identityHash, contentHash, syncHash, unit, type, null, null);
+                      MetricDataType metricDataType) {
+        this(name, path, identityHash, contentHash, syncHash, unit, metricDataType, null, null);
     }
 
-    public MetricType(CanonicalPath path, String identityHash, java.lang.String contentHash, java.lang.String syncHash,
-                      MetricUnit unit, MetricDataType type, Map<String, Object> properties, Long collectionInterval) {
+    public MetricType(CanonicalPath path, String identityHash, String contentHash, String syncHash,
+                      MetricUnit unit, MetricDataType metricDataType, Map<String, Object> properties,
+                      Long collectionInterval) {
         super(null, path, identityHash, contentHash, syncHash, properties);
-        if (type == null) {
+        if (metricDataType == null) {
             throw new IllegalArgumentException("metricDataType == null");
         }
         this.unit = unit;
-        this.type = type;
+        this.metricDataType = metricDataType;
         this.collectionInterval = collectionInterval;
     }
 
     public MetricType(String name, CanonicalPath path, String identityHash, java.lang.String contentHash,
-                      java.lang.String syncHash, MetricUnit unit, MetricDataType type,
+                      java.lang.String syncHash, MetricUnit unit, MetricDataType metricDataType,
                       Map<String, Object> properties, Long collectionInterval) {
         super(name, path, identityHash, contentHash, syncHash, properties);
-        this.type = type;
+        this.metricDataType = metricDataType;
         this.unit = unit;
         this.collectionInterval = collectionInterval;
     }
@@ -103,8 +104,22 @@ public final class MetricType extends SyncedEntity<MetricType.Blueprint, MetricT
         return unit;
     }
 
-    public MetricDataType getType() {
-        return type;
+    public MetricDataType getMetricDataType() {
+        return metricDataType;
+    }
+
+    /**
+     * This is here to keep the serialization of a property called "type" with the upper case representation of the
+     * {@link MetricDataType} enum.
+     *
+     * <p>This will disappear in due time.
+     *
+     * @deprecated use {@link #getMetricDataType()}
+     * @return the metric data type
+     */
+    @Deprecated
+    public String getType() {
+        return getMetricDataType().name();
     }
 
     public Long getCollectionInterval() {
@@ -114,7 +129,7 @@ public final class MetricType extends SyncedEntity<MetricType.Blueprint, MetricT
     @Override
     public Updater<Update, MetricType> update() {
         return new Updater<>((u) -> new MetricType(u.getName(), getPath(), getIdentityHash(), getContentHash(),
-                getSyncHash(), valueOrDefault(u.unit, this.unit), type, u.getProperties(),
+                getSyncHash(), valueOrDefault(u.unit, this.unit), metricDataType, u.getProperties(),
                 valueOrDefault(u.getCollectionInterval(), collectionInterval)));
     }
 
@@ -139,7 +154,7 @@ public final class MetricType extends SyncedEntity<MetricType.Blueprint, MetricT
     @ApiModel("MetricTypeBlueprint")
     public static final class Blueprint extends Entity.Blueprint {
         private final MetricUnit unit;
-        private final MetricDataType type;
+        private final MetricDataType metricDataType;
         private final Long collectionInterval;
 
         public static Builder builder(MetricDataType type) {
@@ -152,38 +167,38 @@ public final class MetricType extends SyncedEntity<MetricType.Blueprint, MetricT
         @SuppressWarnings("unused")
         private Blueprint() {
             unit = null;
-            type = null;
+            metricDataType = null;
             collectionInterval = null;
         }
 
-        public Blueprint(String id, MetricUnit unit, MetricDataType type, Long collectionInterval) {
-            this(id, unit, type, Collections.emptyMap(), collectionInterval);
+        public Blueprint(String id, MetricUnit unit, MetricDataType metricDataType, Long collectionInterval) {
+            this(id, unit, metricDataType, Collections.emptyMap(), collectionInterval);
         }
 
-        public Blueprint(String id, MetricUnit unit, MetricDataType type, Map<String, Object> properties,
+        public Blueprint(String id, MetricUnit unit, MetricDataType metricDataType, Map<String, Object> properties,
                          Long collectionInterval) {
             super(id, properties);
             this.unit = unit == null ? MetricUnit.NONE : unit;
-            this.type = type;
+            this.metricDataType = metricDataType;
             this.collectionInterval = collectionInterval;
         }
 
-        public Blueprint(String id, MetricUnit unit, MetricDataType type, Long collectionInterval,
+        public Blueprint(String id, MetricUnit unit, MetricDataType metricDataType, Long collectionInterval,
                          Map<String, Object> properties,
                          Map<String, Set<CanonicalPath>> outgoing,
                          Map<String, Set<CanonicalPath>> incoming) {
             super(id, properties, outgoing, incoming);
-            this.type = type;
+            this.metricDataType = metricDataType;
             this.unit = unit;
             this.collectionInterval = collectionInterval;
         }
 
-        public Blueprint(String id, String name, MetricUnit unit, MetricDataType type, Map<String, Object> properties,
+        public Blueprint(String id, String name, MetricUnit unit, MetricDataType metricDataType, Map<String, Object> properties,
                          Long collectionInterval,
                          Map<String, Set<CanonicalPath>> outgoing,
                          Map<String, Set<CanonicalPath>> incoming) {
             super(id, name, properties, outgoing, incoming);
-            this.type = type;
+            this.metricDataType = metricDataType;
             this.unit = unit;
             this.collectionInterval = collectionInterval;
         }
@@ -197,13 +212,13 @@ public final class MetricType extends SyncedEntity<MetricType.Blueprint, MetricT
             return unit;
         }
 
-        public MetricDataType getType() {
+        public MetricDataType getMetricDataType() {
             //this is so that we throw a meaningful exception when processing blueprints created by deserialization
             //from user data.
-            if (type == null) {
+            if (metricDataType == null) {
                 throw new IllegalStateException("Data type of metric type cannot be null.");
             }
-            return type;
+            return metricDataType;
         }
 
         public Long getCollectionInterval() {
@@ -217,11 +232,11 @@ public final class MetricType extends SyncedEntity<MetricType.Blueprint, MetricT
 
         public static final class Builder extends Entity.Blueprint.Builder<Blueprint, Builder> {
             private MetricUnit unit;
-            private MetricDataType type;
+            private MetricDataType metricDataType;
             private Long collectionInterval;
 
-            public Builder(MetricDataType type) {
-                this.type = type;
+            public Builder(MetricDataType metricDataType) {
+                this.metricDataType = metricDataType;
             }
 
             public Builder withUnit(MetricUnit unit) {
@@ -229,8 +244,8 @@ public final class MetricType extends SyncedEntity<MetricType.Blueprint, MetricT
                 return this;
             }
 
-            public Builder withType(MetricDataType type) {
-                this.type = type;
+            public Builder withMetridDataType(MetricDataType type) {
+                this.metricDataType = type;
                 return this;
             }
 
@@ -241,7 +256,7 @@ public final class MetricType extends SyncedEntity<MetricType.Blueprint, MetricT
 
             @Override
             public Blueprint build() {
-                return new Blueprint(id, name, unit, type, properties, collectionInterval, outgoing, incoming);
+                return new Blueprint(id, name, unit, metricDataType, properties, collectionInterval, outgoing, incoming);
             }
         }
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetricTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetricTypes.java
@@ -68,7 +68,7 @@ public final class BaseMetricTypes {
 
             MetricType metricType = new MetricType(blueprint.getName(),
                     parentPath.extend(MetricType.SEGMENT_TYPE, tx.extractId(entity)).get(), null, null, null,
-                    blueprint.getUnit(), blueprint.getType(), blueprint.getProperties(),
+                    blueprint.getUnit(), blueprint.getMetricDataType(), blueprint.getProperties(),
                     blueprint.getCollectionInterval());
 
             return new EntityAndPendingNotifications<>(entity, metricType, emptyList());
@@ -87,7 +87,7 @@ public final class BaseMetricTypes {
         @Override
         public MetricTypes.Single create(MetricType.Blueprint blueprint, boolean cache)
                 throws EntityAlreadyExistsException {
-            if (blueprint.getType() == null ||
+            if (blueprint.getMetricDataType() == null ||
                 blueprint.getUnit() == null ||
                 blueprint.getCollectionInterval() == null) {
 
@@ -146,7 +146,7 @@ public final class BaseMetricTypes {
             String msg;
             if (blueprint.getCollectionInterval() == null) {
                 msg = "Interval (\"collectionInterval\" in JSON)";
-            } else if (blueprint.getType() == null) {
+            } else if (blueprint.getMetricDataType() == null) {
                 msg = "Data type (\"type\" in JSON)";
             } else {
                 msg = "Metric unit (\"unit\" in JSON)";

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BasePreCommit.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BasePreCommit.java
@@ -451,7 +451,7 @@ public class BasePreCommit<BE> implements Transaction.PreCommit<BE> {
 
             @Override public Entity<?, ?> visitMetricType(MetricType type, Void parameter) {
                 return new MetricType(type.getName(), type.getPath(), hashes.getIdentityHash(), hashes.getContentHash(),
-                        hashes.getSyncHash(), type.getUnit(), type.getType(), type.getProperties(),
+                        hashes.getSyncHash(), type.getUnit(), type.getMetricDataType(), type.getProperties(),
                         type.getCollectionInterval());
             }
 

--- a/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryTestsuite.java
+++ b/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryTestsuite.java
@@ -1938,7 +1938,7 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
 
         String expectedContentHash = IdentityHash.of(MetadataPack.Members.builder()
                 .with(MetricType.Blueprint
-                        .builder(mt.getType())
+                        .builder(mt.getMetricDataType())
                         .withUnit(mt.getUnit())
                         .withInterval(0L)
                         .withId(mt.getId()).build())

--- a/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/IdentityHashTest.java
+++ b/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/IdentityHashTest.java
@@ -57,7 +57,7 @@ public class IdentityHashTest {
 
         String blueprintHash = IdentityHash.of(structure);
 
-        String expectedHash = digest(mtb.getId() + mtb.getType() + mtb.getUnit());
+        String expectedHash = digest(mtb.getId() + mtb.getMetricDataType() + mtb.getUnit());
 
         Assert.assertEquals(expectedHash, blueprintHash);
     }

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/Constants.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/Constants.java
@@ -100,7 +100,7 @@ final class Constants {
         /**
          * Property used on metric type to distinguish type of metric e.g. gauge, counter...
          */
-        __metric_data_type,
+        __metric_data_type("metricDataType"),
 
         /**
          * Property used to store interval in seconds at which metrics are collected
@@ -145,13 +145,13 @@ final class Constants {
 
         __targetEid,
 
-        __identityHash,
+        __identityHash("identityHash"),
 
         __targetIdentityHash,
 
-        __contentHash,
+        __contentHash("contentHash"),
 
-        __syncHash;
+        __syncHash("syncHash");
 
         private final String sortName;
 

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterVisitor.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterVisitor.java
@@ -317,14 +317,15 @@ class FilterVisitor {
 
     @SuppressWarnings("unchecked")
     private void applyPropertyFilter(HawkularPipeline<?, ?> query, String propertyName, Object... values) {
+        String mappedName = Constants.Property.mapUserDefined(propertyName);
         if (values.length == 0) {
-            query.has(propertyName);
+            query.has(mappedName);
         } else if (values.length == 1) {
-            query.has(propertyName, values[0]);
+            query.has(mappedName, values[0]);
         } else {
             Pipe[] checks = new Pipe[values.length];
 
-            Arrays.setAll(checks, i -> new PropertyFilterPipe<Element, String>(propertyName, Compare.EQUAL, values[i]));
+            Arrays.setAll(checks, i -> new PropertyFilterPipe<Element, String>(mappedName, Compare.EQUAL, values[i]));
 
             query.or(checks);
         }

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
@@ -773,7 +773,7 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
             public Element visitMetricType(MetricType.Blueprint type, Void parameter) {
                 Element entity = common(path, type.getName(), type.getProperties(), MetricType.class);
 
-                entity.setProperty(Constants.Property.__metric_data_type.name(), type.getType().getDisplayName());
+                entity.setProperty(Constants.Property.__metric_data_type.name(), type.getMetricDataType().getDisplayName());
                 entity.setProperty(Constants.Property.__metric_interval.name(), type.getCollectionInterval());
 
                 return entity;

--- a/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/InventoryJacksonConfig.java
+++ b/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/InventoryJacksonConfig.java
@@ -35,6 +35,7 @@ import org.hawkular.inventory.api.model.Feed;
 import org.hawkular.inventory.api.model.IdentityHash;
 import org.hawkular.inventory.api.model.InventoryStructure;
 import org.hawkular.inventory.api.model.Metric;
+import org.hawkular.inventory.api.model.MetricDataType;
 import org.hawkular.inventory.api.model.MetricType;
 import org.hawkular.inventory.api.model.OperationType;
 import org.hawkular.inventory.api.model.Relationship;
@@ -64,7 +65,9 @@ import org.hawkular.inventory.json.mixins.model.EnvironmentMixin;
 import org.hawkular.inventory.json.mixins.model.FeedMixin;
 import org.hawkular.inventory.json.mixins.model.IdentityHashTreeMixin;
 import org.hawkular.inventory.json.mixins.model.InventoryStructureMixin;
+import org.hawkular.inventory.json.mixins.model.MetricDataTypeMixin;
 import org.hawkular.inventory.json.mixins.model.MetricMixin;
+import org.hawkular.inventory.json.mixins.model.MetricTypeBlueprintMixin;
 import org.hawkular.inventory.json.mixins.model.MetricTypeMixin;
 import org.hawkular.inventory.json.mixins.model.OperationTypeMixin;
 import org.hawkular.inventory.json.mixins.model.RelationshipMixin;
@@ -123,6 +126,7 @@ public final class InventoryJacksonConfig {
         objectMapper.addMixIn(Feed.class, FeedMixin.class);
         objectMapper.addMixIn(Metric.class, MetricMixin.class);
         objectMapper.addMixIn(MetricType.class, MetricTypeMixin.class);
+        objectMapper.addMixIn(MetricDataType.class, MetricDataTypeMixin.class);
         objectMapper.addMixIn(Path.class, CanonicalPathMixin.class);
         objectMapper.addMixIn(Relationship.class, RelationshipMixin.class);
         objectMapper.addMixIn(RelativePath.class, RelativePathMixin.class);
@@ -136,6 +140,7 @@ public final class InventoryJacksonConfig {
         objectMapper.addMixIn(InventoryStructure.class, InventoryStructureMixin.class);
         objectMapper.addMixIn(IdentityHash.Tree.class, IdentityHashTreeMixin.class);
         objectMapper.addMixIn(SyncHash.Tree.class, SyncHashTreeMixin.class);
+        objectMapper.addMixIn(MetricType.Blueprint.class, MetricTypeBlueprintMixin.class);
 
         /**
          * Query

--- a/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/InventoryStructureDeserializer.java
+++ b/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/InventoryStructureDeserializer.java
@@ -74,7 +74,8 @@ public class InventoryStructureDeserializer extends JsonDeserializer<InventorySt
                     + " but got '" + typeName + "'.", JsonLocation.NA);
         }
 
-        Entity.Blueprint root = deserializationContext.readValue(prepareTraverse(tree.get("data")), type.blueprintType);
+        Entity.Blueprint root = deserializationContext.readValue(
+                prepareTraverse(tree.get("data"), deserializationContext), type.blueprintType);
 
         InventoryStructure.Builder bld = InventoryStructure.Offline.of(root);
         parseChildren(tree, bld, deserializationContext);
@@ -115,7 +116,8 @@ public class InventoryStructureDeserializer extends JsonDeserializer<InventorySt
                 while (childrenNodes.hasNext()) {
                     JsonNode childNode = childrenNodes.next();
 
-                    Entity.Blueprint bl = mapper.readValue(prepareTraverse(childNode.get("data")), type.blueprintType);
+                    Entity.Blueprint bl = mapper.readValue(prepareTraverse(childNode.get("data"), mapper),
+                            type.blueprintType);
 
                     InventoryStructure.ChildBuilder<?> childBld = bld.startChild(bl);
 
@@ -127,8 +129,8 @@ public class InventoryStructureDeserializer extends JsonDeserializer<InventorySt
         }
     }
 
-    private static JsonParser prepareTraverse(JsonNode node) throws IOException {
-        JsonParser parser = node.traverse();
+    private static JsonParser prepareTraverse(JsonNode node, DeserializationContext ctx) throws IOException {
+        JsonParser parser = node.traverse(ctx.getParser().getCodec());
         parser.nextToken();
         return parser;
     }

--- a/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/mixins/model/MetricDataTypeMixin.java
+++ b/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/mixins/model/MetricDataTypeMixin.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.json.mixins.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.18.0
+ */
+public class MetricDataTypeMixin {
+
+    @JsonValue
+    public String getDisplayName() {
+        return null;
+    }
+}

--- a/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/mixins/model/MetricTypeBlueprintMixin.java
+++ b/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/mixins/model/MetricTypeBlueprintMixin.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.json.mixins.model;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.hawkular.inventory.api.model.MetricDataType;
+import org.hawkular.inventory.api.model.MetricType;
+import org.hawkular.inventory.api.model.MetricUnit;
+import org.hawkular.inventory.paths.CanonicalPath;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Remove this mix-in once we drop the support for the old way of serializing the metric data type.
+ *
+ * @author Lukas Krejci
+ * @since 0.18.0
+ * @deprecated since inception :)
+ */
+@Deprecated
+@JsonSerialize(using = MetricTypeBlueprintMixin.Serializer.class)
+@JsonDeserialize(using = MetricTypeBlueprintMixin.Deserializer.class)
+public final class MetricTypeBlueprintMixin {
+
+    /**
+     * @deprecated don't use this once "type" does not need to be in the JSON
+     */
+    @Deprecated
+    public static final class Serializer extends JsonSerializer<MetricType.Blueprint> {
+        @Override public void serialize(MetricType.Blueprint value, JsonGenerator gen, SerializerProvider serializers)
+                throws IOException {
+            gen.writeStartObject();
+            gen.writeStringField("id", value.getId());
+            gen.writeStringField("name", value.getName());
+            if (value.getCollectionInterval() != null) {
+                gen.writeNumberField("collectionInterval", value.getCollectionInterval());
+            } else {
+                gen.writeNullField("collectionInterval");
+            }
+            gen.writeStringField("type", value.getMetricDataType().name());
+            gen.writeStringField("metricDataType", value.getMetricDataType().getDisplayName());
+            gen.writeStringField("unit", value.getUnit().name());
+            writeNonEmpty(value.getProperties(), "properties", gen);
+            writeNonEmpty(value.getIncomingRelationships(), "incoming", gen);
+            writeNonEmpty(value.getOutgoingRelationships(), "outgoing", gen);
+            gen.writeEndObject();
+        }
+    }
+
+    /**
+     * @deprecated don't use this once "type" does not need to be in the JSON
+     */
+    @Deprecated
+    public static final class Deserializer extends JsonDeserializer<MetricType.Blueprint> {
+        @Override public MetricType.Blueprint deserialize(JsonParser p, DeserializationContext ctxt)
+                throws IOException {
+            String id = null;
+            String name = null;
+            Long collectionInterval = null;
+            MetricDataType type = null;
+            MetricDataType metricDataType = null;
+            MetricUnit unit = null;
+            Map<String, Object> properties = null;
+            Map<String, Set<CanonicalPath>> incomingRelationships = null;
+            Map<String, Set<CanonicalPath>> outgoingRelationships = null;
+
+            while (p.nextValue() != null) {
+                if (p.getCurrentToken() == JsonToken.END_OBJECT) {
+                    break;
+                }
+                String field = p.getCurrentName();
+                switch (field) {
+                    case "id" :
+                        id = p.readValueAs(String.class);
+                        break;
+                    case "name":
+                        name = p.readValueAs(String.class);
+                        break;
+                    case "collectionInterval":
+                        collectionInterval = p.readValueAs(Long.class);
+                        break;
+                    case "type":
+                        type = MetricDataType.valueOf(p.readValueAs(String.class));
+                        break;
+                    case "metricDataType":
+                        metricDataType = p.readValueAs(MetricDataType.class);
+                        break;
+                    case "unit":
+                        unit = p.readValueAs(MetricUnit.class);
+                        break;
+                    case "properties":
+                        properties = p.readValueAs(new TypeReference<Map<String, Object>>() {});
+                        break;
+                    case "incoming":
+                        incomingRelationships = p.readValueAs(new TypeReference<Map<String, Set<CanonicalPath>>>() {});
+                        break;
+                    case "outgoing":
+                        outgoingRelationships = p.readValueAs(new TypeReference<Map<String, Set<CanonicalPath>>>() {});
+                        break;
+                }
+            }
+
+            if (metricDataType == null) {
+                metricDataType = type;
+            }
+
+            return MetricType.Blueprint.builder(metricDataType).withId(id).withName(name)
+                    .withInterval(collectionInterval).withUnit(unit).withProperties(nonNull(properties))
+                    .withIncomingRelationships(nonNull(incomingRelationships))
+                    .withOutgoingRelationships(nonNull(outgoingRelationships))
+                    .build();
+        }
+    }
+
+    private static void writeNonEmpty(Map<?, ?> map, String fieldName, JsonGenerator gen) throws IOException {
+        if (map != null && !map.isEmpty()) {
+            gen.writeObjectField(fieldName, map);
+        }
+    }
+
+    private static <K, V> Map<K, V> nonNull(Map<K, V> map) {
+        return map == null ? Collections.emptyMap() : map;
+    }
+}


### PR DESCRIPTION
This PR tries to retain backwards compatibility for the remote clients by keeping the old property names in the JSON output/input.

Additionally, to make the JSON property names, property filtering and sorting consistent, the `With.Properties` and `With.PropertyValues` filters will use the proper internal names when constructing queries.
