### PR TITLE
Increase the default number of transaction retries

### DIFF
--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TraversalContext.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TraversalContext.java
@@ -121,7 +121,7 @@ public final class TraversalContext<BE, E extends AbstractElement<?, ?>> {
     }
 
     private static int getTransactionRetries(Configuration configuration) {
-        String retries = configuration.getProperty(BaseInventory.TRANSACTION_RETRIES, "5");
+        String retries = configuration.getProperty(BaseInventory.TRANSACTION_RETRIES, "10");
         return Integer.parseInt(retries);
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Util.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Util.java
@@ -96,8 +96,9 @@ final class Util {
         int failures = 0;
         Exception lastException;
 
-        //this could be configurable, but let's just start with the hardcoded 100ms as the first retry wait time.
-        int waitTime = 100;
+        //this could be configurable, but let's just start with the hardcoded 300ms + a random bit
+        //as the first retry wait time.
+        int waitTime = 300 + rand.nextInt(150);
 
         do {
             try {
@@ -146,7 +147,7 @@ final class Util {
                     //takes a long time to complete, it probably is going to be really long.
                     //We randomize the value a little bit so that competing transactions started at roughly same time
                     //don't knock each other out easily.
-                    waitTime = waitTime * 2 + rand.nextInt(waitTime / 10);
+                    waitTime = waitTime * 2 + rand.nextInt(waitTime / 2);
                 }
             } catch (RuntimeException e) {
                 throw e;


### PR DESCRIPTION
 and widen and randomize more the exponential back-off of the retry wait time.

The reason for this PR is that the previous defaults weren't able handle the load the agent itests generate. The delay between retries now increases more rapidly and at the same time the delay is randomized (to a greater extent) from the very retry. Therefore there is an increased chance that the retrying transactions from different threads will not coincide and therefore fail again.
