### PR TITLE
The error message was constructed using the Path.Extender instance

### DIFF
--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
@@ -86,8 +86,8 @@ public final class BaseResources {
                 resourceTypeObject = tx.find(resourceTypePath);
             } catch (ElementNotFoundException e) {
                 throw new IllegalArgumentException("Resource type '" + blueprint.getResourceTypePath() + "' not found" +
-                        " when resolved to '" + resourceTypePath + "' while trying to wire up new resource on path '" +
-                        parentPath.extend(SegmentType.r, blueprint.getId()) + "'.");
+                        " when resolved to '" + resourceTypePath + "' while trying to wire up a new resource on path '"
+                        + parentPath.extend(SegmentType.r, blueprint.getId()).get() + "'.");
             }
 
             //specifically do NOT check relationship rules, here because defines cannot be created "manually".


### PR DESCRIPTION
instead of a fully constructed CanonicalPath. The Extender doesn't
override toString() so the error message was kinda useless.
