### PR TITLE
[HWKINVENT-8] Versioning

### DIFF
--- a/hawkular-inventory-api/pom.xml
+++ b/hawkular-inventory-api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular.inventory</groupId>
     <artifactId>hawkular-inventory-parent</artifactId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-api</artifactId>

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Action.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Action.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.inventory.api;
 
+import java.util.IdentityHashMap;
+
 import org.hawkular.inventory.api.model.AbstractElement;
 import org.hawkular.inventory.api.model.ContentHashable;
 import org.hawkular.inventory.api.model.Environment;
@@ -89,6 +91,14 @@ public final class Action<C, E> {
         SYNC_HASH_CHANGED(_SYNC_HASH_CHANGED), IDENTITY_HASH_CHANGED(_IDENTITY_HASH_CHANGED),
         CONTENT_HASH_CHANGED(_CONTENT_HASH_CHANGED);
 
+        private static final IdentityHashMap<Action<?, ?>, Enumerated> map;
+        static {
+            map = new IdentityHashMap<>();
+            for (Enumerated e : values()) {
+                map.put(e.action, e);
+            }
+        }
+
         private final Action<?, ?> action;
 
         Enumerated(Action<?, ?> action) {
@@ -96,13 +106,12 @@ public final class Action<C, E> {
         }
 
         public static Enumerated from(Action<?, ?> action) {
-            for (Enumerated e : values()) {
-                if (e.action == action) {
-                    return e;
-                }
+            Enumerated ret = map.get(action);
+            if (ret == null) {
+                throw new AssertionError("Unknown action");
+            } else {
+                return ret;
             }
-
-            throw new AssertionError("Unknown action");
         }
 
         public Action<?, ?> getAction() {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Action.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Action.java
@@ -155,5 +155,22 @@ public final class Action<C, E> {
         public U getUpdate() {
             return update;
         }
+
+        @Override public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Update<?, ?> update1 = (Update<?, ?>) o;
+
+            if (!originalEntity.equals(update1.originalEntity)) return false;
+            return update.equals(update1.update);
+
+        }
+
+        @Override public int hashCode() {
+            int result = originalEntity.hashCode();
+            result = 31 * result + update.hashCode();
+            return result;
+        }
     }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
@@ -156,7 +156,7 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(Instant time) {
+        public void delete() {
             throw entityNotFound(entityType);
         }
 
@@ -168,7 +168,7 @@ public class EmptyInventory implements Inventory {
             throw entityNotFound(entityType);
         }
 
-        @Override public List<Change<E, ?>> history() {
+        @Override public List<Change<E, ?>> history(Instant from, Instant to) {
             return Collections.emptyList();
         }
     }
@@ -846,7 +846,7 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(Instant time) {
+        public void delete() {
             throw new RelationNotFoundException((String) null, (Filter[]) null);
         }
 
@@ -854,7 +854,7 @@ public class EmptyInventory implements Inventory {
             throw new RelationNotFoundException((String) null, (Filter[]) null);
         }
 
-        @Override public List<Change<Relationship, ?>> history() {
+        @Override public List<Change<Relationship, ?>> history(Instant from, Instant to) {
             return Collections.emptyList();
         }
     }
@@ -1482,7 +1482,7 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(Instant time) {
+        public void delete() {
             throw new UnsupportedOperationException();
         }
 
@@ -1497,7 +1497,7 @@ public class EmptyInventory implements Inventory {
             throw new UnsupportedOperationException();
         }
 
-        @Override public List<Change<DataEntity, ?>> history() {
+        @Override public List<Change<DataEntity, ?>> history(Instant from, Instant to) {
             return Collections.emptyList();
         }
     }
@@ -1666,7 +1666,7 @@ public class EmptyInventory implements Inventory {
             throw new UnsupportedOperationException();
         }
 
-        @Override public void delete(Instant time) {
+        @Override public void delete() {
             throw new UnsupportedOperationException();
         }
 
@@ -1674,7 +1674,7 @@ public class EmptyInventory implements Inventory {
             throw new UnsupportedOperationException();
         }
 
-        @Override public List<Change<MetadataPack, ?>> history() {
+        @Override public List<Change<MetadataPack, ?>> history(Instant from, Instant to) {
             return Collections.emptyList();
         }
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
@@ -168,7 +168,7 @@ public class EmptyInventory implements Inventory {
             throw entityNotFound(entityType);
         }
 
-        @Override public List<Change<E, ?>> history(Instant from, Instant to) {
+        public List<Change<E, ?>> history(Instant from, Instant to) {
             return Collections.emptyList();
         }
     }
@@ -852,10 +852,6 @@ public class EmptyInventory implements Inventory {
 
         @Override public void eradicate() {
             throw new RelationNotFoundException((String) null, (Filter[]) null);
-        }
-
-        @Override public List<Change<Relationship, ?>> history(Instant from, Instant to) {
-            return Collections.emptyList();
         }
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
@@ -17,14 +17,17 @@
 package org.hawkular.inventory.api;
 
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import org.hawkular.inventory.api.filters.Filter;
 import org.hawkular.inventory.api.filters.RelationFilter;
 import org.hawkular.inventory.api.model.AbstractElement;
 import org.hawkular.inventory.api.model.Blueprint;
+import org.hawkular.inventory.api.model.Change;
 import org.hawkular.inventory.api.model.DataEntity;
 import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.model.Environment;
@@ -57,6 +60,10 @@ import rx.Observable;
  * @since 0.0.2
  */
 public class EmptyInventory implements Inventory {
+    @Override public Inventory at(Instant time) {
+        return this;
+    }
+
     @Override
     public void initialize(Configuration configuration) {
     }
@@ -149,12 +156,20 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete() {
+        public void delete(Instant time) {
             throw entityNotFound(entityType);
         }
 
         public SyncHash.Tree treeHash() {
             throw new UnsupportedOperationException();
+        }
+
+        @Override public void eradicate() {
+            throw entityNotFound(entityType);
+        }
+
+        @Override public List<Change<E, ?>> history() {
+            return Collections.emptyList();
         }
     }
 
@@ -194,7 +209,11 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(String id) throws EntityNotFoundException {
+        public void delete(String id, Instant time) throws EntityNotFoundException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public void eradicate(String s) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
     }
@@ -353,7 +372,11 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(String id) throws EntityNotFoundException {
+        public void delete(String id, Instant time) throws EntityNotFoundException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public void eradicate(String s) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
     }
@@ -497,7 +520,11 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(String id) throws EntityNotFoundException {
+        public void delete(String id, Instant time) throws EntityNotFoundException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public void eradicate(String s) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
     }
@@ -643,7 +670,11 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(String id) throws EntityNotFoundException {
+        public void delete(String id, Instant time) throws EntityNotFoundException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public void eradicate(String s) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
     }
@@ -815,8 +846,16 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete() {
+        public void delete(Instant time) {
             throw new RelationNotFoundException((String) null, (Filter[]) null);
+        }
+
+        @Override public void eradicate() {
+            throw new RelationNotFoundException((String) null, (Filter[]) null);
+        }
+
+        @Override public List<Change<Relationship, ?>> history() {
+            return Collections.emptyList();
         }
     }
 
@@ -931,7 +970,7 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(String id) throws EntityNotFoundException {
+        public void delete(String id, Instant time) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
 
@@ -943,6 +982,10 @@ public class EmptyInventory implements Inventory {
         @Override
         public Feeds.Single get(String id) throws EntityNotFoundException {
             return new FeedsSingle();
+        }
+
+        @Override public void eradicate(String s) throws EntityNotFoundException {
+            throw new UnsupportedOperationException();
         }
     }
 
@@ -1093,7 +1136,11 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(String id) throws EntityNotFoundException {
+        public void delete(String id, Instant time) throws EntityNotFoundException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public void eradicate(String s) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
     }
@@ -1215,7 +1262,11 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(String id) throws EntityNotFoundException {
+        public void delete(String id, Instant time) throws EntityNotFoundException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public void eradicate(String s) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
     }
@@ -1400,7 +1451,11 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(Role ignored) throws EntityNotFoundException {
+        public void delete(Role ignored, Instant time) throws EntityNotFoundException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public void eradicate(Role s) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
     }
@@ -1427,7 +1482,7 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete() {
+        public void delete(Instant time) {
             throw new UnsupportedOperationException();
         }
 
@@ -1436,6 +1491,14 @@ public class EmptyInventory implements Inventory {
 
         @Override public SyncHash.Tree treeHash() {
             throw new UnsupportedOperationException();
+        }
+
+        @Override public void eradicate() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public List<Change<DataEntity, ?>> history() {
+            return Collections.emptyList();
         }
     }
 
@@ -1486,12 +1549,22 @@ public class EmptyInventory implements Inventory {
             throw new UnsupportedOperationException();
         }
 
-        @Override public void delete(String s) throws EntityNotFoundException {
+        @Override public void delete(String s, Instant time) throws EntityNotFoundException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public void eradicate(String s) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
     }
 
-    public static class OperationTypesSingle implements OperationTypes.Single {
+    public static class OperationTypesSingle
+            extends SingleBase<OperationType, OperationType.Blueprint, OperationType.Update>
+            implements OperationTypes.Single {
+
+        public OperationTypesSingle() {
+            super(OperationType.class);
+        }
 
         @Override public Data.ReadWrite<DataRole.OperationType> data() {
             return new DataReadWrite<>();
@@ -1505,24 +1578,7 @@ public class EmptyInventory implements Inventory {
             return new RelationshipsReadWrite();
         }
 
-        @Override public OperationType entity() throws EntityNotFoundException, RelationNotFoundException {
-            throw entityNotFound(OperationType.class);
-        }
-
-        @Override public void update(OperationType.Update update)
-                throws EntityNotFoundException, RelationNotFoundException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override public void delete() {
-            throw new UnsupportedOperationException();
-        }
-
         @Override public void synchronize(SyncRequest<OperationType.Blueprint> syncRequest) {
-        }
-
-        @Override public SyncHash.Tree treeHash() {
-            throw new UnsupportedOperationException();
         }
     }
 
@@ -1574,7 +1630,11 @@ public class EmptyInventory implements Inventory {
             throw new UnsupportedOperationException();
         }
 
-        @Override public void delete(String s) throws EntityNotFoundException {
+        @Override public void delete(String s, Instant time) throws EntityNotFoundException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public void eradicate(String s) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
     }
@@ -1606,8 +1666,16 @@ public class EmptyInventory implements Inventory {
             throw new UnsupportedOperationException();
         }
 
-        @Override public void delete() {
+        @Override public void delete(Instant time) {
             throw new UnsupportedOperationException();
+        }
+
+        @Override public void eradicate() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public List<Change<MetadataPack, ?>> history() {
+            return Collections.emptyList();
         }
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
@@ -209,7 +209,7 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(String id, Instant time) throws EntityNotFoundException {
+        public void delete(String id) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
 
@@ -372,7 +372,7 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(String id, Instant time) throws EntityNotFoundException {
+        public void delete(String id) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
 
@@ -520,7 +520,7 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(String id, Instant time) throws EntityNotFoundException {
+        public void delete(String id) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
 
@@ -670,7 +670,7 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(String id, Instant time) throws EntityNotFoundException {
+        public void delete(String id) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
 
@@ -970,7 +970,7 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(String id, Instant time) throws EntityNotFoundException {
+        public void delete(String id) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
 
@@ -1136,7 +1136,7 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(String id, Instant time) throws EntityNotFoundException {
+        public void delete(String id) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
 
@@ -1262,7 +1262,7 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(String id, Instant time) throws EntityNotFoundException {
+        public void delete(String id) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
 
@@ -1451,7 +1451,7 @@ public class EmptyInventory implements Inventory {
         }
 
         @Override
-        public void delete(Role ignored, Instant time) throws EntityNotFoundException {
+        public void delete(Role ignored) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
 
@@ -1549,7 +1549,7 @@ public class EmptyInventory implements Inventory {
             throw new UnsupportedOperationException();
         }
 
-        @Override public void delete(String s, Instant time) throws EntityNotFoundException {
+        @Override public void delete(String s) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
 
@@ -1630,7 +1630,7 @@ public class EmptyInventory implements Inventory {
             throw new UnsupportedOperationException();
         }
 
-        @Override public void delete(String s, Instant time) throws EntityNotFoundException {
+        @Override public void delete(String s) throws EntityNotFoundException {
             throw new UnsupportedOperationException();
         }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/EmptyInventory.java
@@ -168,7 +168,7 @@ public class EmptyInventory implements Inventory {
             throw entityNotFound(entityType);
         }
 
-        public List<Change<E, ?>> history(Instant from, Instant to) {
+        public List<Change<E>> history(Instant from, Instant to) {
             return Collections.emptyList();
         }
     }
@@ -1493,7 +1493,7 @@ public class EmptyInventory implements Inventory {
             throw new UnsupportedOperationException();
         }
 
-        @Override public List<Change<DataEntity, ?>> history(Instant from, Instant to) {
+        @Override public List<Change<DataEntity>> history(Instant from, Instant to) {
             return Collections.emptyList();
         }
     }
@@ -1670,7 +1670,7 @@ public class EmptyInventory implements Inventory {
             throw new UnsupportedOperationException();
         }
 
-        @Override public List<Change<MetadataPack, ?>> history(Instant from, Instant to) {
+        @Override public List<Change<MetadataPack>> history(Instant from, Instant to) {
             return Collections.emptyList();
         }
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Environments.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Environments.java
@@ -71,7 +71,7 @@ public final class Environments {
     /**
      * Interface for accessing a single environment in a writable manner.
      */
-    public interface Single extends ResolvableToSingleWithRelationships<Environment, Environment.Update>,
+    public interface Single extends ResolvableToSingleEntity<Environment, Environment.Update>,
             BrowserBase<Feeds.ReadAssociate, Resources.ReadWrite, Metrics.ReadWrite> {
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Feeds.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Feeds.java
@@ -53,7 +53,7 @@ public final class Feeds {
         Metrics.Read metricsUnder(MetricParents... parents);
     }
 
-    public interface Single extends Synced.SingleWithRelationships<Feed, Feed.Blueprint, Feed.Update>,
+    public interface Single extends Synced.SingleEntity<Feed, Feed.Blueprint, Feed.Update>,
             BrowserBase<Resources.ReadWrite, Metrics.ReadWrite, MetricTypes.ReadWrite, ResourceTypes.ReadWrite> {}
 
     public interface Multiple extends ResolvableToManyWithRelationships<Feed>,

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Inventory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Inventory.java
@@ -17,6 +17,7 @@
 package org.hawkular.inventory.api;
 
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Iterator;
@@ -107,6 +108,14 @@ import org.hawkular.inventory.paths.SegmentType;
  * @since 0.0.1
  */
 public interface Inventory extends AutoCloseable, Tenants.Container<Tenants.ReadWrite> {
+
+    /**
+     * Defines the "view" on the inventory as it existed at given point in time.
+     *
+     * @param time the time the inventory existed at
+     * @return a new inventory instance set up to query data as it existed at the given time
+     */
+    Inventory at(Instant time);
 
     /**
      * Initializes the inventory from the provided configuration object.

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/MetadataPacks.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/MetadataPacks.java
@@ -46,7 +46,7 @@ public final class MetadataPacks {
         MetricTypes.Read metricTypes();
     }
 
-    public interface Single extends ResolvableToSingleWithRelationships<MetadataPack, MetadataPack.Update>,
+    public interface Single extends ResolvableToSingleEntity<MetadataPack, MetadataPack.Update>,
             BrowserBase {
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/MetricTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/MetricTypes.java
@@ -56,7 +56,7 @@ public final class MetricTypes {
      * Interface for accessing a single metric type in a writable manner.
      */
     public interface Single
-            extends Synced.SingleWithRelationships<MetricType, MetricType.Blueprint, MetricType.Update>,
+            extends Synced.SingleEntity<MetricType, MetricType.Blueprint, MetricType.Update>,
             BrowserBase {
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Metrics.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Metrics.java
@@ -42,7 +42,7 @@ public final class Metrics {
     /**
      * Interface for accessing a single metric in a writable manner.
      */
-    public interface Single extends Synced.SingleWithRelationships<Metric, Metric.Blueprint, Metric.Update> {}
+    public interface Single extends Synced.SingleEntity<Metric, Metric.Blueprint, Metric.Update> {}
 
     /**
      * Interface for traversing over a set of metrics.

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/OperationTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/OperationTypes.java
@@ -49,8 +49,8 @@ public final class OperationTypes {
     }
 
     public interface Single
-            extends Synced.SingleWithRelationships<OperationType, OperationType.Blueprint,
-            OperationType.Update>, BrowserBase<Data.ReadWrite<DataRole.OperationType>> {
+            extends Synced.SingleEntity<OperationType, OperationType.Blueprint,
+                        OperationType.Update>, BrowserBase<Data.ReadWrite<DataRole.OperationType>> {
 
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResolvableToSingle.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResolvableToSingle.java
@@ -16,11 +16,7 @@
  */
 package org.hawkular.inventory.api;
 
-import java.time.Instant;
-import java.util.List;
-
 import org.hawkular.inventory.api.model.AbstractElement;
-import org.hawkular.inventory.api.model.Change;
 
 /**
  * Base interface for all browser interfaces over a single entity.
@@ -92,13 +88,4 @@ public interface ResolvableToSingle<Entity extends AbstractElement<?, ?>, Update
      * of the entity.
      */
     void eradicate();
-
-    /**
-     * The list of the changes is sorted in the ascending order by the time of the change.
-     *
-     * @param from the date from which to retrieve history or null for not limiting the age of the changes
-     * @param to the date to which to retrieve history or null for not limiting the age of the changes
-     * @return the list of changes made to the entity so far.
-     */
-    List<Change<Entity, ?>> history(Instant from, Instant to);
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResolvableToSingle.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResolvableToSingle.java
@@ -74,38 +74,21 @@ public interface ResolvableToSingle<Entity extends AbstractElement<?, ?>, Update
     /**
      * Deletes the entity.
      *
-     * <p>Note that this doesn't actually delete the entity from the inventory. It merely records its removal at this
-     * point in time.
-     *
-     * @throws EntityNotFoundException   if there is no entity corresponding to the traversal
-     * @throws RelationNotFoundException if there is no relation corresponding to the traversal
-     */
-    default void delete() {
-        delete(Instant.now());
-    }
-
-    /**
-     * Deletes the entity.
-     *
      * <p>Note that this doesn't actually delete the entity from the inventory. It merely records its removal at the
      * provided point in time.
-     *
-     * @param time the time from which the entity should be marked as deleted
      *
      * @throws EntityNotFoundException   if there is no entity corresponding to the traversal
      * @throws RelationNotFoundException if there is no relation corresponding to the traversal
      * @throws IllegalArgumentException  if there were changes to the entity already made after the provided time of
      * deletion
-     *
-     * @see #delete()
      */
-    void delete(Instant time);
+    void delete();
 
     /**
      * This removes the entity and all its history from the inventory. After this call, it looks like the entity never
      * existed in the inventory.
      *
-     * <p>Usually, you don't want to use this method. Use {@link #delete(Instant)} instead which preserves the history
+     * <p>Usually, you don't want to use this method. Use {@link #delete()} instead which preserves the history
      * of the entity.
      */
     void eradicate();
@@ -113,7 +96,9 @@ public interface ResolvableToSingle<Entity extends AbstractElement<?, ?>, Update
     /**
      * The list of the changes is sorted in the ascending order by the time of the change.
      *
+     * @param from the date from which to retrieve history or null for not limiting the age of the changes
+     * @param to the date to which to retrieve history or null for not limiting the age of the changes
      * @return the list of changes made to the entity so far.
      */
-    List<Change<Entity, ?>> history();
+    List<Change<Entity, ?>> history(Instant from, Instant to);
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResolvableToSingleEntity.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResolvableToSingleEntity.java
@@ -16,17 +16,18 @@
  */
 package org.hawkular.inventory.api;
 
-import org.hawkular.inventory.api.model.AbstractElement;
+import org.hawkular.inventory.api.model.Entity;
 
 /**
  * Base interface of all browser interfaces over a single entity that can have relations.
  *
- * @param <Entity> the type of the entity being browsed
+ * @param <E> the type of the entity being browsed
  *
  * @author Lukas Krejci
  * @author Jirka Kremser
  * @since 0.0.1
  */
-public interface ResolvableToSingleWithRelationships<Entity extends AbstractElement<?, ?>, Update>
-        extends ResolvableToSingle<Entity, Update>, Relatable<Relationships.ReadWrite> {
+public interface ResolvableToSingleEntity<E extends Entity<?, U>, U extends Entity.Update>
+        extends ResolvableToSingle<E, U>, Relatable<Relationships.ReadWrite>, Versioned<E> {
+
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResourceTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/ResourceTypes.java
@@ -73,7 +73,7 @@ public final class ResourceTypes {
      * Interface for accessing a single resource type in a writable manner.
      */
     public interface Single
-            extends Synced.SingleWithRelationships<ResourceType, ResourceType.Blueprint, ResourceType.Update>,
+            extends Synced.SingleEntity<ResourceType, ResourceType.Blueprint, ResourceType.Update>,
             BrowserBase<Resources.Read, MetricTypes.ReadAssociate, OperationTypes.ReadWrite,
                     Data.ReadWrite<DataRole.ResourceType>> {
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Resources.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Resources.java
@@ -98,7 +98,7 @@ public final class Resources {
      * Interface for accessing a single resource in a writable manner.
      */
     public interface Single
-            extends Synced.SingleWithRelationships<Resource, Resource.Blueprint, Resource.Update>,
+            extends Synced.SingleEntity<Resource, Resource.Blueprint, Resource.Update>,
             BrowserBase<Metrics.ReadWrite, Metrics.ReadAssociate, Data.ReadWrite<DataRole.Resource>, ReadWrite,
                     ReadAssociate> {
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Synced.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Synced.java
@@ -33,12 +33,12 @@ public final class Synced {
 
     }
 
-    public interface SingleWithRelationships<E extends Entity<B, U>, B extends Entity.Blueprint,
-            U extends Entity.Update> extends Single<E, B, U>, ResolvableToSingleWithRelationships<E, U> {
+    public interface SingleEntity<E extends Entity<B, U>, B extends Entity.Blueprint,
+            U extends Entity.Update> extends Single<E, B, U>, ResolvableToSingleEntity<E, U> {
     }
 
     public interface Single<E extends Entity<B, U>, B extends Entity.Blueprint,
-            U extends Entity.Update> extends ResolvableToSingle<E, U> {
+            U extends Entity.Update> extends ResolvableToSingle<E, U>, Versioned<E> {
 
         /**
          * This is useful for figuring out what changed about the structure of the entity

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Tenants.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Tenants.java
@@ -60,7 +60,7 @@ public final class Tenants {
     /**
      * Interface for accessing a single tenant in a writable manner.
      */
-    public interface Single extends ResolvableToSingleWithRelationships<Tenant, Tenant.Update>,
+    public interface Single extends ResolvableToSingleEntity<Tenant, Tenant.Update>,
             BrowserBase<ResourceTypes.ReadWrite, MetricTypes.ReadWrite, Environments.ReadWrite, Feeds.ReadWrite,
                     MetadataPacks.ReadWrite> {
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Versioned.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Versioned.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.api;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.hawkular.inventory.api.model.Change;
+import org.hawkular.inventory.api.model.Entity;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.20.0
+ */
+public interface Versioned<E extends Entity<?, ?>> {
+    /**
+     * The list of the changes is sorted in the ascending order by the time of the change.
+     *
+     * @param from the date from which to retrieve history or null for not limiting the age of the changes
+     * @param to the date to which to retrieve history or null for not limiting the age of the changes
+     * @return the list of changes made to the entity so far.
+     */
+    List<Change<E, ?>> history(Instant from, Instant to);
+
+    default List<Change<E, ?>> history() {
+        return history(Instant.ofEpochMilli(0), Instant.ofEpochMilli(Long.MAX_VALUE));
+    }
+}

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Versioned.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/Versioned.java
@@ -34,9 +34,9 @@ public interface Versioned<E extends Entity<?, ?>> {
      * @param to the date to which to retrieve history or null for not limiting the age of the changes
      * @return the list of changes made to the entity so far.
      */
-    List<Change<E, ?>> history(Instant from, Instant to);
+    List<Change<E>> history(Instant from, Instant to);
 
-    default List<Change<E, ?>> history() {
+    default List<Change<E>> history() {
         return history(Instant.ofEpochMilli(0), Instant.ofEpochMilli(Long.MAX_VALUE));
     }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/WriteInterface.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/WriteInterface.java
@@ -16,8 +16,6 @@
  */
 package org.hawkular.inventory.api;
 
-import java.time.Instant;
-
 import org.hawkular.inventory.api.model.Blueprint;
 
 /**
@@ -74,29 +72,12 @@ public interface WriteInterface<U, B extends Blueprint, Single, Id> {
     void update(Id id, U update) throws EntityNotFoundException;
 
     /**
-     * Deletes an entity with the provided id from the current position in the inventory traversal.
-     *
-     * <p>Note that this doesn't actually delete the entity from the inventory. It merely records its removal at this
-     * point in time.
-     *
-     * @param id the id of the entity to delete
-     * @throws EntityNotFoundException if an entity with given ID doesn't exist on the current position in the inventory
-     *                                 traversal
-     * @throws java.lang.IllegalArgumentException if the supplied entity could not be deleted for some reason
-     */
-    default void delete(Id id) throws EntityNotFoundException {
-        delete(id, Instant.now());
-    }
-
-    /**
      * Deletes the entity.
      *
      * <p>Note that this doesn't actually delete the entity from the inventory. It merely records its removal at the
      * provided point in time.
      *
      * @param id the id of the entity to delete
-     * @param time the time from which the entity should be marked as deleted
-     *
      * @throws EntityNotFoundException   if there is no entity corresponding to the traversal
      * @throws RelationNotFoundException if there is no relation corresponding to the traversal
      * @throws IllegalArgumentException  if there were changes to the entity already made after the provided time of
@@ -104,13 +85,13 @@ public interface WriteInterface<U, B extends Blueprint, Single, Id> {
      *
      * @see #delete(Object)
      */
-    void delete(Id id, Instant time);
+    void delete(Id id);
 
     /**
      * This removes the entity and all its history from the inventory. After this call, it looks like the entity never
      * existed in the inventory.
      *
-     * <p>Usually, you don't want to use this method. Use {@link #delete(Object, Instant)} instead which preserves the
+     * <p>Usually, you don't want to use this method. Use {@link #delete(Object)} instead which preserves the
      * history of the entity.
      */
     void eradicate(Id id) throws EntityNotFoundException;

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/WriteInterface.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/WriteInterface.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.inventory.api;
 
+import java.time.Instant;
+
 import org.hawkular.inventory.api.model.Blueprint;
 
 /**
@@ -74,10 +76,42 @@ public interface WriteInterface<U, B extends Blueprint, Single, Id> {
     /**
      * Deletes an entity with the provided id from the current position in the inventory traversal.
      *
+     * <p>Note that this doesn't actually delete the entity from the inventory. It merely records its removal at this
+     * point in time.
+     *
      * @param id the id of the entity to delete
      * @throws EntityNotFoundException if an entity with given ID doesn't exist on the current position in the inventory
      *                                 traversal
      * @throws java.lang.IllegalArgumentException if the supplied entity could not be deleted for some reason
      */
-    void delete(Id id) throws EntityNotFoundException;
+    default void delete(Id id) throws EntityNotFoundException {
+        delete(id, Instant.now());
+    }
+
+    /**
+     * Deletes the entity.
+     *
+     * <p>Note that this doesn't actually delete the entity from the inventory. It merely records its removal at the
+     * provided point in time.
+     *
+     * @param id the id of the entity to delete
+     * @param time the time from which the entity should be marked as deleted
+     *
+     * @throws EntityNotFoundException   if there is no entity corresponding to the traversal
+     * @throws RelationNotFoundException if there is no relation corresponding to the traversal
+     * @throws IllegalArgumentException  if there were changes to the entity already made after the provided time of
+     * deletion
+     *
+     * @see #delete(Object)
+     */
+    void delete(Id id, Instant time);
+
+    /**
+     * This removes the entity and all its history from the inventory. After this call, it looks like the entity never
+     * existed in the inventory.
+     *
+     * <p>Usually, you don't want to use this method. Use {@link #delete(Object, Instant)} instead which preserves the
+     * history of the entity.
+     */
+    void eradicate(Id id) throws EntityNotFoundException;
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/AbstractElement.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/AbstractElement.java
@@ -213,6 +213,20 @@ public abstract class AbstractElement<B extends org.hawkular.inventory.api.model
 
         public abstract <R, P> R accept(ElementUpdateVisitor<R, P> visitor, P parameter);
 
+        @Override public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Update)) return false;
+
+            Update update = (Update) o;
+
+            return properties != null ? properties.equals(update.properties) : update.properties == null;
+
+        }
+
+        @Override public int hashCode() {
+            return properties != null ? properties.hashCode() : 0;
+        }
+
         public abstract static class Builder<E extends AbstractElement<?, U>, U extends Update,
                 This extends Builder<E, U, This>> {
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/AbstractElement.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/AbstractElement.java
@@ -19,6 +19,7 @@ package org.hawkular.inventory.api.model;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.hawkular.inventory.paths.CanonicalPath;
@@ -212,7 +213,9 @@ public abstract class AbstractElement<B extends org.hawkular.inventory.api.model
 
         public abstract <R, P> R accept(ElementUpdateVisitor<R, P> visitor, P parameter);
 
-        public abstract static class Builder<U extends Update, This extends Builder<U, This>> {
+        public abstract static class Builder<E extends AbstractElement<?, U>, U extends Update,
+                This extends Builder<E, U, This>> {
+
             protected Map<String, Object> properties;
 
             private Map<String, Object> getProperties() {
@@ -233,6 +236,14 @@ public abstract class AbstractElement<B extends org.hawkular.inventory.api.model
                 return castThis();
             }
 
+            public This withDifference(E original, E updated) {
+                if (!Objects.equals(original.getProperties(), updated.getProperties())) {
+                    withProperties(updated.getProperties());
+                }
+
+                return castThis();
+            }
+
             public abstract U build();
 
             @SuppressWarnings("unchecked")
@@ -244,13 +255,21 @@ public abstract class AbstractElement<B extends org.hawkular.inventory.api.model
 
     public static final class Updater<U extends Update, E extends AbstractElement<?, U>> {
         private final Function<U, E> updater;
+        private final E original;
+        private final Update.Builder<E, U, ?> bld;
 
-        Updater(Function<U, E> updater) {
+        Updater(Function<U, E> updater, E original, Update.Builder<E, U, ?> bld) {
             this.updater = updater;
+            this.original = original;
+            this.bld = bld;
         }
 
         public E with(U update) {
             return updater.apply(update);
+        }
+
+        public U to(E entity) {
+            return bld.withDifference(original, entity).build();
         }
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Change.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Change.java
@@ -24,9 +24,10 @@ import org.hawkular.inventory.api.Action;
  * Represents a change made to an entity at some point in time.
  *
  * @author Lukas Krejci
- * @since 0.19.0
+ * @since 0.20.0
  */
-public final class Change<Element extends AbstractElement<?, ?>, Context> implements Comparable<Change<?, ?>> {
+public final class Change<Element extends Entity<?, ?>, Context>
+        implements Comparable<Change<?, ?>> {
     private final Instant time;
     private final Action<Context, Element> action;
     private final Context actionContext;
@@ -66,7 +67,7 @@ public final class Change<Element extends AbstractElement<?, ?>, Context> implem
             return diff;
         }
 
-        return element.getId().compareTo(o.element.getId());
+        return element.getPath().toString().compareTo(o.element.getPath().toString());
     }
 
     @Override public boolean equals(Object o) {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Change.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Change.java
@@ -13,9 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
-
 package org.hawkular.inventory.api.model;
 
 import java.time.Instant;

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Change.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Change.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.hawkular.inventory.api.model;
+
+import java.time.Instant;
+
+import org.hawkular.inventory.api.Action;
+
+/**
+ * Represents a change made to an entity at some point in time.
+ *
+ * @author Lukas Krejci
+ * @since 0.19.0
+ */
+public final class Change<Element extends AbstractElement<?, ?>, Context> implements Comparable<Change<?, ?>> {
+    private final Instant time;
+    private final Action<Context, Element> action;
+    private final Context actionContext;
+    private final Element element;
+
+    public Change(Instant time, Action<Context, Element> action, Context actionContext, Element element) {
+        this.time = time;
+        this.action = action;
+        this.actionContext = actionContext;
+        this.element = element;
+    }
+
+    public Instant getTime() {
+        return time;
+    }
+
+    public Action<Context, Element> getAction() {
+        return action;
+    }
+
+    public Context getActionContext() {
+        return actionContext;
+    }
+
+    public Element getElement() {
+        return element;
+    }
+
+    @Override public int compareTo(Change<?, ?> o) {
+        int diff = time.compareTo(o.time);
+        if (diff != 0) {
+            return diff;
+        }
+
+        diff = action.asEnum().ordinal() - o.action.asEnum().ordinal();
+        if (diff != 0) {
+            return diff;
+        }
+
+        return element.getId().compareTo(o.element.getId());
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Change<?, ?> change = (Change<?, ?>) o;
+
+        return time.equals(change.time) && action.equals(change.action) && element.equals(change.element);
+
+    }
+
+    @Override public int hashCode() {
+        int result = time.hashCode();
+        result = 31 * result + action.hashCode();
+        result = 31 * result + element.hashCode();
+        return result;
+    }
+}

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Change.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Change.java
@@ -17,6 +17,7 @@
 package org.hawkular.inventory.api.model;
 
 import java.time.Instant;
+import java.util.Objects;
 
 import org.hawkular.inventory.api.Action;
 
@@ -32,6 +33,9 @@ public final class Change<Element extends Entity<?, ?>> implements Comparable<Ch
     private final Object actionContext;
 
     public <C> Change(Instant time, Action<C, Element> action, C actionContext) {
+        time = Objects.requireNonNull(time, "time == null");
+        action = Objects.requireNonNull(action, "action == null");
+        actionContext = Objects.requireNonNull(actionContext, "actionContext == null");
         this.time = time;
         this.action = action;
         this.actionContext = actionContext;

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/DataEntity.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/DataEntity.java
@@ -210,6 +210,23 @@ public final class DataEntity extends SyncedEntity<DataEntity.Blueprint<?>, Data
             return visitor.visitData(this, parameter);
         }
 
+        @Override public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Update)) return false;
+            if (!super.equals(o)) return false;
+
+            Update update = (Update) o;
+
+            return value != null ? value.equals(update.value) : update.value == null;
+
+        }
+
+        @Override public int hashCode() {
+            int result = super.hashCode();
+            result = 31 * result + (value != null ? value.hashCode() : 0);
+            return result;
+        }
+
         public static final class Builder extends Entity.Update.Builder<DataEntity, Update, Builder> {
 
             private StructuredData value;

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Entity.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Entity.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.hawkular.inventory.paths.CanonicalPath;
@@ -304,14 +305,22 @@ public abstract class Entity<B extends Blueprint, U extends Entity.Update> exten
             return name;
         }
 
-        public abstract static class Builder<U extends Update, This extends Builder<U, This>>
-                extends AbstractElement.Update.Builder<U, This> {
+        public abstract static class Builder<E extends Entity<?, U>, U extends Update, This extends Builder<E, U, This>>
+                extends AbstractElement.Update.Builder<E, U, This> {
 
             protected String name;
 
             public This withName(String name) {
                 this.name = name;
                 return castThis();
+            }
+
+            @Override public This withDifference(E original, E updated) {
+                if (!Objects.equals(original.getName(), updated.getName())) {
+                    withName(updated.getName());
+                }
+
+                return super.withDifference(original, updated);
             }
         }
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Entity.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Entity.java
@@ -305,6 +305,22 @@ public abstract class Entity<B extends Blueprint, U extends Entity.Update> exten
             return name;
         }
 
+        @Override public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Update)) return false;
+            if (!super.equals(o)) return false;
+
+            Update update = (Update) o;
+
+            return name != null ? name.equals(update.name) : update.name == null;
+        }
+
+        @Override public int hashCode() {
+            int result = super.hashCode();
+            result = 31 * result + (name != null ? name.hashCode() : 0);
+            return result;
+        }
+
         public abstract static class Builder<E extends Entity<?, U>, U extends Update, This extends Builder<E, U, This>>
                 extends AbstractElement.Update.Builder<E, U, This> {
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Environment.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Environment.java
@@ -64,7 +64,8 @@ public final class Environment extends ContentHashedEntity<Environment.Blueprint
 
     @Override
     public Updater<Update, Environment> update() {
-        return new Updater<>((u) -> new Environment(u.getName(), getPath(), getContentHash(), u.getProperties()));
+        return new Updater<>((u) -> new Environment(u.getName(), getPath(), getContentHash(), u.getProperties()),
+                this, Update.builder());
     }
 
     @Override
@@ -143,7 +144,7 @@ public final class Environment extends ContentHashedEntity<Environment.Blueprint
             return visitor.visitEnvironment(this, parameter);
         }
 
-        public static final class Builder extends Entity.Update.Builder<Update, Builder> {
+        public static final class Builder extends Entity.Update.Builder<Environment, Update, Builder> {
             @Override
             public Update build() {
                 return new Update(name, properties);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Feed.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Feed.java
@@ -69,7 +69,7 @@ public final class Feed extends SyncedEntity<Feed.Blueprint, Feed.Update> {
     @Override
     public Updater<Update, Feed> update() {
         return new Updater<>((u) -> new Feed(u.getName(), getPath(), getIdentityHash(), getContentHash(), getSyncHash(),
-                u.getProperties()));
+                u.getProperties()), this, Update.builder());
     }
 
     @Override
@@ -154,7 +154,7 @@ public final class Feed extends SyncedEntity<Feed.Blueprint, Feed.Update> {
             return visitor.visitFeed(this, parameter);
         }
 
-        public static final class Builder extends Entity.Update.Builder<Update, Builder> {
+        public static final class Builder extends Entity.Update.Builder<Feed, Update, Builder> {
             @Override
             public Update build() {
                 return new Update(name, properties);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/MetadataPack.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/MetadataPack.java
@@ -80,7 +80,7 @@ public final class MetadataPack extends Entity<MetadataPack.Blueprint, MetadataP
 
     @Override
     public Updater<Update, MetadataPack> update() {
-        return new Updater<>((u) -> new MetadataPack(getPath(), u.getProperties()));
+        return new Updater<>((u) -> new MetadataPack(getPath(), u.getProperties()), this, Update.builder());
     }
 
     /**
@@ -363,7 +363,7 @@ public final class MetadataPack extends Entity<MetadataPack.Blueprint, MetadataP
             return visitor.visitMetadataPack(this, parameter);
         }
 
-        public static final class Builder extends Entity.Update.Builder<Update, Builder> {
+        public static final class Builder extends Entity.Update.Builder<MetadataPack, Update, Builder> {
             @Override
             public Update build() {
                 return new Update(properties);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Metric.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Metric.java
@@ -232,6 +232,23 @@ public final class Metric extends SyncedEntity<Metric.Blueprint, Metric.Update> 
             return visitor.visitMetric(this, parameter);
         }
 
+        @Override public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Update)) return false;
+            if (!super.equals(o)) return false;
+
+            Update update = (Update) o;
+
+            return collectionInterval != null ? collectionInterval.equals(update.collectionInterval) :
+                    update.collectionInterval == null;
+        }
+
+        @Override public int hashCode() {
+            int result = super.hashCode();
+            result = 31 * result + (collectionInterval != null ? collectionInterval.hashCode() : 0);
+            return result;
+        }
+
         public static final class Builder extends Entity.Update.Builder<Metric, Update, Builder> {
             private Long collectionInterval;
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Metric.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Metric.java
@@ -18,6 +18,7 @@ package org.hawkular.inventory.api.model;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.hawkular.inventory.paths.CanonicalPath;
@@ -82,7 +83,7 @@ public final class Metric extends SyncedEntity<Metric.Blueprint, Metric.Update> 
     @Override
     public Updater<Update, Metric> update() {
         return new Updater<>((u) -> new Metric(u.getName(), getPath(), getIdentityHash(), getContentHash(),
-                getSyncHash(), getType(), u.getCollectionInterval(), u.getProperties()));
+                getSyncHash(), getType(), u.getCollectionInterval(), u.getProperties()), this, Update.builder());
     }
 
     public MetricType getType() {
@@ -231,7 +232,7 @@ public final class Metric extends SyncedEntity<Metric.Blueprint, Metric.Update> 
             return visitor.visitMetric(this, parameter);
         }
 
-        public static final class Builder extends Entity.Update.Builder<Update, Builder> {
+        public static final class Builder extends Entity.Update.Builder<Metric, Update, Builder> {
             private Long collectionInterval;
 
             public Builder withInterval(Long interval) {
@@ -242,6 +243,13 @@ public final class Metric extends SyncedEntity<Metric.Blueprint, Metric.Update> 
             @Override
             public Update build() {
                 return new Update(name, properties, collectionInterval);
+            }
+
+            @Override public Builder withDifference(Metric original, Metric updated) {
+                if (!Objects.equals(original.getCollectionInterval(), updated.getCollectionInterval())) {
+                    withInterval(updated.getCollectionInterval());
+                }
+                return super.withDifference(original, updated);
             }
         }
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/MetricType.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/MetricType.java
@@ -18,6 +18,7 @@ package org.hawkular.inventory.api.model;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.hawkular.inventory.paths.CanonicalPath;
@@ -131,7 +132,7 @@ public final class MetricType extends SyncedEntity<MetricType.Blueprint, MetricT
     public Updater<Update, MetricType> update() {
         return new Updater<>((u) -> new MetricType(u.getName(), getPath(), getIdentityHash(), getContentHash(),
                 getSyncHash(), valueOrDefault(u.unit, this.unit), metricDataType, u.getProperties(),
-                valueOrDefault(u.getCollectionInterval(), collectionInterval)));
+                valueOrDefault(u.getCollectionInterval(), collectionInterval)), this, Update.builder());
     }
 
     @Override
@@ -316,7 +317,7 @@ public final class MetricType extends SyncedEntity<MetricType.Blueprint, MetricT
             return visitor.visitMetricType(this, parameter);
         }
 
-        public static final class Builder extends Entity.Update.Builder<Update, Builder> {
+        public static final class Builder extends Entity.Update.Builder<MetricType, Update, Builder> {
             private MetricUnit unit;
             private Long collectionInterval;
 
@@ -333,6 +334,17 @@ public final class MetricType extends SyncedEntity<MetricType.Blueprint, MetricT
             @Override
             public Update build() {
                 return new Update(name, properties, unit, collectionInterval);
+            }
+
+            @Override public Builder withDifference(MetricType original, MetricType updated) {
+                if (!Objects.equals(original.getUnit(), updated.getUnit())) {
+                    withUnit(updated.getUnit());
+                }
+
+                if (!Objects.equals(original.getCollectionInterval(), updated.getCollectionInterval())) {
+                    withInterval(updated.getCollectionInterval());
+                }
+                return super.withDifference(original, updated);
             }
         }
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/MetricType.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/MetricType.java
@@ -317,6 +317,25 @@ public final class MetricType extends SyncedEntity<MetricType.Blueprint, MetricT
             return visitor.visitMetricType(this, parameter);
         }
 
+        @Override public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Update)) return false;
+            if (!super.equals(o)) return false;
+
+            Update update = (Update) o;
+
+            if (unit != update.unit) return false;
+            return collectionInterval != null ? collectionInterval.equals(update.collectionInterval) :
+                    update.collectionInterval == null;
+        }
+
+        @Override public int hashCode() {
+            int result = super.hashCode();
+            result = 31 * result + (unit != null ? unit.hashCode() : 0);
+            result = 31 * result + (collectionInterval != null ? collectionInterval.hashCode() : 0);
+            return result;
+        }
+
         public static final class Builder extends Entity.Update.Builder<MetricType, Update, Builder> {
             private MetricUnit unit;
             private Long collectionInterval;

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/OperationType.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/OperationType.java
@@ -66,7 +66,7 @@ public final class OperationType extends SyncedEntity<OperationType.Blueprint, O
     @Override
     public Updater<Update, OperationType> update() {
         return new Updater<>((u) -> new OperationType(u.getName(), getPath(), getIdentityHash(), getContentHash(),
-                getSyncHash(), u.getProperties()));
+                getSyncHash(), u.getProperties()), this, Update.builder());
     }
 
     @ApiModel("OperationTypeBlueprint")
@@ -140,7 +140,7 @@ public final class OperationType extends SyncedEntity<OperationType.Blueprint, O
             return visitor.visitOperationType(this, parameter);
         }
 
-        public static final class Builder extends Entity.Update.Builder<Update, Builder> {
+        public static final class Builder extends Entity.Update.Builder<OperationType, Update, Builder> {
             @Override
             public Update build() {
                 return new Update(name, properties);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Relationship.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Relationship.java
@@ -74,7 +74,8 @@ public final class Relationship extends AbstractElement<Relationship.Blueprint, 
 
     @Override
     public Updater<Update, Relationship> update() {
-        return new Updater<>((u) -> new Relationship(getId(), getName(), getSource(), getTarget(), u.getProperties()));
+        return new Updater<>((u) -> new Relationship(getId(), getName(), getSource(), getTarget(), u.getProperties()),
+                this, Update.builder());
     }
 
     @Override
@@ -128,7 +129,7 @@ public final class Relationship extends AbstractElement<Relationship.Blueprint, 
             return visitor.visitRelationship(this, parameter);
         }
 
-        public static final class Builder extends AbstractElement.Update.Builder<Update, Builder> {
+        public static final class Builder extends AbstractElement.Update.Builder<Relationship, Update, Builder> {
             @Override
             public Update build() {
                 return new Update(properties);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Resource.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Resource.java
@@ -75,7 +75,7 @@ public final class Resource extends SyncedEntity<Resource.Blueprint, Resource.Up
     public Updater<Update, Resource> update() {
         return new Updater<>((u) -> new Resource(u.getName(), getPath(), getIdentityHash(), getContentHash(),
                 getSyncHash(), getType(),
-                u.getProperties()));
+                u.getProperties()), this, Update.builder());
     }
 
     public ResourceType getType() {
@@ -189,7 +189,7 @@ public final class Resource extends SyncedEntity<Resource.Blueprint, Resource.Up
             return visitor.visitResource(this, parameter);
         }
 
-        public static final class Builder extends Entity.Update.Builder<Update, Builder> {
+        public static final class Builder extends Entity.Update.Builder<Resource, Update, Builder> {
             @Override
             public Update build() {
                 return new Update(name, properties);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ResourceType.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/ResourceType.java
@@ -67,7 +67,7 @@ public final class ResourceType extends SyncedEntity<ResourceType.Blueprint, Res
     @Override
     public Updater<Update, ResourceType> update() {
         return new Updater<>((u) -> new ResourceType(u.getName(), getPath(), getIdentityHash(), getContentHash(),
-                getSyncHash(), u.getProperties()));
+                getSyncHash(), u.getProperties()), this, Update.builder());
     }
 
     @Override
@@ -154,7 +154,7 @@ public final class ResourceType extends SyncedEntity<ResourceType.Blueprint, Res
             return visitor.visitResourceType(this, parameter);
         }
 
-        public static final class Builder extends Entity.Update.Builder<Update, Builder> {
+        public static final class Builder extends Entity.Update.Builder<ResourceType, Update, Builder> {
 
             @Override
             public Update build() {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Tenant.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/api/model/Tenant.java
@@ -64,7 +64,8 @@ public final class Tenant extends ContentHashedEntity<Tenant.Blueprint, Tenant.U
 
     @Override
     public Updater<Update, Tenant> update() {
-        return new Updater<>((u) -> new Tenant(u.getName(), getPath(), getContentHash(), u.getProperties()));
+        return new Updater<>((u) -> new Tenant(u.getName(), getPath(), getContentHash(), u.getProperties()),
+                this, Update.builder());
     }
 
     @Override
@@ -144,7 +145,7 @@ public final class Tenant extends ContentHashedEntity<Tenant.Blueprint, Tenant.U
             return visitor.visitTenant(this, parameter);
         }
 
-        public static final class Builder extends Entity.Update.Builder<Update, Builder> {
+        public static final class Builder extends Entity.Update.Builder<Tenant, Update, Builder> {
             @Override
             public Update build() {
                 return new Update(name, properties);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Associator.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Associator.java
@@ -54,14 +54,14 @@ class Associator<BE, E extends Entity<?, ?>> extends Traversal<BE, E> {
     static <BE> Relationship associate(TraversalContext<BE, ?> context, SegmentType sourceEntityType,
                                        Relationships.WellKnown relationship, Path id) {
         return inTx(context, tx -> {
-            BE target = Util.find(tx, context.sourcePath, id);
+            BE target = Util.find(context.discriminator(), tx, context.sourcePath, id);
 
             Query sourceQuery = context.sourcePath.extend().filter().with(type(sourceEntityType)).get();
 
-            BE source = tx.querySingle(sourceQuery);
+            BE source = tx.querySingle(context.discriminator(), sourceQuery);
 
-            EntityAndPendingNotifications<BE, Relationship> rel = Util.createAssociation(tx, source,
-                    relationship.name(), target, null);
+            EntityAndPendingNotifications<BE, Relationship> rel = Util.createAssociation(context.discriminator(), tx,
+                    source, relationship.name(), target, null);
 
             tx.getPreCommit().addNotifications(rel);
 
@@ -78,11 +78,11 @@ class Associator<BE, E extends Entity<?, ?>> extends Traversal<BE, E> {
                                           SegmentType sourceEntityType,
                                           Relationships.WellKnown relationship, Path id) {
         return inTx(context, tx -> {
-            BE target = Util.find(tx, context.sourcePath, id);
+            BE target = Util.find(context.discriminator(), tx, context.sourcePath, id);
 
             Query sourceQuery = context.sourcePath.extend().filter().with(type(sourceEntityType)).get();
-            EntityAndPendingNotifications<BE, Relationship> rel = Util.deleteAssociation(tx, sourceQuery,
-                    sourceEntityType, relationship.name(), target);
+            EntityAndPendingNotifications<BE, Relationship> rel = Util.deleteAssociation(context.discriminator(), tx,
+                    sourceQuery, sourceEntityType, relationship.name(), target);
 
             tx.getPreCommit().addNotifications(rel);
 
@@ -105,7 +105,8 @@ class Associator<BE, E extends Entity<?, ?>> extends Traversal<BE, E> {
 
             SegmentType targetType = path.getSegment().getElementType();
 
-            return Util.getAssociation(tx, sourceQuery, sourceEntityType, targetQuery, targetType, relationship.name());
+            return Util.getAssociation(context.discriminator(), tx, sourceQuery, sourceEntityType, targetQuery,
+                    targetType, relationship.name());
         });
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BackendTransaction.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BackendTransaction.java
@@ -19,7 +19,6 @@ package org.hawkular.inventory.base;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -35,7 +34,7 @@ import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
 import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
-import org.hawkular.inventory.base.spi.EntityStateChange;
+import org.hawkular.inventory.base.spi.EntityHistory;
 import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.RelativePath;
@@ -221,7 +220,7 @@ public class BackendTransaction<E> implements Transaction<E> {
     }
 
     @Override public <T extends Entity<?, U>, U extends Entity.Update>
-    List<EntityStateChange<T>> getHistory(E entity, Class<T> entityType, Instant from, Instant to) {
+    EntityHistory<T> getHistory(E entity, Class<T> entityType, Instant from, Instant to) {
         return backend.getHistory(entity, entityType, from, to);
     }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BackendTransaction.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BackendTransaction.java
@@ -31,6 +31,7 @@ import org.hawkular.inventory.api.model.Hashes;
 import org.hawkular.inventory.api.model.StructuredData;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
 import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.paths.CanonicalPath;
@@ -62,20 +63,24 @@ public class BackendTransaction<E> implements Transaction<E> {
         return preCommit;
     }
 
-    @Override public <T> T convert(E entityRepresentation, Class<T> entityType) {
-        return backend.convert(entityRepresentation, entityType);
+    @Override public <T> T convert(Discriminator discriminator, E entityRepresentation, Class<T> entityType) {
+        return backend.convert(discriminator, entityRepresentation, entityType);
     }
 
-    @Override public void delete(E entity) {
-        backend.delete(entity);
+    @Override public void markDeleted(Discriminator discriminator, E entity) {
+        backend.markDeleted(discriminator, entity);
     }
 
     @Override public void deleteStructuredData(E dataRepresentation) {
         backend.deleteStructuredData(dataRepresentation);
     }
 
-    @Override public E descendToData(E dataEntityRepresentation, RelativePath dataPath) {
-        return backend.descendToData(dataEntityRepresentation, dataPath);
+    @Override public E descendToData(Discriminator discriminator, E dataEntityRepresentation, RelativePath dataPath) {
+        return backend.descendToData(discriminator, dataEntityRepresentation, dataPath);
+    }
+
+    @Override public void eradicate(E entityRepresentation) {
+        backend.eradicate(entityRepresentation);
     }
 
     @Override public CanonicalPath extractCanonicalPath(E entityRepresentation) {
@@ -86,16 +91,16 @@ public class BackendTransaction<E> implements Transaction<E> {
         return backend.extractId(entityRepresentation);
     }
 
-    @Override public String extractIdentityHash(E entityRepresentation) {
-        return backend.extractIdentityHash(entityRepresentation);
+    @Override public String extractIdentityHash(Discriminator discriminator, E entityRepresentation) {
+        return backend.extractIdentityHash(discriminator, entityRepresentation);
     }
 
-    @Override public String extractContentHash(E entityRepresentation) {
-        return backend.extractContentHash(entityRepresentation);
+    @Override public String extractContentHash(Discriminator discriminator, E entityRepresentation) {
+        return backend.extractContentHash(discriminator, entityRepresentation);
     }
 
-    @Override public String extractSyncHash(E entityRepresentation) {
-        return backend.extractSyncHash(entityRepresentation);
+    @Override public String extractSyncHash(Discriminator discriminator, E entityRepresentation) {
+        return backend.extractSyncHash(discriminator, entityRepresentation);
     }
 
     @Override public String extractRelationshipName(E relationship) {
@@ -106,51 +111,51 @@ public class BackendTransaction<E> implements Transaction<E> {
         return backend.extractType(entityRepresentation);
     }
 
-    @Override public E find(CanonicalPath element) throws ElementNotFoundException {
-        return backend.find(element);
+    @Override public E find(Discriminator discriminator, CanonicalPath element) throws ElementNotFoundException {
+        return backend.find(discriminator, element);
     }
 
-    @Override public InputStream getGraphSON(String tenantId) {
-        return backend.getGraphSON(tenantId);
+    @Override public InputStream getGraphSON(Discriminator discriminator, String tenantId) {
+        return backend.getGraphSON(discriminator, tenantId);
     }
 
-    @Override public E getRelationship(E source, E target, String relationshipName) throws ElementNotFoundException {
-        return backend.getRelationship(source, target, relationshipName);
+    @Override public E getRelationship(Discriminator discriminator, E source, E target, String relationshipName) throws ElementNotFoundException {
+        return backend.getRelationship(discriminator, source, target, relationshipName);
     }
 
-    @Override public Set<E> getRelationships(E entity, Relationships.Direction direction,
+    @Override public Set<E> getRelationships(Discriminator discriminator, E entity, Relationships.Direction direction,
                                              String... names) {
-        return backend.getRelationships(entity, direction, names);
+        return backend.getRelationships(discriminator, entity, direction, names);
     }
 
-    @Override public E getRelationshipSource(E relationship) {
-        return backend.getRelationshipSource(relationship);
+    @Override public E getRelationshipSource(Discriminator discriminator, E relationship) {
+        return backend.getRelationshipSource(discriminator, relationship);
     }
 
-    @Override public E getRelationshipTarget(E relationship) {
-        return backend.getRelationshipTarget(relationship);
+    @Override public E getRelationshipTarget(Discriminator discriminator, E relationship) {
+        return backend.getRelationshipTarget(discriminator, relationship);
     }
 
     @Override public <T extends Entity<?, ?>> Iterator<T> getTransitiveClosureOver(
-            CanonicalPath startingPoint,
+            Discriminator discriminator, CanonicalPath startingPoint,
             Relationships.Direction direction, Class<T> clazz,
             String... relationshipNames) {
-        return backend.getTransitiveClosureOver(startingPoint, direction, clazz, relationshipNames);
+        return backend.getTransitiveClosureOver(discriminator, startingPoint, direction, clazz, relationshipNames);
     }
 
-    @Override public Iterator<E> getTransitiveClosureOver(E startingPoint,
+    @Override public Iterator<E> getTransitiveClosureOver(Discriminator discriminator, E startingPoint,
                                                           Relationships.Direction direction,
                                                           String... relationshipNames) {
-        return backend.getTransitiveClosureOver(startingPoint, direction, relationshipNames);
+        return backend.getTransitiveClosureOver(discriminator, startingPoint, direction, relationshipNames);
     }
 
-    @Override public boolean hasRelationship(E entity, Relationships.Direction direction,
+    @Override public boolean hasRelationship(Discriminator discriminator, E entity, Relationships.Direction direction,
                                              String relationshipName) {
-        return backend.hasRelationship(entity, direction, relationshipName);
+        return backend.hasRelationship(discriminator, entity, direction, relationshipName);
     }
 
-    @Override public boolean hasRelationship(E source, E target, String relationshipName) {
-        return backend.hasRelationship(source, target, relationshipName);
+    @Override public boolean hasRelationship(Discriminator discriminator, E source, E target, String relationshipName) {
+        return backend.hasRelationship(discriminator, source, target, relationshipName);
     }
 
     @Override public boolean isBackendInternal(E element) {
@@ -170,42 +175,42 @@ public class BackendTransaction<E> implements Transaction<E> {
         return backend.persist(structuredData);
     }
 
-    @Override public Page<E> query(Query query,
+    @Override public Page<E> query(Discriminator discriminator, Query query,
                                    Pager pager) {
-        return backend.query(query, pager);
+        return backend.query(discriminator, query, pager);
     }
 
-    @Override public <T> Page<T> query(Query query,
+    @Override public <T> Page<T> query(Discriminator discriminator, Query query,
                                        Pager pager,
                                        Function<E, T> conversion,
                                        Function<T, Boolean> filter) {
-        return backend.query(query, pager, conversion, filter);
+        return backend.query(discriminator, query, pager, conversion, filter);
     }
 
-    @Override public E querySingle(Query query) {
-        return backend.querySingle(query);
+    @Override public E querySingle(Discriminator discriminator, Query query) {
+        return backend.querySingle(discriminator, query);
     }
 
-    @Override public E relate(E sourceEntity, E targetEntity, String name,
+    @Override public E relate(Discriminator discriminator, E sourceEntity, E targetEntity, String name,
                               Map<String, Object> properties) {
-        return backend.relate(sourceEntity, targetEntity, name, properties);
+        return backend.relate(discriminator, sourceEntity, targetEntity, name, properties);
     }
 
-    @Override public Page<E> traverse(E startingPoint, Query query,
+    @Override public Page<E> traverse(Discriminator discriminator, E startingPoint, Query query,
                                       Pager pager) {
-        return backend.traverse(startingPoint, query, pager);
+        return backend.traverse(discriminator, startingPoint, query, pager);
     }
 
-    @Override public E traverseToSingle(E startingPoint, Query query) {
-        return backend.traverseToSingle(startingPoint, query);
+    @Override public E traverseToSingle(Discriminator discriminator, E startingPoint, Query query) {
+        return backend.traverseToSingle(discriminator, startingPoint, query);
     }
 
-    @Override public void update(E entity, AbstractElement.Update update) {
-        backend.update(entity, update);
+    @Override public void update(Discriminator discriminator, E entity, AbstractElement.Update update) {
+        backend.update(discriminator, entity, update);
     }
 
-    @Override public void updateHashes(E entity, Hashes hashes) {
-        backend.updateHashes(entity, hashes);
+    @Override public void updateHashes(Discriminator discriminator, E entity, Hashes hashes) {
+        backend.updateHashes(discriminator, entity, hashes);
     }
 
     @Override public boolean requiresRollbackAfterFailure(Throwable t) {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BackendTransaction.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BackendTransaction.java
@@ -166,9 +166,9 @@ public class BackendTransaction<E> implements Transaction<E> {
         return backend.isUniqueIndexSupported();
     }
 
-    @Override public E persist(CanonicalPath path,
+    @Override public E persist(Discriminator discriminator, CanonicalPath path,
                                Blueprint blueprint) {
-        return backend.persist(path, blueprint);
+        return backend.persist(discriminator, path, blueprint);
     }
 
     @Override public E persist(StructuredData structuredData) {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BackendTransaction.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BackendTransaction.java
@@ -17,7 +17,9 @@
 package org.hawkular.inventory.base;
 
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -33,6 +35,7 @@ import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
 import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
+import org.hawkular.inventory.base.spi.EntityStateChange;
 import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.RelativePath;
@@ -215,5 +218,10 @@ public class BackendTransaction<E> implements Transaction<E> {
 
     @Override public boolean requiresRollbackAfterFailure(Throwable t) {
         return backend.requiresRollbackAfterFailure(t);
+    }
+
+    @Override public <T extends Entity<?, U>, U extends Entity.Update>
+    List<EntityStateChange<T>> getHistory(E entity, Class<T> entityType, Instant from, Instant to) {
+        return backend.getHistory(entity, entityType, from, to);
     }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseData.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseData.java
@@ -117,17 +117,17 @@ public final class BaseData {
         }
 
         @Override
-        protected EntityAndPendingNotifications<BE, DataEntity> wireUpNewEntity(BE entity,
+        protected EntityAndPendingNotifications<BE, DataEntity> wireUpNewEntity(Discriminator discriminator, BE entity,
                                                                                 DataEntity.Blueprint<R> blueprint,
                                                                                 CanonicalPath parentPath, BE parent,
                                                                                 Transaction<BE> tx) {
-            Validator.validate(context.discriminator(), tx, blueprint.getValue(), entity);
+            Validator.validate(discriminator, tx, blueprint.getValue(), entity);
             BE value = tx.persist(blueprint.getValue());
 
             //don't report this relationship, it is implicit
             //also, don't run the RelationshipRules checks - we're in the "privileged code" that is allowed to do
             //this
-            tx.relate(context.discriminator(), entity, value, hasData.name(), null);
+            tx.relate(discriminator, entity, value, hasData.name(), null);
 
             DataEntity data = new DataEntity(parentPath, blueprint.getRole(), blueprint.getValue(), null,
                     null, null, blueprint.getProperties());

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseData.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseData.java
@@ -205,22 +205,6 @@ public final class BaseData {
         private static <BE> void preDelete(Discriminator discriminator, DataModificationChecks<BE> checks, BE entityRepresentation,
                                            Transaction<BE> tx) {
             checks.preDelete(entityRepresentation, tx);
-
-// This is pre-versioning code - all this is only invoked during eradicate now...
-//            Set<BE> rels = tx.getRelationships(discriminator, entityRepresentation, Relationships.Direction.outgoing,
-//                    hasData.name());
-//
-//            if (rels.isEmpty()) {
-//                Log.LOGGER.wNoDataAssociatedWithEntity(tx.extractCanonicalPath(entityRepresentation));
-//                return;
-//            }
-//
-//            BE dataRel = rels.iterator().next();
-//
-//            BE structuredData = tx.getRelationshipTarget(discriminator, dataRel);
-//
-//            tx.deleteStructuredData(structuredData);
-//            tx.markDeleted(discriminator, dataRel);
         }
 
         private static <BE> void postDelete(DataModificationChecks<BE> checks, BE entity,

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseEnvironments.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseEnvironments.java
@@ -37,6 +37,7 @@ import org.hawkular.inventory.api.model.Environment;
 import org.hawkular.inventory.api.model.Feed;
 import org.hawkular.inventory.api.model.Metric;
 import org.hawkular.inventory.api.model.Resource;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.Path;
 
@@ -125,7 +126,8 @@ public final class BaseEnvironments {
 
         @Override
         protected EntityAndPendingNotifications<BE, Environment>
-        wireUpNewEntity(BE entity, Environment.Blueprint blueprint, CanonicalPath parentPath, BE parent,
+        wireUpNewEntity(Discriminator discriminator, BE entity, Environment.Blueprint blueprint,
+                        CanonicalPath parentPath, BE parent,
                         Transaction<BE> tx) {
             return new EntityAndPendingNotifications<>(entity, new Environment(blueprint.getName(),
                     parentPath.extend(Environment.SEGMENT_TYPE, tx.extractId(entity)).get(),

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseFeeds.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseFeeds.java
@@ -62,7 +62,7 @@ public final class BaseFeeds {
 
         @Override
         protected String getProposedId(Transaction<BE> tx, Feed.Blueprint blueprint) {
-            BE tenant = tx.querySingle(context.sourcePath.extend().filter()
+            BE tenant = tx.querySingle(context.discriminator(), context.sourcePath.extend().filter()
                     .with(type(Tenant.class)).get());
 
             if (tenant == null) {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseFeeds.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseFeeds.java
@@ -39,6 +39,7 @@ import org.hawkular.inventory.api.model.MetricType;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.api.model.ResourceType;
 import org.hawkular.inventory.api.model.Tenant;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.Path;
 import org.hawkular.inventory.paths.SegmentType;
@@ -78,7 +79,8 @@ public final class BaseFeeds {
 
         @Override
         protected EntityAndPendingNotifications<BE, Feed>
-        wireUpNewEntity(BE entity, Feed.Blueprint blueprint, CanonicalPath parentPath, BE parent,
+        wireUpNewEntity(Discriminator discriminator, BE entity, Feed.Blueprint blueprint, CanonicalPath parentPath,
+                        BE parent,
                         Transaction<BE> transaction) {
             return new EntityAndPendingNotifications<>(entity, new Feed(blueprint.getName(),
                     parentPath.extend(Feed.SEGMENT_TYPE, transaction.extractId(entity)).get(), null,

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseInventory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseInventory.java
@@ -360,7 +360,7 @@ public abstract class BaseInventory<E> implements Inventory {
                             adaptTransactionConstructor(fakeTxCtor)
                                     .construct(activeBackend, new BasePreCommit<>())),
                     (TransactionPayload.Committing<Void, E>) tx -> {
-                        activePrecommit.initialize(boundInventory(), tx, tenantContext.now());
+                        activePrecommit.initialize(boundInventory(), tx);
                         activePrecommit.getActions().forEach(a -> a.accept(tx));
                         activeBackend.commit();
                         activePrecommit.getFinalNotifications().forEach(tenantContext::notifyAll);
@@ -375,12 +375,12 @@ public abstract class BaseInventory<E> implements Inventory {
                             //those for each of them
                             Transaction<E> fakeTx = fakeTxCtor.construct(activeBackend,
                                     new Transaction.PreCommit.Simple<>());
-                            fakeTx.getPreCommit().initialize(boundInventory(), fakeTx, tenantContext.now());
+                            fakeTx.getPreCommit().initialize(boundInventory(), fakeTx);
 
                             p.run(fakeTx);
                         }
 
-                        activePrecommit.initialize(boundInventory(), tx, tenantContext.now());
+                        activePrecommit.initialize(boundInventory(), tx);
                         activePrecommit.getActions().forEach(a -> a.accept(tx));
                         activeBackend.commit();
                         activePrecommit.getFinalNotifications().forEach(tenantContext::notifyAll);
@@ -428,7 +428,7 @@ public abstract class BaseInventory<E> implements Inventory {
             Transaction<E> tx = null;
             try {
                 tx = tenantContext.startTransaction();
-                activePrecommit.initialize(BaseInventory.this.keepTransaction(tx), tx, tenantContext.now());
+                activePrecommit.initialize(BaseInventory.this.keepTransaction(tx), tx);
 
                 for(Consumer<Transaction<E>> action : activePrecommit.getActions()) {
                     action.accept(tx);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseInventory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseInventory.java
@@ -91,12 +91,13 @@ public abstract class BaseInventory<E> implements Inventory {
         this.transactionConstructor = transactionConstructor == null
                 ? orig.transactionConstructor : transactionConstructor;
 
-        tenantContext = new TraversalContext<>(this, Instant.now(), Query.empty(),
+        tenantContext = new TraversalContext<>(this, orig.tenantContext.discriminator().getTime(), Query.empty(),
                 Query.path().with(With.type(Tenant.class)).get(), this.backend, Tenant.class, configuration,
                 observableContext, this.transactionConstructor);
 
-        relationshipContext = new TraversalContext<>(this, Instant.now(), Query.empty(), Query.path().get(),
-                this.backend, Relationship.class, configuration, observableContext, this.transactionConstructor);
+        relationshipContext = new TraversalContext<>(this, orig.relationshipContext.discriminator().getTime(),
+                Query.empty(), Query.path().get(), this.backend, Relationship.class, configuration, observableContext,
+                this.transactionConstructor);
     }
 
     protected BaseInventory() {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetadataPacks.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetadataPacks.java
@@ -67,8 +67,8 @@ public final class BaseMetadataPacks {
                         SegmentType type = p.getSegment().getElementType();
                         Class<?> cls = Entity.entityTypeFromSegmentType(type);
                         try {
-                            BE e = tx.find(p);
-                            return (Entity<? extends Entity.Blueprint, ?>) tx.convert(e, cls);
+                            BE e = tx.find(context.discriminator(), p);
+                            return (Entity<? extends Entity.Blueprint, ?>) tx.convert(context.discriminator(), e, cls);
                         } catch (ElementNotFoundException ex) {
                             throw new EntityNotFoundException(cls, Query.filters(Query.to(p)));
                         }
@@ -85,11 +85,11 @@ public final class BaseMetadataPacks {
 
             blueprint.getMembers().forEach((p) -> {
                 try {
-                    BE member = tx.find(p);
+                    BE member = tx.find(context.discriminator(), p);
 
-                    BE rel = tx.relate(entity, member, incorporates.name(), null);
+                    BE rel = tx.relate(context.discriminator(), entity, member, incorporates.name(), null);
 
-                    Relationship r = tx.convert(rel, Relationship.class);
+                    Relationship r = tx.convert(context.discriminator(), rel, Relationship.class);
                     newRels.add(new Notification<>(r, r, created()));
                 } catch (ElementNotFoundException e) {
                     throw new EntityNotFoundException(p.getSegment().getElementType().getSimpleName(),
@@ -97,7 +97,7 @@ public final class BaseMetadataPacks {
                 }
             });
 
-            MetadataPack entityObject = tx.convert(entity, MetadataPack.class);
+            MetadataPack entityObject = tx.convert(context.discriminator(), entity, MetadataPack.class);
 
             return new EntityAndPendingNotifications<>(entity, entityObject, newRels);
         }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetadataPacks.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetadataPacks.java
@@ -37,6 +37,7 @@ import org.hawkular.inventory.api.model.MetadataPack;
 import org.hawkular.inventory.api.model.MetricType;
 import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.ResourceType;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.Path;
@@ -79,17 +80,18 @@ public final class BaseMetadataPacks {
 
         @Override
         protected EntityAndPendingNotifications<BE, MetadataPack>
-        wireUpNewEntity(BE entity, MetadataPack.Blueprint blueprint, CanonicalPath parentPath, BE parent,
+        wireUpNewEntity(Discriminator discriminator, BE entity, MetadataPack.Blueprint blueprint,
+                        CanonicalPath parentPath, BE parent,
                         Transaction<BE> tx) {
             Set<Notification<?, ?>> newRels = new HashSet<>();
 
             blueprint.getMembers().forEach((p) -> {
                 try {
-                    BE member = tx.find(context.discriminator(), p);
+                    BE member = tx.find(discriminator, p);
 
-                    BE rel = tx.relate(context.discriminator(), entity, member, incorporates.name(), null);
+                    BE rel = tx.relate(discriminator, entity, member, incorporates.name(), null);
 
-                    Relationship r = tx.convert(context.discriminator(), rel, Relationship.class);
+                    Relationship r = tx.convert(discriminator, rel, Relationship.class);
                     newRels.add(new Notification<>(r, r, created()));
                 } catch (ElementNotFoundException e) {
                     throw new EntityNotFoundException(p.getSegment().getElementType().getSimpleName(),
@@ -97,7 +99,7 @@ public final class BaseMetadataPacks {
                 }
             });
 
-            MetadataPack entityObject = tx.convert(context.discriminator(), entity, MetadataPack.class);
+            MetadataPack entityObject = tx.convert(discriminator, entity, MetadataPack.class);
 
             return new EntityAndPendingNotifications<>(entity, entityObject, newRels);
         }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetricTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetricTypes.java
@@ -63,9 +63,10 @@ public final class BaseMetricTypes {
 
         @Override
         protected EntityAndPendingNotifications<BE, MetricType>
-        wireUpNewEntity(BE entity, MetricType.Blueprint blueprint, CanonicalPath parentPath, BE parent,
+        wireUpNewEntity(Discriminator discriminator, BE entity, MetricType.Blueprint blueprint,
+                        CanonicalPath parentPath, BE parent,
                         Transaction<BE> tx) {
-            tx.update(context.discriminator(), entity, MetricType.Update.builder().withUnit(blueprint.getUnit()).build());
+            tx.update(discriminator, entity, MetricType.Update.builder().withUnit(blueprint.getUnit()).build());
 
             MetricType metricType = new MetricType(blueprint.getName(),
                     parentPath.extend(MetricType.SEGMENT_TYPE, tx.extractId(entity)).get(), null, null, null,

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetricTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetricTypes.java
@@ -66,8 +66,6 @@ public final class BaseMetricTypes {
         wireUpNewEntity(Discriminator discriminator, BE entity, MetricType.Blueprint blueprint,
                         CanonicalPath parentPath, BE parent,
                         Transaction<BE> tx) {
-            tx.update(discriminator, entity, MetricType.Update.builder().withUnit(blueprint.getUnit()).build());
-
             MetricType metricType = new MetricType(blueprint.getName(),
                     parentPath.extend(MetricType.SEGMENT_TYPE, tx.extractId(entity)).get(), null, null, null,
                     blueprint.getUnit(), blueprint.getMetricDataType(), blueprint.getProperties(),

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetricTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetricTypes.java
@@ -33,6 +33,7 @@ import org.hawkular.inventory.api.filters.With;
 import org.hawkular.inventory.api.model.MetadataPack;
 import org.hawkular.inventory.api.model.Metric;
 import org.hawkular.inventory.api.model.MetricType;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.Path;
 import org.hawkular.inventory.paths.SegmentType;
@@ -64,7 +65,7 @@ public final class BaseMetricTypes {
         protected EntityAndPendingNotifications<BE, MetricType>
         wireUpNewEntity(BE entity, MetricType.Blueprint blueprint, CanonicalPath parentPath, BE parent,
                         Transaction<BE> tx) {
-            tx.update(entity, MetricType.Update.builder().withUnit(blueprint.getUnit()).build());
+            tx.update(context.discriminator(), entity, MetricType.Update.builder().withUnit(blueprint.getUnit()).build());
 
             MetricType metricType = new MetricType(blueprint.getName(),
                     parentPath.extend(MetricType.SEGMENT_TYPE, tx.extractId(entity)).get(), null, null, null,
@@ -100,7 +101,7 @@ public final class BaseMetricTypes {
 
         @Override
         protected void preDelete(String s, BE entityRepresentation, Transaction<BE> transaction) {
-            preDelete(entityRepresentation, transaction);
+            preDelete(entityRepresentation, context.discriminator(), transaction);
         }
 
         @Override
@@ -113,21 +114,21 @@ public final class BaseMetricTypes {
             postUpdate(context, entityRepresentation, transaction);
         }
 
-        private static <BE> void preDelete(BE deletedEntity, Transaction<BE> tx) {
-            if (isInMetadataPack(deletedEntity, tx)) {
+        private static <BE> void preDelete(BE deletedEntity, Discriminator discriminator, Transaction<BE> tx) {
+            if (isInMetadataPack(deletedEntity, discriminator, tx)) {
                 throw new IllegalArgumentException("Cannot delete a metric type that is a part of metadata pack.");
             }
         }
 
         private static <BE> void preUpdate(TraversalContext<BE, ?> context, BE entity, MetricType.Update update,
                                            Transaction<BE> tx) {
-            MetricType mt = tx.convert(entity, MetricType.class);
+            MetricType mt = tx.convert(context.discriminator(), entity, MetricType.class);
             if (mt.getUnit() == update.getUnit()) {
                 //k, this is the only updatable thing that influences metadata packs, so if it is equal, we're ok.
                 return;
             }
 
-            if (isInMetadataPack(entity, tx)) {
+            if (isInMetadataPack(entity, context.discriminator(), tx)) {
                 throw new IllegalArgumentException("Cannot update a metric type that is a part of metadata pack.");
             }
         }
@@ -136,8 +137,8 @@ public final class BaseMetricTypes {
                                             Transaction<BE> tx) {
         }
 
-        private static <BE> boolean isInMetadataPack(BE metricType, Transaction<BE> tx) {
-            return tx.traverseToSingle(metricType, Query.path().with(Related.asTargetBy(incorporates),
+        private static <BE> boolean isInMetadataPack(BE metricType, Discriminator discriminator, Transaction<BE> tx) {
+            return tx.traverseToSingle(discriminator, metricType, Query.path().with(Related.asTargetBy(incorporates),
                     With.type(MetadataPack.class)).get()) != null;
 
         }
@@ -228,7 +229,7 @@ public final class BaseMetricTypes {
 
         @Override
         protected void preDelete(BE deletedEntity, Transaction<BE> transaction) {
-            ReadWrite.preDelete(deletedEntity, transaction);
+            ReadWrite.preDelete(deletedEntity, context.discriminator(), transaction);
         }
 
         @Override

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetrics.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetrics.java
@@ -71,7 +71,7 @@ public final class BaseMetrics {
                 CanonicalPath tenant = CanonicalPath.of().tenant(parentPath.ids().getTenantId()).get();
                 CanonicalPath metricTypePath = Util.canonicalize(blueprint.getMetricTypePath(), tenant, parentPath,
                         MetricType.SEGMENT_TYPE);
-                metricTypeObject = tx.find(metricTypePath);
+                metricTypeObject = tx.find(context.discriminator(), metricTypePath);
 
             } catch (ElementNotFoundException e) {
                 throw new IllegalArgumentException("A metric type with path '" + blueprint.getMetricTypePath() +
@@ -81,11 +81,11 @@ public final class BaseMetrics {
             //specifically do NOT check relationship rules, here because defines cannot be created "manually".
             //here we "know what we are doing" and need to create the defines relationship to capture the
             //contract of the metric.
-            BE r = tx.relate(metricTypeObject, entity, defines.name(), null);
+            BE r = tx.relate(context.discriminator(), metricTypeObject, entity, defines.name(), null);
 
             CanonicalPath entityPath = tx.extractCanonicalPath(entity);
 
-            MetricType metricType = tx.convert(metricTypeObject, MetricType.class);
+            MetricType metricType = tx.convert(context.discriminator(), metricTypeObject, MetricType.class);
 
             Metric ret = new Metric(blueprint.getName(), parentPath.extend(Metric.SEGMENT_TYPE,
                     tx.extractId(entity)).get(), null, null, null, metricType, blueprint.getCollectionInterval(),
@@ -97,7 +97,7 @@ public final class BaseMetrics {
             notifs.add(new Notification<>(rel, rel, created()));
 
             if (Resource.class.equals(tx.extractType(parent))) {
-                r = tx.relate(parent, entity, incorporates.name(), null);
+                r = tx.relate(context.discriminator(), parent, entity, incorporates.name(), null);
                 rel = new Relationship(tx.extractId(r), incorporates.name(), parentPath, entityPath);
                 notifs.add(new Notification<>(rel, rel, created()));
             }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetrics.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseMetrics.java
@@ -32,6 +32,7 @@ import org.hawkular.inventory.api.model.Metric;
 import org.hawkular.inventory.api.model.MetricType;
 import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.Resource;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.Path;
@@ -61,7 +62,8 @@ public final class BaseMetrics {
         }
 
         @Override
-        protected EntityAndPendingNotifications<BE, Metric> wireUpNewEntity(BE entity, Metric.Blueprint blueprint,
+        protected EntityAndPendingNotifications<BE, Metric> wireUpNewEntity(Discriminator discriminator, BE entity,
+                                                                            Metric.Blueprint blueprint,
                                                                             CanonicalPath parentPath, BE parent,
                                                                             Transaction<BE> tx) {
 
@@ -71,7 +73,7 @@ public final class BaseMetrics {
                 CanonicalPath tenant = CanonicalPath.of().tenant(parentPath.ids().getTenantId()).get();
                 CanonicalPath metricTypePath = Util.canonicalize(blueprint.getMetricTypePath(), tenant, parentPath,
                         MetricType.SEGMENT_TYPE);
-                metricTypeObject = tx.find(context.discriminator(), metricTypePath);
+                metricTypeObject = tx.find(discriminator, metricTypePath);
 
             } catch (ElementNotFoundException e) {
                 throw new IllegalArgumentException("A metric type with path '" + blueprint.getMetricTypePath() +
@@ -81,11 +83,11 @@ public final class BaseMetrics {
             //specifically do NOT check relationship rules, here because defines cannot be created "manually".
             //here we "know what we are doing" and need to create the defines relationship to capture the
             //contract of the metric.
-            BE r = tx.relate(context.discriminator(), metricTypeObject, entity, defines.name(), null);
+            BE r = tx.relate(discriminator, metricTypeObject, entity, defines.name(), null);
 
             CanonicalPath entityPath = tx.extractCanonicalPath(entity);
 
-            MetricType metricType = tx.convert(context.discriminator(), metricTypeObject, MetricType.class);
+            MetricType metricType = tx.convert(discriminator, metricTypeObject, MetricType.class);
 
             Metric ret = new Metric(blueprint.getName(), parentPath.extend(Metric.SEGMENT_TYPE,
                     tx.extractId(entity)).get(), null, null, null, metricType, blueprint.getCollectionInterval(),
@@ -97,7 +99,7 @@ public final class BaseMetrics {
             notifs.add(new Notification<>(rel, rel, created()));
 
             if (Resource.class.equals(tx.extractType(parent))) {
-                r = tx.relate(context.discriminator(), parent, entity, incorporates.name(), null);
+                r = tx.relate(discriminator, parent, entity, incorporates.name(), null);
                 rel = new Relationship(tx.extractId(r), incorporates.name(), parentPath, entityPath);
                 notifs.add(new Notification<>(rel, rel, created()));
             }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseOperationTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseOperationTypes.java
@@ -33,6 +33,7 @@ import org.hawkular.inventory.api.filters.With;
 import org.hawkular.inventory.api.model.DataEntity;
 import org.hawkular.inventory.api.model.MetadataPack;
 import org.hawkular.inventory.api.model.OperationType;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.DataRole;
@@ -83,7 +84,7 @@ public final class BaseOperationTypes {
 
         @Override protected void preCreate(OperationType.Blueprint blueprint, Transaction<BE> tx) {
             //disallow this if the parent resource type is a part of a metadata pack
-            if (tx.traverseToSingle(getParent(tx), Query.path().with(asTargetBy(incorporates),
+            if (tx.traverseToSingle(context.discriminator(), getParent(tx), Query.path().with(asTargetBy(incorporates),
                     With.type(MetadataPack.class)).get()) != null) {
                 throw new IllegalArgumentException("Cannot create an operation type of resource type included in " +
                         "a meta data pack. This would invalidate the metadata pack's identity.");
@@ -93,14 +94,14 @@ public final class BaseOperationTypes {
 
         @Override
         protected void preDelete(String s, BE entityRepresentation, Transaction<BE> tx) {
-            if (isResourceTypeInMetadataPack(entityRepresentation, tx)) {
+            if (isResourceTypeInMetadataPack(entityRepresentation, context.discriminator(), tx)) {
                 throw new IllegalArgumentException("Cannot delete an operation type of resource type included in " +
                         "a meta data pack. This would invalidate the metadata pack's identity.");
             }
         }
 
-        private static <BE> boolean isResourceTypeInMetadataPack(BE operationType, Transaction<BE> tx) {
-            return tx.traverseToSingle(operationType, Query.path().with(asTargetBy(contains),
+        private static <BE> boolean isResourceTypeInMetadataPack(BE operationType, Discriminator discriminator, Transaction<BE> tx) {
+            return tx.traverseToSingle(discriminator, operationType, Query.path().with(asTargetBy(contains),
                     asTargetBy(incorporates), With.type(MetadataPack.class)).get()) != null;
         }
     }
@@ -136,7 +137,7 @@ public final class BaseOperationTypes {
         }
 
         @Override protected void preDelete(BE deletedEntity, Transaction<BE> transaction) {
-            if (ReadWrite.isResourceTypeInMetadataPack(deletedEntity, transaction)) {
+            if (ReadWrite.isResourceTypeInMetadataPack(deletedEntity, context.discriminator(), transaction)) {
                 throw new IllegalArgumentException("Cannot delete an operation type of resource type included in " +
                         "a meta data pack. This would invalidate the metadata pack's identity.");
             }
@@ -167,11 +168,11 @@ public final class BaseOperationTypes {
 
         @Override
         public void preCreate(DataEntity.Blueprint blueprint, Transaction<BE> transaction) {
-            BE mp = transaction.querySingle(context.select().path().with(asTargetBy(contains),
+            BE mp = transaction.querySingle(context.discriminator(), context.select().path().with(asTargetBy(contains),
                     asTargetBy(incorporates), With.type(MetadataPack.class)).get());
 
             if (mp != null) {
-                BE ot = transaction.querySingle(context.select().get());
+                BE ot = transaction.querySingle(context.discriminator(), context.select().get());
                 throw new IllegalArgumentException(
                         "Data '" + blueprint.getId() + "' cannot be created" +
                                 " under operation type " + transaction.extractCanonicalPath(ot) +
@@ -186,7 +187,7 @@ public final class BaseOperationTypes {
                 return;
             }
 
-            BE mp = tx.traverseToSingle(dataEntity, Query.path().with(
+            BE mp = tx.traverseToSingle(context.discriminator(), dataEntity, Query.path().with(
                     asTargetBy(contains), //up to operation type
                     asTargetBy(contains), //up to resource type
                     asTargetBy(incorporates), With.type(MetadataPack.class) // up to the pack
@@ -211,12 +212,12 @@ public final class BaseOperationTypes {
             CanonicalPath dataPath = tx.extractCanonicalPath(dataEntity);
             BE ot = null;
             try {
-                ot = tx.find(dataPath.up());
+                ot = tx.find(context.discriminator(), dataPath.up());
             } catch (ElementNotFoundException e) {
                 Fetcher.throwNotFoundException(context);
             }
 
-            if (ReadWrite.isResourceTypeInMetadataPack(ot, tx)) {
+            if (ReadWrite.isResourceTypeInMetadataPack(ot, context.discriminator(), tx)) {
                 throw new IllegalArgumentException(
                         "Data '" + dataPath.getSegment().getElementId() + "' cannot be deleted" +
                                 " under operation type " + dataPath.up() +

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseOperationTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseOperationTypes.java
@@ -62,7 +62,8 @@ public final class BaseOperationTypes {
 
         @Override
         protected EntityAndPendingNotifications<BE, OperationType>
-        wireUpNewEntity(BE entity, OperationType.Blueprint blueprint, CanonicalPath parentPath, BE parent,
+        wireUpNewEntity(Discriminator discriminator, BE entity, OperationType.Blueprint blueprint,
+                        CanonicalPath parentPath, BE parent,
                         Transaction<BE> tx) {
             return new EntityAndPendingNotifications<>(entity, new OperationType(blueprint.getName(),
                     parentPath.extend(OperationType.SEGMENT_TYPE, tx.extractId(entity)).get(), null,

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BasePreCommit.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BasePreCommit.java
@@ -96,17 +96,15 @@ public class BasePreCommit<BE> implements Transaction.PreCommit<BE> {
 
     private Inventory inventory;
     private Transaction<BE> tx;
-    private Instant txStart;
 
     /**
      * Pre-commit actions that reset the identity hash
      */
     private Consumer<Transaction<BE>> correctiveAction;
 
-    @Override public void initialize(Inventory inventory, Transaction<BE> tx, Instant txStart) {
+    @Override public void initialize(Inventory inventory, Transaction<BE> tx) {
         this.inventory = inventory;
         this.tx = tx;
-        this.txStart = txStart;
     }
 
     @Override public void reset() {
@@ -537,7 +535,7 @@ public class BasePreCommit<BE> implements Transaction.PreCommit<BE> {
         void loadFrom(Transaction<BE> tx) throws ElementNotFoundException {
             if (element == null || loadingTx != tx) {
                 loadingTx = tx;
-                Discriminator disc = Discriminator.time(/*isDelete ? txStart :*/ Instant.now());
+                Discriminator disc = Discriminator.time(Instant.now());
                 representation = tx.find(disc, cp);
                 @SuppressWarnings("unchecked")
                 Class<? extends AbstractElement<?, ?>> type = (Class<? extends AbstractElement<?, ?>>)

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResourceTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResourceTypes.java
@@ -73,10 +73,9 @@ public final class BaseResourceTypes {
 
         @Override
         protected EntityAndPendingNotifications<BE, ResourceType>
-        wireUpNewEntity(BE entity, ResourceType.Blueprint blueprint, CanonicalPath parentPath, BE parent,
+        wireUpNewEntity(Discriminator discriminator, BE entity, ResourceType.Blueprint blueprint,
+                        CanonicalPath parentPath, BE parent,
                         Transaction<BE> tx) {
-
-            tx.update(context.discriminator(), entity, ResourceType.Update.builder().build());
 
             ResourceType resourceType = new ResourceType(blueprint.getName(),
                     parentPath.extend(ResourceType.SEGMENT_TYPE, tx.extractId(entity)).get(), null, null, null,

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResourceTypes.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResourceTypes.java
@@ -42,6 +42,7 @@ import org.hawkular.inventory.api.model.MetricType;
 import org.hawkular.inventory.api.model.OperationType;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.api.model.ResourceType;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.DataRole;
@@ -75,7 +76,7 @@ public final class BaseResourceTypes {
         wireUpNewEntity(BE entity, ResourceType.Blueprint blueprint, CanonicalPath parentPath, BE parent,
                         Transaction<BE> tx) {
 
-            tx.update(entity, ResourceType.Update.builder().build());
+            tx.update(context.discriminator(), entity, ResourceType.Update.builder().build());
 
             ResourceType resourceType = new ResourceType(blueprint.getName(),
                     parentPath.extend(ResourceType.SEGMENT_TYPE, tx.extractId(entity)).get(), null, null, null,
@@ -101,7 +102,7 @@ public final class BaseResourceTypes {
 
         @Override
         protected void preDelete(String s, BE entityRepresentation, Transaction<BE> tx) {
-            if (isResourceTypeInMetadataPack(entityRepresentation, tx)) {
+            if (isResourceTypeInMetadataPack(entityRepresentation, context.discriminator(), tx)) {
                 throw new IllegalArgumentException("Cannot delete a resource type that is part of a metadata pack. " +
                         "This would invalidate the meta data pack's identity.");
             }
@@ -114,8 +115,8 @@ public final class BaseResourceTypes {
             //because resource types contain no such updatable data, this is a no-op.
         }
 
-        private static <BE> boolean isResourceTypeInMetadataPack(BE resourceType, Transaction<BE> tx) {
-            return tx.traverseToSingle(resourceType, Query.path()
+        private static <BE> boolean isResourceTypeInMetadataPack(BE resourceType, Discriminator disc, Transaction<BE> tx) {
+            return tx.traverseToSingle(disc, resourceType, Query.path()
                     .with(asTargetBy(incorporates), type(MetadataPack.class)).get()) != null;
         }
     }
@@ -179,7 +180,7 @@ public final class BaseResourceTypes {
 
         @Override
         protected void preDelete(BE deletedEntity, Transaction<BE> tx) {
-            if (ReadWrite.isResourceTypeInMetadataPack(deletedEntity, tx)) {
+            if (ReadWrite.isResourceTypeInMetadataPack(deletedEntity, context.discriminator(), tx)) {
                 throw new IllegalArgumentException("Cannot delete a resource type that is part of a metadata pack. " +
                         "This would invalidate the meta data pack's identity.");
             }
@@ -245,11 +246,11 @@ public final class BaseResourceTypes {
 
         @Override
         public void preCreate(DataEntity.Blueprint blueprint, Transaction<BE> tx) {
-            BE pack = tx.querySingle(context.select().path().with(Related
+            BE pack = tx.querySingle(context.discriminator(), context.select().path().with(Related
                     .asTargetBy(incorporates), With.type(MetadataPack.class)).get());
 
             if (pack != null) {
-                BE rt = tx.querySingle(context.select().get());
+                BE rt = tx.querySingle(context.discriminator(), context.select().get());
                 throw new IllegalArgumentException(
                         "Data '" + blueprint.getId() + "' cannot be created" +
                                 " under resource type " + tx.extractCanonicalPath(rt) +
@@ -268,7 +269,7 @@ public final class BaseResourceTypes {
                 return;
             }
 
-            BE mp = tx.traverseToSingle(dataEntity, Query.path().with(
+            BE mp = tx.traverseToSingle(context.discriminator(), dataEntity, Query.path().with(
                     Related.asTargetBy(contains), //up to resource type
                     Related.asTargetBy(incorporates), With.type(MetadataPack.class) // up to the pack
             ).get());
@@ -292,12 +293,12 @@ public final class BaseResourceTypes {
             CanonicalPath dataPath = tx.extractCanonicalPath(dataEntity);
             BE rt = null;
             try {
-                rt = tx.find(dataPath.up());
+                rt = tx.find(context.discriminator(), dataPath.up());
             } catch (ElementNotFoundException e) {
                 Fetcher.throwNotFoundException(context);
             }
 
-            if (ReadWrite.isResourceTypeInMetadataPack(rt, tx)) {
+            if (ReadWrite.isResourceTypeInMetadataPack(rt, context.discriminator(), tx)) {
                 throw new IllegalArgumentException(
                         "Data '" + dataPath.getSegment().getElementId() + "' cannot be deleted" +
                                 " under resource type " + dataPath.up() +

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
@@ -83,7 +83,7 @@ public final class BaseResources {
                 CanonicalPath tenant = CanonicalPath.of().tenant(parentPath.ids().getTenantId()).get();
                 resourceTypePath = Util.canonicalize(blueprint.getResourceTypePath(), tenant,
                         parentPath, ResourceType.SEGMENT_TYPE);
-                resourceTypeObject = tx.find(resourceTypePath);
+                resourceTypeObject = tx.find(context.discriminator(), resourceTypePath);
             } catch (ElementNotFoundException e) {
                 throw new IllegalArgumentException("Resource type '" + blueprint.getResourceTypePath() + "' not found" +
                         " when resolved to '" + resourceTypePath + "' while trying to wire up a new resource on path '"
@@ -93,12 +93,12 @@ public final class BaseResources {
             //specifically do NOT check relationship rules, here because defines cannot be created "manually".
             //here we "know what we are doing" and need to create the defines relationship to capture the
             //contract of the resource.
-            BE r = tx.relate(resourceTypeObject, entity, defines.name(), null);
+            BE r = tx.relate(context.discriminator(), resourceTypeObject, entity, defines.name(), null);
 
             CanonicalPath entityPath = tx.extractCanonicalPath(entity);
             resourceTypePath = tx.extractCanonicalPath(resourceTypeObject);
 
-            ResourceType resourceType = tx.convert(resourceTypeObject, ResourceType.class);
+            ResourceType resourceType = tx.convert(context.discriminator(), resourceTypeObject, ResourceType.class);
 
             Resource ret = new Resource(blueprint.getName(), parentPath.extend(Resource.SEGMENT_TYPE,
                     tx.extractId(entity)).get(), null, null, null, resourceType, blueprint.getProperties());
@@ -114,8 +114,8 @@ public final class BaseResources {
                 //in here, we do use the relationship rules to check if the hierarchy we're introducing by this call
                 //conforms to the rules.
                 String relationshipName = isParentOf.name();
-                RelationshipRules.checkCreate(tx, parent, outgoing, relationshipName, entity);
-                r = tx.relate(parent, entity, relationshipName, null);
+                RelationshipRules.checkCreate(context.discriminator(), tx, parent, outgoing, relationshipName, entity);
+                r = tx.relate(context.discriminator(), parent, entity, relationshipName, null);
 
                 Relationship parentRel = new Relationship(tx.extractId(r), isParentOf.name(),
                         parentPath, entityPath);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseResources.java
@@ -43,6 +43,7 @@ import org.hawkular.inventory.api.model.Metric;
 import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.api.model.ResourceType;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.DataRole;
@@ -72,7 +73,7 @@ public final class BaseResources {
         }
 
         @Override
-        protected EntityAndPendingNotifications<BE, Resource> wireUpNewEntity(BE entity,
+        protected EntityAndPendingNotifications<BE, Resource> wireUpNewEntity(Discriminator discriminator, BE entity,
                                                                               Resource.Blueprint blueprint,
                                                                               CanonicalPath parentPath, BE parent,
                                                                               Transaction<BE> tx) {
@@ -83,7 +84,7 @@ public final class BaseResources {
                 CanonicalPath tenant = CanonicalPath.of().tenant(parentPath.ids().getTenantId()).get();
                 resourceTypePath = Util.canonicalize(blueprint.getResourceTypePath(), tenant,
                         parentPath, ResourceType.SEGMENT_TYPE);
-                resourceTypeObject = tx.find(context.discriminator(), resourceTypePath);
+                resourceTypeObject = tx.find(discriminator, resourceTypePath);
             } catch (ElementNotFoundException e) {
                 throw new IllegalArgumentException("Resource type '" + blueprint.getResourceTypePath() + "' not found" +
                         " when resolved to '" + resourceTypePath + "' while trying to wire up a new resource on path '"
@@ -93,12 +94,12 @@ public final class BaseResources {
             //specifically do NOT check relationship rules, here because defines cannot be created "manually".
             //here we "know what we are doing" and need to create the defines relationship to capture the
             //contract of the resource.
-            BE r = tx.relate(context.discriminator(), resourceTypeObject, entity, defines.name(), null);
+            BE r = tx.relate(discriminator, resourceTypeObject, entity, defines.name(), null);
 
             CanonicalPath entityPath = tx.extractCanonicalPath(entity);
             resourceTypePath = tx.extractCanonicalPath(resourceTypeObject);
 
-            ResourceType resourceType = tx.convert(context.discriminator(), resourceTypeObject, ResourceType.class);
+            ResourceType resourceType = tx.convert(discriminator, resourceTypeObject, ResourceType.class);
 
             Resource ret = new Resource(blueprint.getName(), parentPath.extend(Resource.SEGMENT_TYPE,
                     tx.extractId(entity)).get(), null, null, null, resourceType, blueprint.getProperties());
@@ -114,8 +115,8 @@ public final class BaseResources {
                 //in here, we do use the relationship rules to check if the hierarchy we're introducing by this call
                 //conforms to the rules.
                 String relationshipName = isParentOf.name();
-                RelationshipRules.checkCreate(context.discriminator(), tx, parent, outgoing, relationshipName, entity);
-                r = tx.relate(context.discriminator(), parent, entity, relationshipName, null);
+                RelationshipRules.checkCreate(discriminator, tx, parent, outgoing, relationshipName, entity);
+                r = tx.relate(discriminator, parent, entity, relationshipName, null);
 
                 Relationship parentRel = new Relationship(tx.extractId(r), isParentOf.name(),
                         parentPath, entityPath);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseTenants.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/BaseTenants.java
@@ -38,6 +38,7 @@ import org.hawkular.inventory.api.model.MetadataPack;
 import org.hawkular.inventory.api.model.MetricType;
 import org.hawkular.inventory.api.model.ResourceType;
 import org.hawkular.inventory.api.model.Tenant;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.Path;
 
@@ -64,7 +65,8 @@ public final class BaseTenants {
         }
 
         @Override
-        protected EntityAndPendingNotifications<BE, Tenant> wireUpNewEntity(BE entity, Tenant.Blueprint blueprint,
+        protected EntityAndPendingNotifications<BE, Tenant> wireUpNewEntity(Discriminator discriminator, BE entity,
+                                                                            Tenant.Blueprint blueprint,
                                                                             CanonicalPath parentPath, BE parent,
                                                                             Transaction<BE> tx) {
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingInventoryBackend.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingInventoryBackend.java
@@ -32,6 +32,7 @@ import org.hawkular.inventory.api.model.StructuredData;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
 import org.hawkular.inventory.base.spi.CommitFailureException;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
 import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.paths.CanonicalPath;
@@ -66,13 +67,13 @@ public class DelegatingInventoryBackend<E> implements InventoryBackend<E> {
     }
 
     @Override
-    public <T> T convert(E entityRepresentation, Class<T> entityType) {
-        return backend.convert(entityRepresentation, entityType);
+    public <T> T convert(Discriminator discriminator, E entityRepresentation, Class<T> entityType) {
+        return backend.convert(discriminator, entityRepresentation, entityType);
     }
 
     @Override
-    public void delete(E entity) {
-        backend.delete(entity);
+    public void markDeleted(Discriminator discriminator, E entity) {
+        backend.markDeleted(discriminator, entity);
     }
 
     @Override
@@ -81,8 +82,8 @@ public class DelegatingInventoryBackend<E> implements InventoryBackend<E> {
     }
 
     @Override
-    public E descendToData(E dataEntityRepresentation, RelativePath dataPath) {
-        return backend.descendToData(dataEntityRepresentation, dataPath);
+    public E descendToData(Discriminator discriminator, E dataEntityRepresentation, RelativePath dataPath) {
+        return backend.descendToData(discriminator, dataEntityRepresentation, dataPath);
     }
 
     @Override
@@ -91,16 +92,16 @@ public class DelegatingInventoryBackend<E> implements InventoryBackend<E> {
     }
 
     @Override
-    public String extractIdentityHash(E entityRepresentation) {
-        return backend.extractIdentityHash(entityRepresentation);
+    public String extractIdentityHash(Discriminator discriminator, E entityRepresentation) {
+        return backend.extractIdentityHash(discriminator, entityRepresentation);
     }
 
-    @Override public String extractContentHash(E entityRepresentation) {
-        return backend.extractContentHash(entityRepresentation);
+    @Override public String extractContentHash(Discriminator discriminator, E entityRepresentation) {
+        return backend.extractContentHash(discriminator, entityRepresentation);
     }
 
-    @Override public String extractSyncHash(E entityRepresentation) {
-        return backend.extractSyncHash(entityRepresentation);
+    @Override public String extractSyncHash(Discriminator discriminator, E entityRepresentation) {
+        return backend.extractSyncHash(discriminator, entityRepresentation);
     }
 
     @Override
@@ -119,70 +120,70 @@ public class DelegatingInventoryBackend<E> implements InventoryBackend<E> {
     }
 
     @Override
-    public E find(CanonicalPath element) throws ElementNotFoundException {
-        return backend.find(element);
+    public E find(Discriminator discriminator, CanonicalPath element) throws ElementNotFoundException {
+        return backend.find(discriminator, element);
     }
 
     @Override
-    public E querySingle(Query query) {
-        return backend.querySingle(query);
+    public E querySingle(Discriminator discriminator, Query query) {
+        return backend.querySingle(discriminator, query);
     }
 
     @Override
-    public E traverseToSingle(E startingPoint, Query query) {
-        return backend.traverseToSingle(startingPoint, query);
+    public E traverseToSingle(Discriminator discriminator, E startingPoint, Query query) {
+        return backend.traverseToSingle(discriminator, startingPoint, query);
     }
 
     @Override
-    public InputStream getGraphSON(String tenantId) {
-        return backend.getGraphSON(tenantId);
+    public InputStream getGraphSON(Discriminator discriminator, String tenantId) {
+        return backend.getGraphSON(discriminator, tenantId);
     }
 
     @Override
-    public E getRelationship(E source, E target, String relationshipName) throws ElementNotFoundException {
-        return backend.getRelationship(source, target, relationshipName);
+    public E getRelationship(Discriminator discriminator, E source, E target, String relationshipName) throws ElementNotFoundException {
+        return backend.getRelationship(discriminator, source, target, relationshipName);
     }
 
     @Override
-    public Set<E> getRelationships(E entity, Relationships.Direction direction,
+    public Set<E> getRelationships(Discriminator discriminator, E entity, Relationships.Direction direction,
                                    String... names) {
-        return backend.getRelationships(entity, direction, names);
+        return backend.getRelationships(discriminator, entity, direction, names);
     }
 
     @Override
-    public E getRelationshipSource(E relationship) {
-        return backend.getRelationshipSource(relationship);
+    public E getRelationshipSource(Discriminator discriminator, E relationship) {
+        return backend.getRelationshipSource(discriminator, relationship);
     }
 
     @Override
-    public E getRelationshipTarget(E relationship) {
-        return backend.getRelationshipTarget(relationship);
+    public E getRelationshipTarget(Discriminator discriminator, E relationship) {
+        return backend.getRelationshipTarget(discriminator, relationship);
     }
 
     @Override
     public <T extends Entity<?, ?>> Iterator<T> getTransitiveClosureOver(
-            CanonicalPath startingPoint,
+            Discriminator discriminator, CanonicalPath startingPoint,
             Relationships.Direction direction, Class<T> clazz,
             String... relationshipNames) {
-        return backend.getTransitiveClosureOver(startingPoint, direction, clazz, relationshipNames);
+        return backend.getTransitiveClosureOver(discriminator, startingPoint, direction, clazz, relationshipNames);
     }
 
     @Override
-    public Iterator<E> getTransitiveClosureOver(E startingPoint,
+    public Iterator<E> getTransitiveClosureOver(Discriminator discriminator, E startingPoint,
                                                 Relationships.Direction direction,
                                                 String... relationshipNames) {
-        return backend.getTransitiveClosureOver(startingPoint, direction, relationshipNames);
+        return backend.getTransitiveClosureOver(discriminator, startingPoint, direction, relationshipNames);
     }
 
     @Override
-    public boolean hasRelationship(E entity, Relationships.Direction direction,
+    public boolean hasRelationship(Discriminator discriminator, E entity, Relationships.Direction direction,
                                    String relationshipName) {
-        return backend.hasRelationship(entity, direction, relationshipName);
+        return backend.hasRelationship(discriminator, entity, direction, relationshipName);
     }
 
     @Override
-    public boolean hasRelationship(E source, E target, String relationshipName) {
-        return backend.hasRelationship(source, target, relationshipName);
+    public boolean hasRelationship(Discriminator discriminator, E source, E target, String relationshipName) {
+        return backend.hasRelationship(discriminator, source, target, relationshipName);
     }
 
     @Override
@@ -197,21 +198,21 @@ public class DelegatingInventoryBackend<E> implements InventoryBackend<E> {
     }
 
     @Override
-    public Page<E> query(Query query, Pager pager) {
-        return backend.query(query, pager);
+    public Page<E> query(Discriminator discriminator, Query query, Pager pager) {
+        return backend.query(discriminator, query, pager);
     }
 
     @Override
-    public <T> Page<T> query(Query query, Pager pager,
+    public <T> Page<T> query(Discriminator discriminator, Query query, Pager pager,
                              Function<E, T> conversion,
                              Function<T, Boolean> filter) {
-        return backend.query(query, pager, conversion, filter);
+        return backend.query(discriminator, query, pager, conversion, filter);
     }
 
     @Override
-    public E relate(E sourceEntity, E targetEntity, String name,
+    public E relate(Discriminator discriminator, E sourceEntity, E targetEntity, String name,
                     Map<String, Object> properties) {
-        return backend.relate(sourceEntity, targetEntity, name, properties);
+        return backend.relate(discriminator, sourceEntity, targetEntity, name, properties);
     }
 
     @Override
@@ -230,18 +231,18 @@ public class DelegatingInventoryBackend<E> implements InventoryBackend<E> {
     }
 
     @Override
-    public Page<E> traverse(E startingPoint, Query query,
+    public Page<E> traverse(Discriminator discriminator, E startingPoint, Query query,
                             Pager pager) {
-        return backend.traverse(startingPoint, query, pager);
+        return backend.traverse(discriminator, startingPoint, query, pager);
     }
 
     @Override
-    public void update(E entity, AbstractElement.Update update) {
-        backend.update(entity, update);
+    public void update(Discriminator discriminator, E entity, AbstractElement.Update update) {
+        backend.update(discriminator, entity, update);
     }
 
-    @Override public void updateHashes(E entity, Hashes hashes) {
-        backend.updateHashes(entity, hashes);
+    @Override public void updateHashes(Discriminator discriminator, E entity, Hashes hashes) {
+        backend.updateHashes(discriminator, entity, hashes);
     }
 
     @Override
@@ -251,5 +252,9 @@ public class DelegatingInventoryBackend<E> implements InventoryBackend<E> {
 
     @Override public boolean requiresRollbackAfterFailure(Throwable t) {
         return backend.requiresRollbackAfterFailure(t);
+    }
+
+    @Override public void eradicate(E entity) {
+        backend.eradicate(entity);
     }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingInventoryBackend.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingInventoryBackend.java
@@ -19,7 +19,6 @@ package org.hawkular.inventory.base;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -36,7 +35,7 @@ import org.hawkular.inventory.api.paging.Pager;
 import org.hawkular.inventory.base.spi.CommitFailureException;
 import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
-import org.hawkular.inventory.base.spi.EntityStateChange;
+import org.hawkular.inventory.base.spi.EntityHistory;
 import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.RelativePath;
@@ -262,7 +261,7 @@ public class DelegatingInventoryBackend<E> implements InventoryBackend<E> {
     }
 
     @Override public <T extends Entity<?, U>, U extends Entity.Update>
-    List<EntityStateChange<T>> getHistory(E entity, Class<T> entityType, Instant from, Instant to) {
+    EntityHistory<T> getHistory(E entity, Class<T> entityType, Instant from, Instant to) {
         return backend.getHistory(entity, entityType, from, to);
     }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingInventoryBackend.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingInventoryBackend.java
@@ -187,9 +187,9 @@ public class DelegatingInventoryBackend<E> implements InventoryBackend<E> {
     }
 
     @Override
-    public E persist(CanonicalPath path,
+    public E persist(Discriminator discriminator, CanonicalPath path,
                      Blueprint blueprint) {
-        return backend.persist(path, blueprint);
+        return backend.persist(discriminator, path, blueprint);
     }
 
     @Override

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingInventoryBackend.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingInventoryBackend.java
@@ -17,7 +17,9 @@
 package org.hawkular.inventory.base;
 
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -34,6 +36,7 @@ import org.hawkular.inventory.api.paging.Pager;
 import org.hawkular.inventory.base.spi.CommitFailureException;
 import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
+import org.hawkular.inventory.base.spi.EntityStateChange;
 import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.RelativePath;
@@ -256,5 +259,10 @@ public class DelegatingInventoryBackend<E> implements InventoryBackend<E> {
 
     @Override public void eradicate(E entity) {
         backend.eradicate(entity);
+    }
+
+    @Override public <T extends Entity<?, U>, U extends Entity.Update>
+    List<EntityStateChange<T>> getHistory(E entity, Class<T> entityType, Instant from, Instant to) {
+        return backend.getHistory(entity, entityType, from, to);
     }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingTransaction.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingTransaction.java
@@ -159,9 +159,9 @@ public class DelegatingTransaction<E> implements Transaction<E> {
         return tx.isUniqueIndexSupported();
     }
 
-    @Override public E persist(CanonicalPath path,
+    @Override public E persist(Discriminator discriminator, CanonicalPath path,
                                Blueprint blueprint) {
-        return tx.persist(path, blueprint);
+        return tx.persist(discriminator, path, blueprint);
     }
 
     @Override public E persist(StructuredData structuredData) {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingTransaction.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingTransaction.java
@@ -19,7 +19,6 @@ package org.hawkular.inventory.base;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -35,7 +34,7 @@ import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
 import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
-import org.hawkular.inventory.base.spi.EntityStateChange;
+import org.hawkular.inventory.base.spi.EntityHistory;
 import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.RelativePath;
@@ -218,7 +217,7 @@ public class DelegatingTransaction<E> implements Transaction<E> {
     }
 
     @Override public <T extends Entity<?, U>, U extends Entity.Update>
-    List<EntityStateChange<T>> getHistory(E entity, Class<T> entityType, Instant from, Instant to) {
+    EntityHistory<T> getHistory(E entity, Class<T> entityType, Instant from, Instant to) {
         return tx.getHistory(entity, entityType, from, to);
     }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingTransaction.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingTransaction.java
@@ -17,7 +17,9 @@
 package org.hawkular.inventory.base;
 
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -33,6 +35,7 @@ import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
 import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
+import org.hawkular.inventory.base.spi.EntityStateChange;
 import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.RelativePath;
@@ -212,5 +215,10 @@ public class DelegatingTransaction<E> implements Transaction<E> {
 
     @Override public boolean requiresRollbackAfterFailure(Throwable t) {
         return tx.requiresRollbackAfterFailure(t);
+    }
+
+    @Override public <T extends Entity<?, U>, U extends Entity.Update>
+    List<EntityStateChange<T>> getHistory(E entity, Class<T> entityType, Instant from, Instant to) {
+        return tx.getHistory(entity, entityType, from, to);
     }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingTransaction.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/DelegatingTransaction.java
@@ -31,6 +31,7 @@ import org.hawkular.inventory.api.model.Hashes;
 import org.hawkular.inventory.api.model.StructuredData;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
 import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.paths.CanonicalPath;
@@ -47,24 +48,28 @@ public class DelegatingTransaction<E> implements Transaction<E> {
         this.tx = tx;
     }
 
-    @Override public <T> T convert(E entityRepresentation, Class<T> entityType) {
-        return tx.convert(entityRepresentation, entityType);
+    @Override public <T> T convert(Discriminator discriminator, E entityRepresentation, Class<T> entityType) {
+        return tx.convert(discriminator, entityRepresentation, entityType);
     }
 
-    @Override public void delete(E entity) {
-        tx.delete(entity);
+    @Override public void markDeleted(Discriminator discriminator, E entity) {
+        tx.markDeleted(discriminator, entity);
     }
 
     @Override public void deleteStructuredData(E dataRepresentation) {
         tx.deleteStructuredData(dataRepresentation);
     }
 
-    @Override public E descendToData(E dataEntityRepresentation, RelativePath dataPath) {
-        return tx.descendToData(dataEntityRepresentation, dataPath);
+    @Override public E descendToData(Discriminator discriminator, E dataEntityRepresentation, RelativePath dataPath) {
+        return tx.descendToData(discriminator, dataEntityRepresentation, dataPath);
     }
 
     @Override public InventoryBackend<E> directAccess() {
         return tx.directAccess();
+    }
+
+    @Override public void eradicate(E entityRepresentation) {
+        tx.eradicate(entityRepresentation);
     }
 
     @Override public CanonicalPath extractCanonicalPath(E entityRepresentation) {
@@ -75,16 +80,16 @@ public class DelegatingTransaction<E> implements Transaction<E> {
         return tx.extractId(entityRepresentation);
     }
 
-    @Override public String extractIdentityHash(E entityRepresentation) {
-        return tx.extractIdentityHash(entityRepresentation);
+    @Override public String extractIdentityHash(Discriminator discriminator, E entityRepresentation) {
+        return tx.extractIdentityHash(discriminator, entityRepresentation);
     }
 
-    @Override public String extractContentHash(E entityRepresentation) {
-        return tx.extractContentHash(entityRepresentation);
+    @Override public String extractContentHash(Discriminator discriminator, E entityRepresentation) {
+        return tx.extractContentHash(discriminator, entityRepresentation);
     }
 
-    @Override public String extractSyncHash(E entityRepresentation) {
-        return tx.extractSyncHash(entityRepresentation);
+    @Override public String extractSyncHash(Discriminator discriminator, E entityRepresentation) {
+        return tx.extractSyncHash(discriminator, entityRepresentation);
     }
 
     @Override public String extractRelationshipName(E relationship) {
@@ -95,55 +100,55 @@ public class DelegatingTransaction<E> implements Transaction<E> {
         return tx.extractType(entityRepresentation);
     }
 
-    @Override public E find(CanonicalPath element) throws ElementNotFoundException {
-        return tx.find(element);
+    @Override public E find(Discriminator discriminator, CanonicalPath element) throws ElementNotFoundException {
+        return tx.find(discriminator, element);
     }
 
-    @Override public InputStream getGraphSON(String tenantId) {
-        return tx.getGraphSON(tenantId);
+    @Override public InputStream getGraphSON(Discriminator discriminator, String tenantId) {
+        return tx.getGraphSON(discriminator, tenantId);
     }
 
     @Override public PreCommit<E> getPreCommit() {
         return tx.getPreCommit();
     }
 
-    @Override public E getRelationship(E source, E target, String relationshipName) throws ElementNotFoundException {
-        return tx.getRelationship(source, target, relationshipName);
+    @Override public E getRelationship(Discriminator discriminator, E source, E target, String relationshipName) throws ElementNotFoundException {
+        return tx.getRelationship(discriminator, source, target, relationshipName);
     }
 
-    @Override public Set<E> getRelationships(E entity, Relationships.Direction direction,
+    @Override public Set<E> getRelationships(Discriminator discriminator, E entity, Relationships.Direction direction,
                                              String... names) {
-        return tx.getRelationships(entity, direction, names);
+        return tx.getRelationships(discriminator, entity, direction, names);
     }
 
-    @Override public E getRelationshipSource(E relationship) {
-        return tx.getRelationshipSource(relationship);
+    @Override public E getRelationshipSource(Discriminator discriminator, E relationship) {
+        return tx.getRelationshipSource(discriminator, relationship);
     }
 
-    @Override public E getRelationshipTarget(E relationship) {
-        return tx.getRelationshipTarget(relationship);
+    @Override public E getRelationshipTarget(Discriminator discriminator, E relationship) {
+        return tx.getRelationshipTarget(discriminator, relationship);
     }
 
     @Override public <T extends Entity<?, ?>> Iterator<T> getTransitiveClosureOver(
-            CanonicalPath startingPoint,
+            Discriminator discriminator, CanonicalPath startingPoint,
             Relationships.Direction direction, Class<T> clazz,
             String... relationshipNames) {
-        return tx.getTransitiveClosureOver(startingPoint, direction, clazz, relationshipNames);
+        return tx.getTransitiveClosureOver(discriminator, startingPoint, direction, clazz, relationshipNames);
     }
 
-    @Override public Iterator<E> getTransitiveClosureOver(E startingPoint,
+    @Override public Iterator<E> getTransitiveClosureOver(Discriminator discriminator, E startingPoint,
                                                           Relationships.Direction direction,
                                                           String... relationshipNames) {
-        return tx.getTransitiveClosureOver(startingPoint, direction, relationshipNames);
+        return tx.getTransitiveClosureOver(discriminator, startingPoint, direction, relationshipNames);
     }
 
-    @Override public boolean hasRelationship(E entity, Relationships.Direction direction,
+    @Override public boolean hasRelationship(Discriminator discriminator, E entity, Relationships.Direction direction,
                                              String relationshipName) {
-        return tx.hasRelationship(entity, direction, relationshipName);
+        return tx.hasRelationship(discriminator, entity, direction, relationshipName);
     }
 
-    @Override public boolean hasRelationship(E source, E target, String relationshipName) {
-        return tx.hasRelationship(source, target, relationshipName);
+    @Override public boolean hasRelationship(Discriminator discriminator, E source, E target, String relationshipName) {
+        return tx.hasRelationship(discriminator, source, target, relationshipName);
     }
 
     @Override public boolean isBackendInternal(E element) {
@@ -163,46 +168,46 @@ public class DelegatingTransaction<E> implements Transaction<E> {
         return tx.persist(structuredData);
     }
 
-    @Override public Page<E> query(Query query,
+    @Override public Page<E> query(Discriminator discriminator, Query query,
                                    Pager pager) {
-        return tx.query(query, pager);
+        return tx.query(discriminator, query, pager);
     }
 
-    @Override public <T> Page<T> query(Query query,
+    @Override public <T> Page<T> query(Discriminator discriminator, Query query,
                                        Pager pager,
                                        Function<E, T> conversion,
                                        Function<T, Boolean> filter) {
-        return tx.query(query, pager, conversion, filter);
+        return tx.query(discriminator, query, pager, conversion, filter);
     }
 
-    @Override public E querySingle(Query query) {
-        return tx.querySingle(query);
+    @Override public E querySingle(Discriminator discriminator, Query query) {
+        return tx.querySingle(discriminator, query);
     }
 
     @Override public void registerCommittedPayload(TransactionPayload.Committing<?, E> committedPayload) {
         tx.registerCommittedPayload(committedPayload);
     }
 
-    @Override public E relate(E sourceEntity, E targetEntity, String name,
+    @Override public E relate(Discriminator discriminator, E sourceEntity, E targetEntity, String name,
                               Map<String, Object> properties) {
-        return tx.relate(sourceEntity, targetEntity, name, properties);
+        return tx.relate(discriminator, sourceEntity, targetEntity, name, properties);
     }
 
-    @Override public Page<E> traverse(E startingPoint, Query query,
+    @Override public Page<E> traverse(Discriminator discriminator, E startingPoint, Query query,
                                       Pager pager) {
-        return tx.traverse(startingPoint, query, pager);
+        return tx.traverse(discriminator, startingPoint, query, pager);
     }
 
-    @Override public E traverseToSingle(E startingPoint, Query query) {
-        return tx.traverseToSingle(startingPoint, query);
+    @Override public E traverseToSingle(Discriminator discriminator, E startingPoint, Query query) {
+        return tx.traverseToSingle(discriminator, startingPoint, query);
     }
 
-    @Override public void update(E entity, AbstractElement.Update update) {
-        tx.update(entity, update);
+    @Override public void update(Discriminator discriminator, E entity, AbstractElement.Update update) {
+        tx.update(discriminator, entity, update);
     }
 
-    @Override public void updateHashes(E entity, Hashes hashes) {
-        tx.updateHashes(entity, hashes);
+    @Override public void updateHashes(Discriminator discriminator, E entity, Hashes hashes) {
+        tx.updateHashes(discriminator, entity, hashes);
     }
 
     @Override public boolean requiresRollbackAfterFailure(Throwable t) {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Fetcher.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Fetcher.java
@@ -16,6 +16,9 @@
  */
 package org.hawkular.inventory.base;
 
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Function;
 
 import org.hawkular.inventory.api.EntityNotFoundException;
@@ -24,6 +27,7 @@ import org.hawkular.inventory.api.RelationNotFoundException;
 import org.hawkular.inventory.api.ResolvableToMany;
 import org.hawkular.inventory.api.ResolvableToSingle;
 import org.hawkular.inventory.api.model.AbstractElement;
+import org.hawkular.inventory.api.model.Change;
 import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
@@ -87,13 +91,24 @@ abstract class Fetcher<BE, E extends AbstractElement<?, U>, U extends AbstractEl
     }
 
     @Override
-    public void delete() {
+    public void delete(Instant time) {
+        //TODO implement
+        useCachedEntity = false;
+        context.setCreatedEntity(null);
+    }
+
+    @Override public void eradicate() {
         inTx(tx -> {
             Util.delete(context.entityClass, tx, context.select().get(), this::preDelete, this::postDelete);
             return null;
         });
         useCachedEntity = false;
         context.setCreatedEntity(null);
+    }
+
+    @Override public List<Change<E, ?>> history() {
+        //TODO implement
+        return Collections.emptyList();
     }
 
     @Override

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Fetcher.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Fetcher.java
@@ -92,14 +92,19 @@ abstract class Fetcher<BE, E extends AbstractElement<?, U>, U extends AbstractEl
 
     @Override
     public void delete() {
-        //TODO implement
+        inTx(tx -> {
+            Util.delete(context.discriminator(), context.entityClass, tx, context.select().get(), this::preDelete,
+                    this::postDelete, false);
+            return null;
+        });
         useCachedEntity = false;
         context.setCreatedEntity(null);
     }
 
     @Override public void eradicate() {
         inTx(tx -> {
-            Util.delete(context.discriminator(), context.entityClass, tx, context.select().get(), this::preDelete, this::postDelete);
+            Util.delete(context.discriminator(), context.entityClass, tx, context.select().get(), this::preDelete,
+                    this::postDelete, true);
             return null;
         });
         useCachedEntity = false;

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Fetcher.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Fetcher.java
@@ -16,9 +16,6 @@
  */
 package org.hawkular.inventory.base;
 
-import java.time.Instant;
-import java.util.Collections;
-import java.util.List;
 import java.util.function.Function;
 
 import org.hawkular.inventory.api.EntityNotFoundException;
@@ -27,7 +24,6 @@ import org.hawkular.inventory.api.RelationNotFoundException;
 import org.hawkular.inventory.api.ResolvableToMany;
 import org.hawkular.inventory.api.ResolvableToSingle;
 import org.hawkular.inventory.api.model.AbstractElement;
-import org.hawkular.inventory.api.model.Change;
 import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
@@ -109,11 +105,6 @@ abstract class Fetcher<BE, E extends AbstractElement<?, U>, U extends AbstractEl
         });
         useCachedEntity = false;
         context.setCreatedEntity(null);
-    }
-
-    @Override public List<Change<E, ?>> history(Instant from, Instant to) {
-        //TODO implement
-        return Collections.emptyList();
     }
 
     @Override

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Fetcher.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Fetcher.java
@@ -74,13 +74,13 @@ abstract class Fetcher<BE, E extends AbstractElement<?, U>, U extends AbstractEl
             throws EntityNotFoundException, RelationNotFoundException {
 
         return inTx(tx -> {
-            BE result = tx.querySingle(context.select().get());
+            BE result = tx.querySingle(context.discriminator(), context.select().get());
 
             if (result == null) {
                 throwNotFoundException();
             }
 
-            E entity = tx.convert(result, context.entityClass);
+            E entity = tx.convert(context.discriminator(), result, context.entityClass);
 
             if (!isApplicable(entity)) {
                 throwNotFoundException();
@@ -91,7 +91,7 @@ abstract class Fetcher<BE, E extends AbstractElement<?, U>, U extends AbstractEl
     }
 
     @Override
-    public void delete(Instant time) {
+    public void delete() {
         //TODO implement
         useCachedEntity = false;
         context.setCreatedEntity(null);
@@ -99,14 +99,14 @@ abstract class Fetcher<BE, E extends AbstractElement<?, U>, U extends AbstractEl
 
     @Override public void eradicate() {
         inTx(tx -> {
-            Util.delete(context.entityClass, tx, context.select().get(), this::preDelete, this::postDelete);
+            Util.delete(context.discriminator(), context.entityClass, tx, context.select().get(), this::preDelete, this::postDelete);
             return null;
         });
         useCachedEntity = false;
         context.setCreatedEntity(null);
     }
 
-    @Override public List<Change<E, ?>> history() {
+    @Override public List<Change<E, ?>> history(Instant from, Instant to) {
         //TODO implement
         return Collections.emptyList();
     }
@@ -114,7 +114,8 @@ abstract class Fetcher<BE, E extends AbstractElement<?, U>, U extends AbstractEl
     @Override
     public void update(U u) throws EntityNotFoundException, RelationNotFoundException {
         inTx(tx -> {
-            Util.update(context.entityClass, tx, context.select().get(), u, this::preUpdate, this::postUpdate);
+            Util.update(context.discriminator(), context.entityClass, tx, context.select().get(), u, this::preUpdate, this::postUpdate
+            );
             return null;
         });
 
@@ -185,13 +186,13 @@ abstract class Fetcher<BE, E extends AbstractElement<?, U>, U extends AbstractEl
     protected <T> Page<T> loadEntities(Pager pager, EntityConvertor<BE, E, T> conversionFunction) {
         return inCommittableTx(tx -> {
             Function<BE, Pair<BE, E>> conversion =
-                    (e) -> new Pair<>(e, tx.convert(e, context.entityClass));
+                    (e) -> new Pair<>(e, tx.convert(context.discriminator(), e, context.entityClass));
 
             Function<Pair<BE, E>, Boolean> filter = context.configuration.getResultFilter() == null ? null :
                     (p) -> context.configuration.getResultFilter().isApplicable(p.second);
 
             Page<Pair<BE, E>> intermediate =
-                    tx.<Pair<BE, E>>query(context.select().get(), pager, conversion, filter);
+                    tx.<Pair<BE, E>>query(context.discriminator(), context.select().get(), pager, conversion, filter);
 
             return new TransformingPage<Pair<BE, E>, T>(intermediate,
                     (p) -> conversionFunction.convert(p.first, p.second, tx)) {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Mutator.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Mutator.java
@@ -22,7 +22,6 @@ import static org.hawkular.inventory.api.Relationships.Direction.outgoing;
 import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
 import static org.hawkular.inventory.api.filters.With.id;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -194,11 +193,11 @@ abstract class Mutator<BE, E extends Entity<?, U>, B extends Blueprint, U extend
         });
     }
 
-    public final void delete(Id id, Instant time) throws EntityNotFoundException {
-        //TODO implement
+    public final void delete(Id id) throws EntityNotFoundException {
         inTx(tx -> {
             Query q = id == null ? context.select().get() : context.select().with(id(id.toString())).get();
-            Util.delete(context.discriminator(), context.entityClass, tx, q, (e, t) -> preDelete(id, e, t), this::postDelete);
+            Util.delete(context.discriminator(), context.entityClass, tx, q, (e, t) -> preDelete(id, e, t),
+                    this::postDelete, false);
             return null;
         });
     }
@@ -206,7 +205,8 @@ abstract class Mutator<BE, E extends Entity<?, U>, B extends Blueprint, U extend
     public final void eradicate(Id id) throws EntityNotFoundException {
         inTx(tx -> {
             Query q = id == null ? context.select().get() : context.select().with(id(id.toString())).get();
-            Util.delete(context.discriminator(), context.entityClass, tx, q, (e, t) -> preDelete(id, e, t), this::postDelete);
+            Util.delete(context.discriminator(), context.entityClass, tx, q, (e, t) -> preDelete(id, e, t),
+                    this::postDelete, true);
             return null;
         });
     }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Mutator.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Mutator.java
@@ -22,6 +22,7 @@ import static org.hawkular.inventory.api.Relationships.Direction.outgoing;
 import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
 import static org.hawkular.inventory.api.filters.With.id;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -192,7 +193,16 @@ abstract class Mutator<BE, E extends Entity<?, U>, B extends Blueprint, U extend
         });
     }
 
-    public final void delete(Id id) throws EntityNotFoundException {
+    public final void delete(Id id, Instant time) throws EntityNotFoundException {
+        //TODO implement
+        inTx(tx -> {
+            Query q = id == null ? context.select().get() : context.select().with(id(id.toString())).get();
+            Util.delete(context.entityClass, tx, q, (e, t) -> preDelete(id, e, t), this::postDelete);
+            return null;
+        });
+    }
+
+    public final void eradicate(Id id) throws EntityNotFoundException {
         inTx(tx -> {
             Query q = id == null ? context.select().get() : context.select().with(id(id.toString())).get();
             Util.delete(context.entityClass, tx, q, (e, t) -> preDelete(id, e, t), this::postDelete);

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/SingleEntityFetcher.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/SingleEntityFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,8 +18,15 @@ package org.hawkular.inventory.base;
 
 import static org.hawkular.inventory.api.Relationships.Direction.outgoing;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hawkular.inventory.api.Action;
 import org.hawkular.inventory.api.Relationships;
+import org.hawkular.inventory.api.model.Change;
 import org.hawkular.inventory.api.model.Entity;
+import org.hawkular.inventory.base.spi.EntityStateChange;
 
 /**
  * Base for {@code *Single} implementations on entities.
@@ -31,6 +38,58 @@ class SingleEntityFetcher<BE, E extends Entity<?, U>, U extends Entity.Update>
         extends Fetcher<BE, E, U> {
     public SingleEntityFetcher(TraversalContext<BE, E> context) {
         super(context);
+    }
+
+
+    public List<Change<E, ?>> history(Instant from, Instant to) {
+        List<EntityStateChange<E>> changes = inTx(tx -> {
+            BE myEntity = tx.querySingle(context.discriminator(), context.select().get());
+
+            return tx.getHistory(myEntity, context.entityClass, from, to);
+        });
+
+        List<Change<E, ?>> ret = new ArrayList<>(changes.size());
+
+        boolean first = true;
+        int processed = 0;
+        Action.Enumerated created = Action.Enumerated.CREATED;
+        Action.Enumerated updated = Action.Enumerated.UPDATED;
+        Action.Enumerated deleted = Action.Enumerated.DELETED;
+
+        for (EntityStateChange<E> ch : changes) {
+            Action.Enumerated chAction = ch.getAction().asEnum();
+
+            if (chAction == updated) {
+                if (first && (processed == 0
+                        || changes.size() > processed && changes.get(processed).getAction().asEnum() == deleted)) {
+                    //the backend actually might represent a create immediatelly followed by delete as an update
+                    //followed by delete.
+                    ret.add(new Change<>(ch.getOccurrenceTime(), Action.created(), ch.getEntity(), ch.getEntity()));
+                } else {
+                    //k, ordinary update... we need to compute the update object from the previous and current state
+                    E previous = changes.get(processed - 1).getEntity();
+                    E current = ch.getEntity();
+
+                    //casting fun to overcome the imperfect typing of the update() method
+                    @SuppressWarnings({"unchecked", "rawtypes"})
+                    U update = (U) ((Entity.Updater) previous.update()).to(current);
+
+                    ret.add(new Change<E, Action.Update<E, U>>(ch.getOccurrenceTime(), Action.updated(),
+                            new Action.Update<>(previous, update), previous));
+                }
+                first = false;
+            } else if (chAction == created) {
+                ret.add(new Change<>(ch.getOccurrenceTime(), Action.created(), ch.getEntity(), ch.getEntity()));
+                first = false;
+            } else {
+                ret.add(new Change<>(ch.getOccurrenceTime(), Action.deleted(), ch.getEntity(), ch.getEntity()));
+                first = true; //the next change will be understood as a create, i.e. the first state in that
+                              //incarnation of the entity
+            }
+            processed++;
+        }
+
+        return ret;
     }
 
     public Relationships.ReadWrite relationships() {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/SingleSyncedFetcher.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/SingleSyncedFetcher.java
@@ -83,7 +83,7 @@ import org.hawkular.inventory.paths.SegmentType;
 abstract class SingleSyncedFetcher<BE, E extends Entity<B, U> & Syncable, B extends Entity.Blueprint,
         U extends Entity.Update>
         extends SingleEntityFetcher<BE, E, U>
-        implements Synced.SingleWithRelationships<E, B, U> {
+        implements Synced.SingleEntity<E, B, U> {
 
     SingleSyncedFetcher(TraversalContext<BE, E> context) {
         super(context);
@@ -382,7 +382,8 @@ abstract class SingleSyncedFetcher<BE, E extends Entity<B, U> & Syncable, B exte
                 return fillCommon(ResourceType.Update.builder(), type).build();
             }
 
-            private <UU extends Entity.Update, Bld extends Entity.Update.Builder<UU, Bld>>
+            private <EE extends Entity<?, UU>, UU extends Entity.Update,
+                    Bld extends Entity.Update.Builder<EE, UU, Bld>>
             Bld fillCommon(Bld bld, Entity.Blueprint bl) {
                 if (bl.getProperties() != null) {
                     bld.withProperties(bl.getProperties());

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/SingleSyncedFetcher.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/SingleSyncedFetcher.java
@@ -91,7 +91,7 @@ abstract class SingleSyncedFetcher<BE, E extends Entity<B, U> & Syncable, B exte
 
     @Override public void synchronize(SyncRequest<B> syncRequest) {
         inTx(tx -> {
-            BE root = tx.querySingle(context.select().get());
+            BE root = tx.querySingle(context.discriminator(), context.select().get());
 
             boolean rootFullyInitialized = true;
             if (root == null) {
@@ -251,7 +251,7 @@ abstract class SingleSyncedFetcher<BE, E extends Entity<B, U> & Syncable, B exte
                 SyncHash.Tree update = e.getValue();
                 CanonicalPath childCp = update.getPath().applyTo(root);
                 try {
-                    BE child = tx.find(childCp);
+                    BE child = tx.find(context.discriminator(), childCp);
                     syncTrees(tx, root, child, oldChild, update, newStructure);
                 } catch (ElementNotFoundException ex) {
                     Log.LOGGER.debug("Failed to find entity on " + childCp + " that we thought was there. Never mind " +
@@ -393,8 +393,8 @@ abstract class SingleSyncedFetcher<BE, E extends Entity<B, U> & Syncable, B exte
     }
 
     private Map.Entry<InventoryStructure<B>, SyncHash.Tree> treeHashAndStructure(Transaction<BE> tx) {
-        BE root = tx.querySingle(context.select().get());
-        E entity = tx.convert(root, context.entityClass);
+        BE root = tx.querySingle(context.discriminator(), context.select().get());
+        E entity = tx.convert(context.discriminator(), root, context.entityClass);
 
         SyncHash.Tree.Builder bld = SyncHash.Tree.builder();
         InventoryStructure.Builder<B> structBld = InventoryStructure.of(Inventory.asBlueprint(entity));
@@ -402,11 +402,11 @@ abstract class SingleSyncedFetcher<BE, E extends Entity<B, U> & Syncable, B exte
         bld.withPath(RelativePath.empty().get()).withHash(entity.getSyncHash());
 
         //the closure is returned in a breadth-first manner
-        Iterator<BE> closure = tx.getTransitiveClosureOver(root, outgoing, contains.name());
+        Iterator<BE> closure = tx.getTransitiveClosureOver(context.discriminator(), root, outgoing, contains.name());
 
         if (closure.hasNext()) {
             Function<BE, Entity<? extends Entity.Blueprint, ?>> convert =
-                    e -> (Entity<Entity.Blueprint, ?>) tx.convert(e, tx.extractType(e));
+                    e -> (Entity<Entity.Blueprint, ?>) tx.convert(context.discriminator(), e, tx.extractType(e));
             Stream<BE> st = StreamSupport.stream(Spliterators.spliteratorUnknownSize(closure, 0), false);
             Iterator<Entity<? extends Entity.Blueprint, ?>> entities = st.map(convert).iterator();
 
@@ -564,7 +564,7 @@ abstract class SingleSyncedFetcher<BE, E extends Entity<B, U> & Syncable, B exte
                     }
 
                     @Override public Mutator<BE, ?, ?, ?, String> visitData(Void parameter) {
-                        BE parent = tx.querySingle(context.previous.sourcePath);
+                        BE parent = tx.querySingle(context.discriminator(), context.previous.sourcePath);
                         if (parent == null) {
                             throw new EntityNotFoundException(Query.filters(context.previous.sourcePath));
                         }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Transaction.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Transaction.java
@@ -36,6 +36,7 @@ import org.hawkular.inventory.api.model.StructuredData;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
 import org.hawkular.inventory.base.spi.CommitFailureException;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
 import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.paths.CanonicalPath;
@@ -77,54 +78,56 @@ public interface Transaction<E> {
 
     PreCommit<E> getPreCommit();
 
-    <T> T convert(E entityRepresentation, Class<T> entityType);
+    <T> T convert(Discriminator discriminator, E entityRepresentation, Class<T> entityType);
 
-    void delete(E entity);
+    void markDeleted(Discriminator discriminator, E entity);
 
     void deleteStructuredData(E dataRepresentation);
 
-    E descendToData(E dataEntityRepresentation, RelativePath dataPath);
+    E descendToData(Discriminator discriminator, E dataEntityRepresentation, RelativePath dataPath);
+
+    void eradicate(E entityRepresentation);
 
     CanonicalPath extractCanonicalPath(E entityRepresentation);
 
     String extractId(E entityRepresentation);
 
-    String extractIdentityHash(E entityRepresentation);
+    String extractIdentityHash(Discriminator discriminator, E entityRepresentation);
 
-    String extractContentHash(E entityRepresentation);
+    String extractContentHash(Discriminator discriminator, E entityRepresentation);
 
-    String extractSyncHash(E entityRepresentation);
+    String extractSyncHash(Discriminator discriminator, E entityRepresentation);
 
     String extractRelationshipName(E relationship);
 
     Class<?> extractType(E entityRepresentation);
 
-    E find(CanonicalPath element) throws ElementNotFoundException;
+    E find(Discriminator discriminator, CanonicalPath element) throws ElementNotFoundException;
 
-    InputStream getGraphSON(String tenantId);
+    InputStream getGraphSON(Discriminator discriminator, String tenantId);
 
-    E getRelationship(E source, E target, String relationshipName) throws ElementNotFoundException;
+    E getRelationship(Discriminator discriminator, E source, E target, String relationshipName) throws ElementNotFoundException;
 
-    Set<E> getRelationships(E entity, Relationships.Direction direction,
+    Set<E> getRelationships(Discriminator discriminator, E entity, Relationships.Direction direction,
                             String... names);
 
-    E getRelationshipSource(E relationship);
+    E getRelationshipSource(Discriminator discriminator, E relationship);
 
-    E getRelationshipTarget(E relationship);
+    E getRelationshipTarget(Discriminator discriminator, E relationship);
 
     <T extends Entity<?, ?>> Iterator<T> getTransitiveClosureOver(
-            CanonicalPath startingPoint,
+            Discriminator discriminator, CanonicalPath startingPoint,
             Relationships.Direction direction, Class<T> clazz,
             String... relationshipNames);
 
-    Iterator<E> getTransitiveClosureOver(E startingPoint,
+    Iterator<E> getTransitiveClosureOver(Discriminator discriminator, E startingPoint,
                                          Relationships.Direction direction,
                                          String... relationshipNames);
 
-    boolean hasRelationship(E entity, Relationships.Direction direction,
+    boolean hasRelationship(Discriminator discriminator, E entity, Relationships.Direction direction,
                             String relationshipName);
 
-    boolean hasRelationship(E source, E target, String relationshipName);
+    boolean hasRelationship(Discriminator discriminator, E source, E target, String relationshipName);
 
     boolean isBackendInternal(E element);
 
@@ -135,27 +138,27 @@ public interface Transaction<E> {
 
     E persist(StructuredData structuredData);
 
-    Page<E> query(Query query,
+    Page<E> query(Discriminator discriminator, Query query,
                   Pager pager);
 
-    <T> Page<T> query(Query query,
+    <T> Page<T> query(Discriminator discriminator, Query query,
                       Pager pager,
                       Function<E, T> conversion,
                       Function<T, Boolean> filter);
 
-    E querySingle(Query query);
+    E querySingle(Discriminator discriminator, Query query);
 
-    E relate(E sourceEntity, E targetEntity, String name,
+    E relate(Discriminator discriminator, E sourceEntity, E targetEntity, String name,
              Map<String, Object> properties);
 
-    Page<E> traverse(E startingPoint, Query query,
+    Page<E> traverse(Discriminator discriminator, E startingPoint, Query query,
                      Pager pager);
 
-    E traverseToSingle(E startingPoint, Query query);
+    E traverseToSingle(Discriminator discriminator, E startingPoint, Query query);
 
-    void update(E entity, AbstractElement.Update update);
+    void update(Discriminator discriminator, E entity, AbstractElement.Update update);
 
-    void updateHashes(E entity, Hashes hashes);
+    void updateHashes(Discriminator discriminator, E entity, Hashes hashes);
 
     /**
      * Checks the exception thrown during the commit and returns true if the backend requires explicit rollback after

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Transaction.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Transaction.java
@@ -17,6 +17,7 @@
 package org.hawkular.inventory.base;
 
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -133,7 +134,7 @@ public interface Transaction<E> {
 
     boolean isUniqueIndexSupported();
 
-    E persist(CanonicalPath path,
+    E persist(Discriminator discriminator, CanonicalPath path,
               Blueprint blueprint);
 
     E persist(StructuredData structuredData);
@@ -185,8 +186,9 @@ public interface Transaction<E> {
          *
          * @param inventory the inventory to use, it is bound to the provided transaction
          * @param tx the transaction for which this pre-commit is defined
+         * @param txStart the time the transaction has started
          */
-        void initialize(Inventory inventory, Transaction<E> tx);
+        void initialize(Inventory inventory, Transaction<E> tx, Instant txStart);
 
         /**
          * Resets all the internal structures as to the initialized state.
@@ -231,10 +233,12 @@ public interface Transaction<E> {
             private List<Consumer<Transaction<E>>> actions = new ArrayList<>();
             protected Transaction<E> transaction;
             protected Inventory inventory;
+            protected Instant txStart;
 
-            @Override public void initialize(Inventory inventory, Transaction<E> tx) {
+            @Override public void initialize(Inventory inventory, Transaction<E> tx, Instant txStart) {
                 this.inventory = inventory;
                 this.transaction = tx;
+                this.txStart = txStart;
             }
 
             @Override public void reset() {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Transaction.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Transaction.java
@@ -187,12 +187,10 @@ public interface Transaction<E> {
 
         /**
          * Initializes this pre-commit using the inventory and/or the backend.
-         *
-         * @param inventory the inventory to use, it is bound to the provided transaction
+         *  @param inventory the inventory to use, it is bound to the provided transaction
          * @param tx the transaction for which this pre-commit is defined
-         * @param txStart the time the transaction has started
          */
-        void initialize(Inventory inventory, Transaction<E> tx, Instant txStart);
+        void initialize(Inventory inventory, Transaction<E> tx);
 
         /**
          * Resets all the internal structures as to the initialized state.
@@ -237,12 +235,10 @@ public interface Transaction<E> {
             private List<Consumer<Transaction<E>>> actions = new ArrayList<>();
             protected Transaction<E> transaction;
             protected Inventory inventory;
-            protected Instant txStart;
 
-            @Override public void initialize(Inventory inventory, Transaction<E> tx, Instant txStart) {
+            @Override public void initialize(Inventory inventory, Transaction<E> tx) {
                 this.inventory = inventory;
                 this.transaction = tx;
-                this.txStart = txStart;
             }
 
             @Override public void reset() {

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Transaction.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Transaction.java
@@ -39,6 +39,7 @@ import org.hawkular.inventory.api.paging.Pager;
 import org.hawkular.inventory.base.spi.CommitFailureException;
 import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
+import org.hawkular.inventory.base.spi.EntityStateChange;
 import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.RelativePath;
@@ -171,6 +172,9 @@ public interface Transaction<E> {
     default boolean requiresRollbackAfterFailure(Throwable t) {
         return true;
     }
+
+    <T extends Entity<?, U>, U extends Entity.Update>
+    List<EntityStateChange<T>> getHistory(E entity, Class<T> entityType, Instant from, Instant to);
 
     interface PreCommit<E> {
         /**

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Transaction.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Transaction.java
@@ -39,7 +39,7 @@ import org.hawkular.inventory.api.paging.Pager;
 import org.hawkular.inventory.base.spi.CommitFailureException;
 import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
-import org.hawkular.inventory.base.spi.EntityStateChange;
+import org.hawkular.inventory.base.spi.EntityHistory;
 import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.RelativePath;
@@ -174,7 +174,7 @@ public interface Transaction<E> {
     }
 
     <T extends Entity<?, U>, U extends Entity.Update>
-    List<EntityStateChange<T>> getHistory(E entity, Class<T> entityType, Instant from, Instant to);
+    EntityHistory<T> getHistory(E entity, Class<T> entityType, Instant from, Instant to);
 
     interface PreCommit<E> {
         /**

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Traversal.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Traversal.java
@@ -60,7 +60,7 @@ public abstract class Traversal<BE, E extends AbstractElement<?, ?>> {
      * @throws EntityNotFoundException if the query doesn't return any results
      */
     protected BE getSingle(Query query, SegmentType entityType) {
-        return inTx(tx -> Util.getSingle(tx, query, entityType));
+        return inTx(tx -> Util.getSingle(context.discriminator(), tx, query, entityType));
     }
 
     /**

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TraversalContext.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TraversalContext.java
@@ -377,7 +377,7 @@ public final class TraversalContext<BE, E extends AbstractElement<?, ?>> {
 
     Transaction<BE> startTransaction(Transaction.PreCommit<BE> preCommit) {
         Transaction<BE> tx = transactionConstructor.construct(backend, preCommit);
-        tx.getPreCommit().initialize(inventory.keepTransaction(tx), tx, now);
+        tx.getPreCommit().initialize(inventory.keepTransaction(tx), tx);
         return tx;
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TraversalContext.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TraversalContext.java
@@ -23,6 +23,8 @@ import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.function.BiConsumer;
 
+import javax.annotation.Nullable;
+
 import org.hawkular.inventory.api.Action;
 import org.hawkular.inventory.api.Configuration;
 import org.hawkular.inventory.api.Parents;
@@ -265,7 +267,26 @@ public final class TraversalContext<BE, E extends AbstractElement<?, ?>> {
     }
 
     Discriminator discriminator() {
-        return Discriminator.time(now);
+        return Discriminator.time(now());
+    }
+
+    /**
+     * If this context was explicitly set up to operate at a certain point in time, return that, otherwise just return
+     * the "true" current time.
+     *
+     * @return a "now"
+     */
+    Instant now() {
+        return now == null ? Instant.now() : now;
+    }
+
+    /**
+     * Returns the point in time to operate at or null if no such time was set up.
+     *
+     * @return a "now"
+     */
+    @Nullable  Instant declaredNow() {
+        return now;
     }
 
     /**
@@ -356,7 +377,7 @@ public final class TraversalContext<BE, E extends AbstractElement<?, ?>> {
 
     Transaction<BE> startTransaction(Transaction.PreCommit<BE> preCommit) {
         Transaction<BE> tx = transactionConstructor.construct(backend, preCommit);
-        tx.getPreCommit().initialize(inventory.keepTransaction(tx), tx);
+        tx.getPreCommit().initialize(inventory.keepTransaction(tx), tx, now);
         return tx;
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TraversalContext.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TraversalContext.java
@@ -267,17 +267,7 @@ public final class TraversalContext<BE, E extends AbstractElement<?, ?>> {
     }
 
     Discriminator discriminator() {
-        return Discriminator.time(now());
-    }
-
-    /**
-     * If this context was explicitly set up to operate at a certain point in time, return that, otherwise just return
-     * the "true" current time.
-     *
-     * @return a "now"
-     */
-    Instant now() {
-        return now == null ? Instant.now() : now;
+        return now == null ? Discriminator.latest() : Discriminator.time(now);
     }
 
     /**
@@ -285,7 +275,7 @@ public final class TraversalContext<BE, E extends AbstractElement<?, ?>> {
      *
      * @return a "now"
      */
-    @Nullable  Instant declaredNow() {
+    @Nullable Instant declaredNow() {
         return now;
     }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TraversalContext.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/TraversalContext.java
@@ -34,6 +34,7 @@ import org.hawkular.inventory.api.filters.SwitchElementType;
 import org.hawkular.inventory.api.model.AbstractElement;
 import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.model.Relationship;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.paths.Path;
 
@@ -261,6 +262,10 @@ public final class TraversalContext<BE, E extends AbstractElement<?, ?>> {
     TraversalContext<BE, E> at(Instant time) {
         return new TraversalContext<>(inventory, time, sourcePath, Query.empty(), backend, entityClass, configuration,
                 observableContext, transactionRetries, this, null, transactionConstructor);
+    }
+
+    Discriminator discriminator() {
+        return Discriminator.time(now);
     }
 
     /**

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Util.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/Util.java
@@ -45,6 +45,7 @@ import org.hawkular.inventory.api.filters.With;
 import org.hawkular.inventory.api.model.AbstractElement;
 import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.base.spi.CommitFailureException;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.ElementNotFoundException;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.Path;
@@ -160,9 +161,9 @@ final class Util {
         throw new TransactionFailureException(lastException, failures);
     }
 
-    public static <BE> BE getSingle(Transaction<BE> backend, Query query,
+    public static <BE> BE getSingle(Discriminator discriminator, Transaction<BE> backend, Query query,
                                     SegmentType entityType) {
-        BE result = backend.querySingle(query);
+        BE result = backend.querySingle(discriminator, query);
         if (result == null) {
             throw new EntityNotFoundException(entityType, Query.filters(query));
         }
@@ -171,66 +172,66 @@ final class Util {
     }
 
     public static <BE> EntityAndPendingNotifications<BE, Relationship>
-    createAssociation(Transaction<BE> tx, BE source, String relationship, BE target, Map<String, Object> properties) {
+    createAssociation(Discriminator discriminator, Transaction<BE> tx, BE source, String relationship, BE target, Map<String, Object> properties) {
 
-        if (tx.hasRelationship(source, target, relationship)) {
+        if (tx.hasRelationship(discriminator, source, target, relationship)) {
             throw new RelationAlreadyExistsException(relationship, Query.filters(Query.to(tx.extractCanonicalPath
                     (source))));
         }
 
-        RelationshipRules.checkCreate(tx, source, Relationships.Direction.outgoing, relationship,
+        RelationshipRules.checkCreate(discriminator, tx, source, Relationships.Direction.outgoing, relationship,
                 target);
-        BE relationshipObject = tx.relate(source, target, relationship, properties);
+        BE relationshipObject = tx.relate(discriminator, source, target, relationship, properties);
 
-        Relationship ret = tx.convert(relationshipObject, Relationship.class);
+        Relationship ret = tx.convert(discriminator, relationshipObject, Relationship.class);
 
         return new EntityAndPendingNotifications<>(relationshipObject, ret,
                 new Notification<>(ret, ret, created()));
     }
 
     public static <BE> EntityAndPendingNotifications<BE, Relationship>
-    deleteAssociation(Transaction<BE> tx, Query sourceQuery, SegmentType sourceType,
+    deleteAssociation(Discriminator discriminator, Transaction<BE> tx, Query sourceQuery, SegmentType sourceType,
                       String relationship, BE target) {
 
-        BE source = getSingle(tx, sourceQuery, sourceType);
+        BE source = getSingle(discriminator, tx, sourceQuery, sourceType);
 
         BE relationshipObject;
 
         try {
-            relationshipObject = tx.getRelationship(source, target, relationship);
+            relationshipObject = tx.getRelationship(discriminator, source, target, relationship);
         } catch (ElementNotFoundException e) {
             throw new RelationNotFoundException(sourceType, relationship, Query.filters(sourceQuery),
                     null, e);
         }
 
-        RelationshipRules.checkDelete(tx, source, Relationships.Direction.outgoing, relationship,
+        RelationshipRules.checkDelete(discriminator, tx, source, Relationships.Direction.outgoing, relationship,
                 target);
 
-        Relationship ret = tx.convert(relationshipObject, Relationship.class);
+        Relationship ret = tx.convert(discriminator, relationshipObject, Relationship.class);
 
-        tx.delete(relationshipObject);
+        tx.markDeleted(discriminator, relationshipObject);
 
         return new EntityAndPendingNotifications<>(relationshipObject, ret,
                 new Notification<>(ret, ret, deleted()));
     }
 
-    public static <BE> Relationship getAssociation(Transaction<BE> tx, Query sourceQuery,
+    public static <BE> Relationship getAssociation(Discriminator discriminator, Transaction<BE> tx, Query sourceQuery,
                                                    SegmentType sourceType, Query targetQuery,
                                                    SegmentType targetType,
                                                    String rel) {
 
-        BE source = getSingle(tx, sourceQuery, sourceType);
-        BE target = getSingle(tx, targetQuery, targetType);
+        BE source = getSingle(discriminator, tx, sourceQuery, sourceType);
+        BE target = getSingle(discriminator, tx, targetQuery, targetType);
 
         BE relationship;
         try {
-            relationship = tx.getRelationship(source, target, rel);
+            relationship = tx.getRelationship(discriminator, source, target, rel);
         } catch (ElementNotFoundException e) {
             throw new RelationNotFoundException(sourceType, rel, Query.filters(sourceQuery),
                     null, null);
         }
 
-        return tx.convert(relationship, Relationship.class);
+        return tx.convert(discriminator, relationship, Relationship.class);
     }
 
     @SuppressWarnings("unchecked")
@@ -255,18 +256,18 @@ final class Util {
      * @throws ElementNotFoundException if the element is not found
      */
     @SuppressWarnings("unchecked")
-    public static <BE> BE find(Transaction<BE> tx, Query sourcePath, Path path) throws
+    public static <BE> BE find(Discriminator discriminator, Transaction<BE> tx, Query sourcePath, Path path) throws
             EntityNotFoundException {
         BE element;
         if (path.isCanonical()) {
             try {
-                element = tx.find(path.toCanonicalPath());
+                element = tx.find(discriminator, path.toCanonicalPath());
             } catch (ElementNotFoundException e) {
                 throw new EntityNotFoundException("Entity not found on path: " + path);
             }
         } else {
             Query query = queryTo(sourcePath, path);
-            element = getSingle(tx, query, null);
+            element = getSingle(discriminator, tx, query, null);
         }
         return element;
     }
@@ -284,12 +285,12 @@ final class Util {
 
     @SuppressWarnings("unchecked")
     public static <BE, E extends AbstractElement<?, U>, U extends AbstractElement.Update> void update(
-            Class<E> entityClass,
+            Discriminator discriminator, Class<E> entityClass,
             Transaction<BE> tx, Query entityQuery, U update,
             TransactionParticipant<BE, U> preUpdateCheck,
             BiConsumer<BE, Transaction<BE>> postUpdateCheck) {
 
-        BE entity = tx.querySingle(entityQuery);
+        BE entity = tx.querySingle(discriminator, entityQuery);
         if (entity == null) {
             if (update instanceof Relationship.Update) {
                 throw new RelationNotFoundException((String) null, Query.filters(entityQuery));
@@ -302,15 +303,15 @@ final class Util {
             preUpdateCheck.execute(entity, update, tx);
         }
 
-        E orig = tx.convert(entity, entityClass);
+        E orig = tx.convert(discriminator, entity, entityClass);
 
-        tx.update(entity, update);
+        tx.update(discriminator, entity, update);
 
         if (postUpdateCheck != null) {
             postUpdateCheck.accept(entity, tx);
         }
 
-        E updated = tx.convert(entity, entityClass);
+        E updated = tx.convert(discriminator, entity, entityClass);
 
         tx.getPreCommit().addNotifications(new EntityAndPendingNotifications<>(entity, updated,
                 new Action.Update<>(orig, update), Action.updated()));
@@ -318,11 +319,11 @@ final class Util {
 
     @SuppressWarnings("unchecked")
     public static <BE, E extends AbstractElement<?, ?>>
-    void delete(Class<E> entityClass, Transaction<BE> tx, Query entityQuery,
+    void delete(Discriminator discriminator, Class<E> entityClass, Transaction<BE> tx, Query entityQuery,
                 BiConsumer<BE, Transaction<BE>> cleanupFunction,
                 BiConsumer<BE, Transaction<BE>> postDelete) {
 
-        BE entity = tx.querySingle(entityQuery);
+        BE entity = tx.querySingle(discriminator, entityQuery);
         if (entity == null) {
             if (entityClass.equals(Relationship.class)) {
                 throw new RelationNotFoundException((String) null, Query.filters(entityQuery));
@@ -342,27 +343,27 @@ final class Util {
         Set<BE> deletedRels = new HashSet<>();
 
         Consumer<BE> categorizer = (e) -> {
-            if (tx.hasRelationship(e, outgoing, defines.name())) {
+            if (tx.hasRelationship(discriminator, e, outgoing, defines.name())) {
                 verticesToDeleteThatDefineSomething.add(e);
             } else {
                 deleted.add(e);
             }
             //not only the entity, but also its relationships are going to disappear
-            deletedRels.addAll(tx.getRelationships(e, both));
+            deletedRels.addAll(tx.getRelationships(discriminator, e, both));
 
-            tx.getRelationships(e, outgoing, hasData.name()).forEach(rel -> {
-                dataToBeDeleted.add(tx.getRelationshipTarget(rel));
+            tx.getRelationships(discriminator, e, outgoing, hasData.name()).forEach(rel -> {
+                dataToBeDeleted.add(tx.getRelationshipTarget(discriminator, rel));
             });
         };
 
         categorizer.accept(entity);
-        tx.getTransitiveClosureOver(entity, outgoing, contains.name())
+        tx.getTransitiveClosureOver(discriminator, entity, outgoing, contains.name())
                 .forEachRemaining(categorizer::accept);
 
         //we've gathered all entities to be deleted. Now record the notifications to be sent out when the transaction
         //commits.
         Consumer<BE> addNotification = be -> {
-            AbstractElement<?, ?> e = tx.convert(be, (Class<AbstractElement<?, ?>>) tx.extractType(be));
+            AbstractElement<?, ?> e = tx.convert(discriminator, be, (Class<AbstractElement<?, ?>>) tx.extractType(be));
             tx.getPreCommit().addNotifications(new EntityAndPendingNotifications<>(be, e, deleted()));
         };
 
@@ -373,11 +374,11 @@ final class Util {
 
         //k, now we can delete them all... the order is not important anymore
         for (BE e : deleted) {
-            tx.delete(e);
+            tx.markDeleted(discriminator, e);
         }
 
         for (BE e : verticesToDeleteThatDefineSomething) {
-            if (tx.hasRelationship(e, outgoing, defines.name())) {
+            if (tx.hasRelationship(discriminator, e, outgoing, defines.name())) {
                 //we avoid the convert() function here because it assumes the containing entities of the passed in
                 //entity exist. This might not be true during the delete because the transitive closure "walks" the
                 //entities from the "top" down the containment chain and the entities are immediately deleted.
@@ -394,7 +395,7 @@ final class Util {
                         "entities that are not deleted along with it, which would leave them without a " +
                         "definition. This is illegal.");
             } else {
-                tx.delete(e);
+                tx.markDeleted(discriminator, e);
             }
         }
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/Discriminator.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/Discriminator.java
@@ -14,19 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.inventory.api;
+package org.hawkular.inventory.base.spi;
 
-import org.hawkular.inventory.api.model.AbstractElement;
+import java.time.Instant;
 
 /**
- * Base interface of all browser interfaces over a single entity that can have relations.
- *
- * @param <Entity> the type of the entity being browsed
+ * A discriminator is basically a global filter on any request to an inventory backend.
  *
  * @author Lukas Krejci
- * @author Jirka Kremser
- * @since 0.0.1
+ * @since 0.19.0
  */
-public interface ResolvableToSingleWithRelationships<Entity extends AbstractElement<?, ?>, Update>
-        extends ResolvableToSingle<Entity, Update>, Relatable<Relationships.ReadWrite> {
+public final class Discriminator {
+    private final Instant time;
+
+    public static Discriminator time(Instant time) {
+        return new Discriminator(time);
+    }
+
+    private Discriminator(Instant time) {
+        this.time = time;
+    }
+
+    public Instant getTime() {
+        return time;
+    }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/Discriminator.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/Discriminator.java
@@ -27,9 +27,14 @@ import java.time.Instant;
 public final class Discriminator {
     private final Instant time;
     private final boolean preferExistence;
+    private final boolean queryLatest;
 
     public static Discriminator time(Instant time) {
         return new Discriminator(time, true);
+    }
+
+    public static Discriminator latest() {
+        return new Discriminator(null, true);
     }
 
     public static Discriminator timeExcludingMillisecondDeletes(Instant time) {
@@ -37,12 +42,17 @@ public final class Discriminator {
     }
 
     private Discriminator(Instant time, boolean preferExistence) {
-        this.time = time;
+        this.time = time == null ? Instant.now() : time;
         this.preferExistence = preferExistence;
+        this.queryLatest = time == null;
     }
 
     public Instant getTime() {
         return time;
+    }
+
+    public boolean isQueryLatest() {
+        return queryLatest;
     }
 
     /**

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/Discriminator.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/Discriminator.java
@@ -26,16 +26,36 @@ import java.time.Instant;
  */
 public final class Discriminator {
     private final Instant time;
+    private final boolean preferExistence;
 
     public static Discriminator time(Instant time) {
-        return new Discriminator(time);
+        return new Discriminator(time, true);
     }
 
-    private Discriminator(Instant time) {
+    public static Discriminator timeExcludingMillisecondDeletes(Instant time) {
+        return new Discriminator(time, false);
+    }
+
+    private Discriminator(Instant time, boolean preferExistence) {
         this.time = time;
+        this.preferExistence = preferExistence;
     }
 
     public Instant getTime() {
         return time;
+    }
+
+    /**
+     * Depending on situation, once may want to include states that were created and ended within a millisecond in some
+     * sort of results or not.
+     *
+     * @return whether to include sub-millisecond changes in results (true) or not (false).
+     */
+    public boolean isPreferExistence() {
+        return preferExistence;
+    }
+
+    public Discriminator excludeDeletedInMillisecond() {
+        return new Discriminator(time, false);
     }
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/EntityHistory.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/EntityHistory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.base.spi;
+
+import java.util.List;
+
+import org.hawkular.inventory.api.model.Entity;
+
+/**
+ * Represents a series of changes in the history of an entity.
+ *
+ * @author Lukas Krejci
+ * @since 0.20.0
+ */
+public final class EntityHistory<E extends Entity<?, ?>> {
+    private final List<EntityStateChange<E>> changes;
+    private final E initialState;
+
+    public EntityHistory(List<EntityStateChange<E>> changes, E initialState) {
+        this.changes = changes;
+        this.initialState = initialState;
+    }
+
+    public List<EntityStateChange<E>> getChanges() {
+        return changes;
+    }
+
+    public E getInitialState() {
+        return initialState;
+    }
+
+    @Override public String toString() {
+        final StringBuilder sb = new StringBuilder("EntityHistory[");
+        sb.append("changes=").append(changes);
+        sb.append(", initialState=").append(initialState);
+        sb.append(']');
+        return sb.toString();
+    }
+}

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/EntityStateChange.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/EntityStateChange.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.base.spi;
+
+import java.time.Instant;
+
+import org.hawkular.inventory.api.Action;
+import org.hawkular.inventory.api.model.Entity;
+
+/**
+ * Represents a change of a state of an entity. This is a simpler, internal representation of the
+ * {@link org.hawkular.inventory.api.model.Change} API class.
+ *
+ * @author Lukas Krejci
+ * @since 0.20.0
+ */
+public final class EntityStateChange<E extends Entity<?, ?>> implements Comparable<EntityStateChange<E>> {
+    private final Action<?, E> action;
+    private final E entity;
+    private final Instant occurrenceTime;
+
+    public EntityStateChange(Action<?, E> action, E entity, Instant occurrenceTime) {
+        this.action = action;
+        this.entity = entity;
+        this.occurrenceTime = occurrenceTime;
+    }
+
+    public Action<?, E> getAction() {
+        return action;
+    }
+
+    public E getEntity() {
+        return entity;
+    }
+
+    public Instant getOccurrenceTime() {
+        return occurrenceTime;
+    }
+
+    @Override public int compareTo(EntityStateChange<E> o) {
+        int ret = occurrenceTime.compareTo(o.getOccurrenceTime());
+
+        if (ret == 0) {
+            ret = action.asEnum().compareTo(o.getAction().asEnum());
+        }
+
+        if (ret == 0) {
+            return entity.getPath().toString().compareTo(o.entity.getPath().toString());
+        }
+
+        return ret;
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        EntityStateChange<?> that = (EntityStateChange<?>) o;
+
+        if (!action.equals(that.action)) return false;
+        if (!entity.equals(that.entity)) return false;
+        return occurrenceTime.equals(that.occurrenceTime);
+
+    }
+
+    @Override public int hashCode() {
+        int result = action.hashCode();
+        result = 31 * result + entity.hashCode();
+        result = 31 * result + occurrenceTime.hashCode();
+        return result;
+    }
+
+    @Override public String toString() {
+        final StringBuilder sb = new StringBuilder("EntityStateChange[");
+        sb.append("action=").append(action.asEnum());
+        sb.append(", entity=").append(entity);
+        sb.append(", occurrenceTime=").append(occurrenceTime);
+        sb.append(']');
+        return sb.toString();
+    }
+
+
+}

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InconsistenStateException.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InconsistenStateException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.base.spi;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.19.0
+ */
+public class InconsistenStateException extends RuntimeException {
+    public InconsistenStateException() {
+    }
+
+    public InconsistenStateException(String message) {
+        super(message);
+    }
+
+    public InconsistenStateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InconsistenStateException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InventoryBackend.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InventoryBackend.java
@@ -19,7 +19,6 @@ package org.hawkular.inventory.base.spi;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -408,8 +407,8 @@ public interface InventoryBackend<E> extends AutoCloseable {
      *
      * @param from from when to return the changes
      * @param to to when to return the changes
-     * @return a sorted map keyed by the time of the changes occurrences, where values are the converted entities
+     * @return a history object containing the changes made to the entity in the given time-frame.
      */
     <T extends Entity<?, U>, U extends Entity.Update>
-    List<EntityStateChange<T>> getHistory(E entity, Class<T> entityType, Instant from, Instant to);
+    EntityHistory<T> getHistory(E entity, Class<T> entityType, Instant from, Instant to);
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InventoryBackend.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InventoryBackend.java
@@ -342,8 +342,11 @@ public interface InventoryBackend<E> extends AutoCloseable {
     /**
      * Simply marks the entity as deleted.
      *
+     * <p>Must fail if there was any update to the entity after the time specified by the discriminator.
+     *
      * @param discriminator the discriminator to apply on the query
      * @param entity the entity to delete
+     * @throws IllegalArgumentException if there was an update after the designated time
      */
     void markDeleted(Discriminator discriminator, E entity);
 

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InventoryBackend.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InventoryBackend.java
@@ -17,7 +17,9 @@
 package org.hawkular.inventory.base.spi;
 
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -397,4 +399,14 @@ public interface InventoryBackend<E> extends AutoCloseable {
     default boolean requiresRollbackAfterFailure(Throwable t) {
         return true;
     }
+
+    /**
+     * Lists the changes of the entity. Note that this is not supported for edges...
+     *
+     * @param from from when to return the changes
+     * @param to to when to return the changes
+     * @return a sorted map keyed by the time of the changes occurrences, where values are the converted entities
+     */
+    <T extends Entity<?, U>, U extends Entity.Update>
+    List<EntityStateChange<T>> getHistory(E entity, Class<T> entityType, Instant from, Instant to);
 }

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InventoryBackend.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/InventoryBackend.java
@@ -301,11 +301,13 @@ public interface InventoryBackend<E> extends AutoCloseable {
     /**
      * Persists a new entity with the provided assigned path.
      *
+     *
+     * @param discriminator
      * @param path      the canonical path to the entity
      * @param blueprint the blueprint of the entity
      * @return the representation object of the newly created entity
      */
-    E persist(CanonicalPath path, Blueprint blueprint);
+    E persist(Discriminator discriminator, CanonicalPath path, Blueprint blueprint);
 
     /**
      * Persists the structured data and returns a reference to it. It is the responsibility of the caller to wire it up

--- a/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/ShallowStructuredData.java
+++ b/hawkular-inventory-api/src/main/java/org/hawkular/inventory/base/spi/ShallowStructuredData.java
@@ -24,7 +24,7 @@ import org.hawkular.inventory.paths.RelativePath;
  * doesn't contain the potential children (see for example
  * {@link org.hawkular.inventory.api.Data.Single#flatData(RelativePath)}).
  *
- * <p>When calling {@link InventoryBackend#convert(Object, Class)}, with {@link StructuredData}, the whole structured
+ * <p>When calling {@link InventoryBackend#convert(Discriminator, Object, Class)}, with {@link StructuredData}, the whole structured
  * data is loaded. On the other hand calling it with {@code ShallowStructuredData} will make the convert method not load
  * the potential children of the structured data.
  *

--- a/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryTestsuite.java
+++ b/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryTestsuite.java
@@ -91,6 +91,7 @@ import org.hawkular.inventory.api.feeds.AcceptWithFallbackFeedIdStrategy;
 import org.hawkular.inventory.api.feeds.RandomUUIDFeedIdStrategy;
 import org.hawkular.inventory.api.filters.Defined;
 import org.hawkular.inventory.api.filters.Filter;
+import org.hawkular.inventory.api.filters.RecurseFilter;
 import org.hawkular.inventory.api.filters.Related;
 import org.hawkular.inventory.api.filters.RelationWith;
 import org.hawkular.inventory.api.filters.SwitchElementType;
@@ -3041,6 +3042,19 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
                     "com.acme.tenant".equals(e.getId())));
         } finally {
             backend.rollback();
+        }
+    }
+
+    @Test
+    public void testRecurseFilter() throws Exception {
+        Query q = Query.path()
+                .with(With.path(CanonicalPath.of().tenant("com.acme.tenant").feed("feed1").get()))
+                .with(RecurseFilter.builder().addChain(Related.by(contains)).build())
+                .with(With.type(Metric.class))
+                .get();
+
+        try (Page<Metric> results = inventory.execute(q, Metric.class, Pager.none())) {
+            Assert.assertEquals(2, results.getTotalSize());
         }
     }
 

--- a/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryTestsuite.java
+++ b/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryTestsuite.java
@@ -3754,7 +3754,7 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
 
             ts.update(update);
 
-            List<Change<Tenant, ?>> cs = ts.history();
+            List<Change<Tenant>> cs = ts.history();
 
             Assert.assertEquals(4, cs.size());
 

--- a/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryTestsuite.java
+++ b/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryTestsuite.java
@@ -43,6 +43,7 @@ import static org.hawkular.inventory.paths.DataRole.ResourceType.configurationSc
 import static org.hawkular.inventory.paths.DataRole.ResourceType.connectionConfigurationSchema;
 
 import java.io.FileInputStream;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -120,6 +121,7 @@ import org.hawkular.inventory.api.paging.Order;
 import org.hawkular.inventory.api.paging.Page;
 import org.hawkular.inventory.api.paging.Pager;
 import org.hawkular.inventory.base.BaseInventory;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.DataRole;
@@ -571,6 +573,10 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
      */
     protected abstract BaseInventory<E> getInventoryForTest();
 
+    protected static Discriminator now() {
+        return Discriminator.time(Instant.now());
+    }
+
     @Before
     public final void setupData() throws Exception {
         inventory = getInventoryForTest();
@@ -584,7 +590,7 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
 
             InventoryBackend<E> bcknd = inventory.getBackend().startTransaction();
             try {
-                Page<E> results = bcknd.query(query, Pager.unlimited(Order.unspecified()));
+                Page<E> results = bcknd.query(now(), query, Pager.unlimited(Order.unspecified()));
 
                 Assert.assertTrue(results.hasNext());
 
@@ -610,7 +616,7 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
 
         InventoryBackend<E> bcknd = inventory.getBackend().startTransaction();
         try {
-            Page<E> results = bcknd.query(query, Pager.unlimited(Order.unspecified()));
+            Page<E> results = bcknd.query(now(), query, Pager.unlimited(Order.unspecified()));
 
             Assert.assertTrue(results.hasNext());
             results.next();
@@ -637,12 +643,12 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
                 testHelper = (numberOfParents -> parentType -> edgeLabel -> numberOfKids -> childType ->
                 multipleParents -> multipleChildren -> {
 
-                    Page<E> parents = inTx.apply(b -> b.query(Query.path().with(type(parentType)).get(),
+                    Page<E> parents = inTx.apply(b -> b.query(now(), Query.path().with(type(parentType)).get(),
                             Pager.unlimited(Order.unspecified())));
 
                     List<E> parentsList = parents.toList();
 
-                    Page<E> children = inTx.apply(b -> b.query(Query.path().with(type(parentType),
+                    Page<E> children = inTx.apply(b -> b.query(now(), Query.path().with(type(parentType),
                             by(edgeLabel), type(childType)).get(), Pager.unlimited(Order.unspecified())));
 
                     List<E> childrenList = children.toList();
@@ -904,11 +910,11 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
 
             InventoryBackend<E> bcknd = inventory.getBackend().startTransaction();
             try {
-                Page<E> envs = bcknd.query(q, Pager.unlimited(Order.unspecified()));
+                Page<E> envs = bcknd.query(now(), q, Pager.unlimited(Order.unspecified()));
 
                 Assert.assertTrue(envs.hasNext());
 
-                env = inventory.getBackend().convert(envs.next(), Environment.class);
+                env = bcknd.convert(now(), envs.next(), Environment.class);
                 Assert.assertTrue(!envs.hasNext());
                 Assert.assertEquals(id, env.getId());
             } finally {
@@ -926,7 +932,7 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
 
         InventoryBackend<E> bcknd = inventory.getBackend().startTransaction();
         try {
-            Assert.assertEquals(2, bcknd.query(q, Pager.unlimited(Order.unspecified())).toList().size());
+            Assert.assertEquals(2, bcknd.query(now(), q, Pager.unlimited(Order.unspecified())).toList().size());
         } finally {
             bcknd.rollback();
         }
@@ -941,7 +947,7 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
 
             InventoryBackend<E> bcknd = inventory.getBackend().startTransaction();
             try {
-                Page<?> results = bcknd.query(query, Pager.unlimited(Order.unspecified()));
+                Page<?> results = bcknd.query(now(), query, Pager.unlimited(Order.unspecified()));
 
                 Assert.assertTrue(results.hasNext());
             } finally {
@@ -962,7 +968,7 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
         Query query = Query.path().with(type(ResourceType.class)).get();
         InventoryBackend<E> bcknd = inventory.getBackend().startTransaction();
         try {
-            Assert.assertEquals(6, bcknd.query(query, Pager.unlimited(Order.unspecified())).toList()
+            Assert.assertEquals(6, bcknd.query(now(), query, Pager.unlimited(Order.unspecified())).toList()
                     .size());
         } finally {
             bcknd.rollback();
@@ -978,7 +984,7 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
 
             InventoryBackend<E> bcknd = inventory.getBackend().startTransaction();
             try {
-                assert bcknd.query(query, Pager.unlimited(Order.unspecified())).hasNext();
+                assert bcknd.query(now(), query, Pager.unlimited(Order.unspecified())).hasNext();
             } finally {
                 bcknd.rollback();
             }
@@ -995,7 +1001,7 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
         Query query = Query.path().with(type(MetricType.class)).get();
         InventoryBackend<E> bcknd = inventory.getBackend().startTransaction();
         try {
-            Assert.assertEquals(4, bcknd.query(query, Pager.unlimited(Order.unspecified())).toList()
+            Assert.assertEquals(4, bcknd.query(now(), query, Pager.unlimited(Order.unspecified())).toList()
                     .size());
         } finally {
             bcknd.rollback();
@@ -1012,7 +1018,7 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
 
             InventoryBackend<E> bcknd = inventory.getBackend().startTransaction();
             try {
-                assert bcknd.query(q, Pager.unlimited(Order.unspecified())).hasNext();
+                assert bcknd.query(now(), q, Pager.unlimited(Order.unspecified())).hasNext();
             } finally {
                 bcknd.rollback();
             }
@@ -1051,7 +1057,7 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
 
         InventoryBackend<E> bcknd = inventory.getBackend().startTransaction();
         try {
-            Assert.assertEquals(5, bcknd.query(Query.path().with(type(Metric.class)).get(),
+            Assert.assertEquals(5, bcknd.query(now(), Query.path().with(type(Metric.class)).get(),
                     Pager.unlimited(Order.unspecified())).toList().size());
         } finally {
             bcknd.rollback();
@@ -1078,7 +1084,7 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
 
         InventoryBackend<E> bcknd = inventory.getBackend().startTransaction();
         try {
-            Assert.assertEquals(15, inventory.getBackend().query(Query.path().with(type(
+            Assert.assertEquals(15, inventory.getBackend().query(now(), Query.path().with(type(
                     Resource.class)).get(),
                     Pager.unlimited(Order.unspecified())).toList().size());
         } finally {
@@ -2861,56 +2867,56 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
         try {
             CanonicalPath tenantPath = CanonicalPath.of().tenant("com.acme.tenant").get();
 
-            E entity = backend.find(tenantPath);
-            Tenant tenant = backend.convert(entity, Tenant.class);
+            E entity = backend.find(now(), tenantPath);
+            Tenant tenant = backend.convert(now(), entity, Tenant.class);
             Assert.assertEquals("com.acme.tenant", tenant.getId());
 
             CanonicalPath envPath = tenantPath.extend(Environment.SEGMENT_TYPE, "production").get();
-            entity = backend.find(envPath);
-            Environment env = backend.convert(entity, Environment.class);
+            entity = backend.find(now(), envPath);
+            Environment env = backend.convert(now(), entity, Environment.class);
             Assert.assertEquals("com.acme.tenant", env.getPath().ids().getTenantId());
             Assert.assertEquals("production", env.getId());
 
-            entity = backend.find(envPath.extend(Resource.SEGMENT_TYPE, "host1").get());
-            Resource r = backend.convert(entity, Resource.class);
+            entity = backend.find(now(), envPath.extend(Resource.SEGMENT_TYPE, "host1").get());
+            Resource r = backend.convert(now(), entity, Resource.class);
             Assert.assertEquals("com.acme.tenant", r.getPath().ids().getTenantId());
             Assert.assertEquals("production", r.getPath().ids().getEnvironmentId());
             Assert.assertNull(r.getPath().ids().getFeedId());
             Assert.assertEquals("host1", r.getId());
 
-            entity = backend.find(envPath.extend(Metric.SEGMENT_TYPE, "host1_ping_response").get());
-            Metric m = backend.convert(entity, Metric.class);
+            entity = backend.find(now(), envPath.extend(Metric.SEGMENT_TYPE, "host1_ping_response").get());
+            Metric m = backend.convert(now(), entity, Metric.class);
             Assert.assertEquals("com.acme.tenant", m.getPath().ids().getTenantId());
             Assert.assertEquals("production", m.getPath().ids().getEnvironmentId());
             Assert.assertNull(m.getPath().ids().getFeedId());
             Assert.assertEquals("host1_ping_response", m.getId());
 
             CanonicalPath feedPath = tenantPath.extend(Feed.SEGMENT_TYPE, "feed1").get();
-            entity = backend.find(feedPath);
-            Feed f = backend.convert(entity, Feed.class);
+            entity = backend.find(now(), feedPath);
+            Feed f = backend.convert(now(), entity, Feed.class);
             Assert.assertEquals("com.acme.tenant", f.getPath().ids().getTenantId());
             Assert.assertEquals("feed1", f.getId());
 
-            entity = backend.find(feedPath.extend(Resource.SEGMENT_TYPE, "feedResource1").get());
-            r = backend.convert(entity, Resource.class);
+            entity = backend.find(now(), feedPath.extend(Resource.SEGMENT_TYPE, "feedResource1").get());
+            r = backend.convert(now(), entity, Resource.class);
             Assert.assertEquals("com.acme.tenant", r.getPath().ids().getTenantId());
             Assert.assertEquals("feed1", r.getPath().ids().getFeedId());
             Assert.assertEquals("feedResource1", r.getId());
 
-            entity = backend.find(feedPath.extend(Metric.SEGMENT_TYPE, "feedMetric1").get());
-            m = backend.convert(entity, Metric.class);
+            entity = backend.find(now(), feedPath.extend(Metric.SEGMENT_TYPE, "feedMetric1").get());
+            m = backend.convert(now(), entity, Metric.class);
             Assert.assertEquals("com.acme.tenant", m.getPath().ids().getTenantId());
             Assert.assertEquals("feed1", m.getPath().ids().getFeedId());
             Assert.assertEquals("feedMetric1", m.getId());
 
-            entity = backend.find(tenantPath.extend(ResourceType.SEGMENT_TYPE, "URL").get());
+            entity = backend.find(now(), tenantPath.extend(ResourceType.SEGMENT_TYPE, "URL").get());
             ResourceType
-                    rt = backend.convert(entity, ResourceType.class);
+                    rt = backend.convert(now(), entity, ResourceType.class);
             Assert.assertEquals("com.acme.tenant", rt.getPath().ids().getTenantId());
             Assert.assertEquals("URL", rt.getId());
 
-            entity = backend.find(tenantPath.extend(MetricType.SEGMENT_TYPE, "ResponseTime").get());
-            MetricType mt = backend.convert(entity, MetricType.class);
+            entity = backend.find(now(), tenantPath.extend(MetricType.SEGMENT_TYPE, "ResponseTime").get());
+            MetricType mt = backend.convert(now(), entity, MetricType.class);
             Assert.assertEquals("com.acme.tenant", mt.getPath().ids().getTenantId());
             Assert.assertEquals("ResponseTime", mt.getId());
         } finally {
@@ -2923,11 +2929,11 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
         InventoryBackend<E> backend = inventory.getBackend().startTransaction();
 
         try {
-            E tenant = backend.find(CanonicalPath.of().tenant("com.acme.tenant").get());
-            E environment = backend.find(CanonicalPath.of().tenant("com.acme.tenant").environment("production").get());
-            E r = backend.getRelationship(tenant, environment, contains.name());
+            E tenant = backend.find(now(), CanonicalPath.of().tenant("com.acme.tenant").get());
+            E environment = backend.find(now(), CanonicalPath.of().tenant("com.acme.tenant").environment("production").get());
+            E r = backend.getRelationship(now(), tenant, environment, contains.name());
 
-            Relationship rel = backend.convert(r, Relationship.class);
+            Relationship rel = backend.convert(now(), r, Relationship.class);
 
             Assert.assertEquals("com.acme.tenant", rel.getSource().getSegment().getElementId());
             Assert.assertEquals("production", rel.getTarget().getSegment().getElementId());
@@ -2942,12 +2948,12 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
         InventoryBackend<E> backend = inventory.getBackend().startTransaction();
 
         try {
-            E entity = backend.find(CanonicalPath.of().tenant("com.acme.tenant").get());
+            E entity = backend.find(now(), CanonicalPath.of().tenant("com.acme.tenant").get());
             Assert.assertEquals("com.acme.tenant", backend.extractId(entity));
-            Set<E> rels = backend.getRelationships(entity, both);
+            Set<E> rels = backend.getRelationships(now(), entity, both);
             Assert.assertEquals(8, rels.size());
 
-            Function<Set<E>, Stream<Relationship>> checks = (es) -> es.stream().map((e) -> backend.convert(e,
+            Function<Set<E>, Stream<Relationship>> checks = (es) -> es.stream().map((e) -> backend.convert(now(), e,
                     Relationship.class));
 
             Assert.assertTrue(checks.apply(rels).anyMatch((r) -> contains.name().equals(r.getName()) &&
@@ -2966,10 +2972,10 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
                     "com.acme.tenant".equals(r.getSource().getSegment().getElementId()) &&
                     "feed1".equals(r.getTarget().getSegment().getElementId())));
 
-            rels = backend.getRelationships(entity, incoming);
+            rels = backend.getRelationships(now(), entity, incoming);
             Assert.assertTrue(rels.isEmpty());
 
-            rels = backend.getRelationships(entity, outgoing);
+            rels = backend.getRelationships(now(), entity, outgoing);
             Assert.assertTrue(checks.apply(rels).anyMatch((r) -> contains.name().equals(r.getName()) &&
                     "com.acme.tenant".equals(r.getSource().getSegment().getElementId()) &&
                     "production".equals(r.getTarget().getSegment().getElementId())));
@@ -2980,17 +2986,17 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
                     "com.acme.tenant".equals(r.getSource().getSegment().getElementId()) &&
                     "ResponseTime".equals(r.getTarget().getSegment().getElementId())));
 
-            entity = backend.find(CanonicalPath.of().tenant("com.example.tenant").environment("test").get());
+            entity = backend.find(now(), CanonicalPath.of().tenant("com.example.tenant").environment("test").get());
             Assert.assertEquals("test", backend.extractId(entity));
 
-            rels = backend.getRelationships(entity, incoming);
+            rels = backend.getRelationships(now(), entity, incoming);
             Assert.assertEquals(2, rels.size());
             Assert.assertTrue(checks.apply(rels).anyMatch((r) -> "contains".equals(r.getName()) &&
                     "com.example.tenant".equals(r.getSource().getSegment().getElementId())));
             Assert.assertTrue(checks.apply(rels).anyMatch((r) -> "yourMom".equals(r.getName()) &&
                     "playroom2_size".equals(r.getSource().getSegment().getElementId())));
 
-            rels = backend.getRelationships(entity, outgoing, "IamYourFather");
+            rels = backend.getRelationships(now(), entity, outgoing, "IamYourFather");
             Assert.assertEquals(1, rels.size());
             Assert.assertTrue(checks.apply(rels).anyMatch((r) -> "IamYourFather".equals(r.getName()) &&
                     "playroom2_size".equals(r.getTarget().getSegment().getElementId())));
@@ -3006,14 +3012,13 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
         try {
             TriFunction<E, Relationships.Direction, String[], Stream<? extends Entity<?, ?>>> test =
                     (start, direction, name) -> {
-                        Iterator<E> transitiveClosure = backend.getTransitiveClosureOver(start, direction, name);
+                        Iterator<E> transitiveClosure = backend.getTransitiveClosureOver(now(), start, direction, name);
                         return StreamSupport.stream(Spliterators.spliterator(transitiveClosure, Integer.MAX_VALUE, 0),
-                                false).map((e) -> (Entity<?, ?>) backend.convert(e, backend.extractType(e)));
+                                false).map((e) -> (Entity<?, ?>) backend.convert(now(), e, backend.extractType(e)));
                     };
 
-            E env = backend.find(CanonicalPath.of().tenant("com.acme.tenant").environment("production").get());
-            E feed = backend.find(CanonicalPath.of().tenant("com.acme.tenant").feed("feed1")
-                    .get());
+            E env = backend.find(now(), CanonicalPath.of().tenant("com.acme.tenant").environment("production").get());
+            E feed = backend.find(now(), CanonicalPath.of().tenant("com.acme.tenant").feed("feed1").get());
 
             Assert.assertEquals(8, test.apply(feed, outgoing, new String[]{"contains"}).count());
             Assert.assertFalse(test.apply(feed, outgoing, new String[]{"contains"}).anyMatch((e) -> e instanceof Feed &&
@@ -3044,16 +3049,16 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
         InventoryBackend<E> backend = inventory.getBackend().startTransaction();
 
         try {
-            E tenant = backend.find(CanonicalPath.of().tenant("com.example.tenant").get());
+            E tenant = backend.find(now(), CanonicalPath.of().tenant("com.example.tenant").get());
 
-            Assert.assertTrue(backend.hasRelationship(tenant, outgoing, "contains"));
-            Assert.assertFalse(backend.hasRelationship(tenant, incoming, "contains"));
-            Assert.assertTrue(backend.hasRelationship(tenant, both, "contains"));
+            Assert.assertTrue(backend.hasRelationship(now(), tenant, outgoing, "contains"));
+            Assert.assertFalse(backend.hasRelationship(now(), tenant, incoming, "contains"));
+            Assert.assertTrue(backend.hasRelationship(now(), tenant, both, "contains"));
 
-            E env = backend.find(CanonicalPath.of().tenant("com.example.tenant").environment("test").get());
+            E env = backend.find(now(), CanonicalPath.of().tenant("com.example.tenant").environment("test").get());
 
-            Assert.assertTrue(backend.hasRelationship(tenant, env, "contains"));
-            Assert.assertFalse(backend.hasRelationship(tenant, env, "e-kachny"));
+            Assert.assertTrue(backend.hasRelationship(now(), tenant, env, "contains"));
+            Assert.assertFalse(backend.hasRelationship(now(), tenant, env, "e-kachny"));
         } finally {
             backend.rollback();
         }
@@ -3064,7 +3069,7 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
         InventoryBackend<E> backend = inventory.getBackend().startTransaction();
 
         try {
-            E tenant = backend.find(CanonicalPath.of().tenant("com.example.tenant").get());
+            E tenant = backend.find(now(), CanonicalPath.of().tenant("com.example.tenant").get());
 
             Assert.assertEquals("com.example.tenant", backend.extractId(tenant));
         } finally {
@@ -3079,33 +3084,33 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
         try {
             CanonicalPath tenantPath = CanonicalPath.of().tenant("com.acme.tenant").get();
 
-            E entity = backend.find(tenantPath);
+            E entity = backend.find(now(), tenantPath);
             Assert.assertEquals(Tenant.class, backend.extractType(entity));
 
             CanonicalPath envPath = tenantPath.extend(Environment.SEGMENT_TYPE, "production").get();
-            entity = backend.find(envPath);
+            entity = backend.find(now(), envPath);
             Assert.assertEquals(Environment.class, backend.extractType(entity));
 
-            entity = backend.find(envPath.extend(Resource.SEGMENT_TYPE, "host1").get());
+            entity = backend.find(now(), envPath.extend(Resource.SEGMENT_TYPE, "host1").get());
             Assert.assertEquals(Resource.class, backend.extractType(entity));
 
-            entity = backend.find(envPath.extend(Metric.SEGMENT_TYPE, "host1_ping_response").get());
+            entity = backend.find(now(), envPath.extend(Metric.SEGMENT_TYPE, "host1_ping_response").get());
             Assert.assertEquals(Metric.class, backend.extractType(entity));
 
             CanonicalPath feedPath = tenantPath.extend(Feed.SEGMENT_TYPE, "feed1").get();
-            entity = backend.find(feedPath);
+            entity = backend.find(now(), feedPath);
             Assert.assertEquals(Feed.class, backend.extractType(entity));
 
-            entity = backend.find(feedPath.extend(Resource.SEGMENT_TYPE, "feedResource1").get());
+            entity = backend.find(now(), feedPath.extend(Resource.SEGMENT_TYPE, "feedResource1").get());
             Assert.assertEquals(Resource.class, backend.extractType(entity));
 
-            entity = backend.find(feedPath.extend(Metric.SEGMENT_TYPE, "feedMetric1").get());
+            entity = backend.find(now(), feedPath.extend(Metric.SEGMENT_TYPE, "feedMetric1").get());
             Assert.assertEquals(Metric.class, backend.extractType(entity));
 
-            entity = backend.find(tenantPath.extend(ResourceType.SEGMENT_TYPE, "URL").get());
+            entity = backend.find(now(), tenantPath.extend(ResourceType.SEGMENT_TYPE, "URL").get());
             Assert.assertEquals(ResourceType.class, backend.extractType(entity));
 
-            entity = backend.find(tenantPath.extend(MetricType.SEGMENT_TYPE, "ResponseTime").get());
+            entity = backend.find(now(), tenantPath.extend(MetricType.SEGMENT_TYPE, "ResponseTime").get());
             Assert.assertEquals(MetricType.class, backend.extractType(entity));
         } finally {
             backend.rollback();
@@ -3120,14 +3125,14 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
             Pager unlimited = Pager.unlimited(Order.unspecified());
 
             Query q = Query.path().with(type(Tenant.class), id("com.acme.tenant")).get();
-            Page<E> results = backend.query(q, unlimited);
+            Page<E> results = backend.query(now(), q, unlimited);
             Assert.assertTrue(results.hasNext());
             Assert.assertEquals("com.acme.tenant", backend.extractId(results.next()));
             Assert.assertTrue(!results.hasNext());
 
             q = Query.path().with(type(Tenant.class), id("com.acme.tenant"), Related.by("contains"),
                     type(Environment.class), id("production")).get();
-            results = backend.query(q, unlimited);
+            results = backend.query(now(), q, unlimited);
             Assert.assertTrue(results.hasNext());
             Assert.assertEquals("production", backend.extractId(results.next()));
             Assert.assertTrue(!results.hasNext());
@@ -3137,7 +3142,7 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
             q = Query.path().with(type(Tenant.class)).filter().with(Related.by("contains"), type(
                     ResourceType.class),
                     id("URL")).path().with(Related.by("contains"), type(Environment.class)).get();
-            results = backend.query(q, unlimited);
+            results = backend.query(now(), q, unlimited);
             Assert.assertTrue(results.hasNext());
             Assert.assertEquals("production", backend.extractId(results.next()));
             Assert.assertTrue(!results.hasNext());

--- a/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryTestsuite.java
+++ b/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryTestsuite.java
@@ -3801,21 +3801,25 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
         try {
             Tenants.Single ts = inventory.tenants()
                     .create(Tenant.Blueprint.builder().withId(tenantId).build());
+            Thread.sleep(10);
 
             Tenant afterCreateTenant = ts.entity();
-            Thread.sleep(10);
             Instant afterCreate = Instant.now();
 
             Tenant.Update update = Tenant.Update.builder().withName("kachny").build();
             ts.update(update);
+            Thread.sleep(10);
 
             Tenant beforeDeleteTenant = afterCreateTenant.update().with(update);
             Instant beforeDelete = Instant.now();
-            Thread.sleep(10);
 
             ts.delete();
+            Thread.sleep(10);
 
             Instant past = Instant.ofEpochMilli(0);
+
+            System.out.println("testHistory_constrained times: past=" + past.toEpochMilli() + ", afterCreate = "
+                    + afterCreate.toEpochMilli() + ", beforeDelete = " + beforeDelete.toEpochMilli());
 
             List<Change<Tenant>> cs = ts.history(past, afterCreate);
             Assert.assertEquals(1, cs.size());

--- a/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryTestsuite.java
+++ b/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/AbstractBaseInventoryTestsuite.java
@@ -3818,9 +3818,6 @@ public abstract class AbstractBaseInventoryTestsuite<E> {
 
             Instant past = Instant.ofEpochMilli(0);
 
-            System.out.println("testHistory_constrained times: past=" + past.toEpochMilli() + ", afterCreate = "
-                    + afterCreate.toEpochMilli() + ", beforeDelete = " + beforeDelete.toEpochMilli());
-
             List<Change<Tenant>> cs = ts.history(past, afterCreate);
             Assert.assertEquals(1, cs.size());
             Assert.assertEquals(Action.created().asEnum(), cs.get(0).getAction().asEnum());

--- a/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/PreCommitActionsTest.java
+++ b/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/PreCommitActionsTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
@@ -308,11 +307,11 @@ public class PreCommitActionsTest {
                     return pc.getFinalNotifications();
                 }
 
-                @Override public void initialize(Inventory inventory, Transaction<String> tx, Instant txStart) {
+                @Override public void initialize(Inventory inventory, Transaction<String> tx) {
                     if (this.getClass() != pc.getClass()) {
                         initialized++;
                     }
-                    pc.initialize(inventory, tx, txStart);
+                    pc.initialize(inventory, tx);
                 }
 
                 @Override public void reset() {

--- a/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/PreCommitActionsTest.java
+++ b/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/PreCommitActionsTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
@@ -40,6 +41,7 @@ import org.hawkular.inventory.base.EntityAndPendingNotifications;
 import org.hawkular.inventory.base.Transaction;
 import org.hawkular.inventory.base.TransactionConstructor;
 import org.hawkular.inventory.base.spi.CommitFailureException;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.SegmentType;
@@ -266,9 +268,9 @@ public class PreCommitActionsTest {
             return Inventory.types().bySegment(t).getElementType();
         });
 
-        when(backend.find(any())).thenAnswer(args -> args.getArgumentAt(0, CanonicalPath.class).toString());
+        when(backend.find(now(), any())).thenAnswer(args -> args.getArgumentAt(0, CanonicalPath.class).toString());
 
-        when(backend.convert(any(), any())).thenAnswer(args -> {
+        when(backend.convert(now(), any(), any())).thenAnswer(args -> {
             Class<?> type = args.getArgumentAt(1, Class.class);
             String path = args.getArgumentAt(0, String.class);
 
@@ -380,5 +382,9 @@ public class PreCommitActionsTest {
         @Override protected InventoryBackend<String> doInitialize(Configuration configuration) {
             return backend;
         }
+    }
+
+    private static Discriminator now() {
+        return Discriminator.time(Instant.now());
     }
 }

--- a/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/PreCommitActionsTest.java
+++ b/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/PreCommitActionsTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
@@ -67,7 +68,7 @@ public class PreCommitActionsTest {
             Assert.assertEquals(0, pct.actionsObtained);
             return backend;
         });
-        when(backend.persist(any(), any())).thenAnswer((args) -> args.getArguments()[0].toString());
+        when(backend.persist(any(), any(), any())).thenAnswer((args) -> args.getArguments()[1].toString());
 
         commonBackendMocks(backend);
 
@@ -107,9 +108,9 @@ public class PreCommitActionsTest {
 
         //this way we check that the backend is actually contacted twice to persist the tenants, which would normally
         //cause 2 transactions to be committed.
-        when(backend.persist(any(), any())).thenAnswer((args) -> {
+        when(backend.persist(any(), any(), any())).thenAnswer((args) -> {
             dataPersisted[0]++;
-            return args.getArguments()[0].toString();
+            return args.getArguments()[1].toString();
         });
 
         commonBackendMocks(backend);
@@ -177,9 +178,9 @@ public class PreCommitActionsTest {
             return null;
         }).when(backend).commit();
 
-        when(backend.persist(any(), any())).thenAnswer((args) -> {
+        when(backend.persist(any(), any(), any())).thenAnswer((args) -> {
             dataPersisted[0]++;
-            return args.getArguments()[0].toString();
+            return args.getArguments()[1].toString();
         });
 
         commonBackendMocks(backend);
@@ -227,9 +228,9 @@ public class PreCommitActionsTest {
             return null;
         }).when(backend).commit();
 
-        when(backend.persist(any(), any())).thenAnswer((args) -> {
+        when(backend.persist(any(), any(), any())).thenAnswer((args) -> {
             dataPersisted[0]++;
-            return args.getArguments()[0].toString();
+            return args.getArguments()[1].toString();
         });
 
         commonBackendMocks(backend);
@@ -307,11 +308,11 @@ public class PreCommitActionsTest {
                     return pc.getFinalNotifications();
                 }
 
-                @Override public void initialize(Inventory inventory, Transaction<String> tx) {
+                @Override public void initialize(Inventory inventory, Transaction<String> tx, Instant txStart) {
                     if (this.getClass() != pc.getClass()) {
                         initialized++;
                     }
-                    pc.initialize(inventory, tx);
+                    pc.initialize(inventory, tx, txStart);
                 }
 
                 @Override public void reset() {

--- a/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/PreCommitActionsTest.java
+++ b/hawkular-inventory-api/src/test/java/org/hawkular/inventory/api/test/PreCommitActionsTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
@@ -41,7 +40,6 @@ import org.hawkular.inventory.base.EntityAndPendingNotifications;
 import org.hawkular.inventory.base.Transaction;
 import org.hawkular.inventory.base.TransactionConstructor;
 import org.hawkular.inventory.base.spi.CommitFailureException;
-import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.InventoryBackend;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.SegmentType;
@@ -268,11 +266,11 @@ public class PreCommitActionsTest {
             return Inventory.types().bySegment(t).getElementType();
         });
 
-        when(backend.find(now(), any())).thenAnswer(args -> args.getArgumentAt(0, CanonicalPath.class).toString());
+        when(backend.find(any(), any())).thenAnswer(args -> args.getArgumentAt(1, CanonicalPath.class).toString());
 
-        when(backend.convert(now(), any(), any())).thenAnswer(args -> {
-            Class<?> type = args.getArgumentAt(1, Class.class);
-            String path = args.getArgumentAt(0, String.class);
+        when(backend.convert(any(), any(), any())).thenAnswer(args -> {
+            Class<?> type = args.getArgumentAt(2, Class.class);
+            String path = args.getArgumentAt(1, String.class);
 
             Constructor<?> ctor = type.getDeclaredConstructor();
             ctor.setAccessible(true);
@@ -382,9 +380,5 @@ public class PreCommitActionsTest {
         @Override protected InventoryBackend<String> doInitialize(Configuration configuration) {
             return backend;
         }
-    }
-
-    private static Discriminator now() {
-        return Discriminator.time(Instant.now());
     }
 }

--- a/hawkular-inventory-bus-api/pom.xml
+++ b/hawkular-inventory-bus-api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hawkular-inventory-parent</artifactId>
     <groupId>org.hawkular.inventory</groupId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-bus-api</artifactId>

--- a/hawkular-inventory-bus/pom.xml
+++ b/hawkular-inventory-bus/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hawkular-inventory-parent</artifactId>
     <groupId>org.hawkular.inventory</groupId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-bus</artifactId>

--- a/hawkular-inventory-cdi/pom.xml
+++ b/hawkular-inventory-cdi/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hawkular-inventory-parent</artifactId>
     <groupId>org.hawkular.inventory</groupId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-cdi</artifactId>

--- a/hawkular-inventory-dist/pom.xml
+++ b/hawkular-inventory-dist/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hawkular-inventory-parent</artifactId>
     <groupId>org.hawkular.inventory</groupId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-dist</artifactId>

--- a/hawkular-inventory-feature-pack/pom.xml
+++ b/hawkular-inventory-feature-pack/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>hawkular-inventory-parent</artifactId>
     <groupId>org.hawkular.inventory</groupId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/pom.xml
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hawkular-inventory-impl-tinkerpop-parent</artifactId>
     <groupId>org.hawkular.inventory</groupId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-impl-tinkerpop-spi</artifactId>

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/src/main/java/org/hawkular/inventory/impl/tinkerpop/spi/Constants.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/src/main/java/org/hawkular/inventory/impl/tinkerpop/spi/Constants.java
@@ -41,6 +41,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -161,7 +162,15 @@ public final class Constants {
 
         __contentHash("contentHash", String.class),
 
-        __syncHash("syncHash", String.class);
+        __syncHash("syncHash", String.class),
+
+        __from(Long.class),
+
+        __to(Long.class),
+
+        __deleted(Boolean.class)
+
+        ;
 
         private final String sortName;
         private final Class<?> propertyType;
@@ -236,9 +245,13 @@ public final class Constants {
         private final String[] mappedProperties;
         private final Class<?> entityType;
 
+        private static final List<String> identityVertexProperties =
+                Arrays.asList(Property.__type.name(), Property.__eid.name(), Property.__cp.name(),
+                        Property.__deleted.name());
+
         Type(Class<?> entityType, Property... mappedProperties) {
             this.entityType = entityType;
-            this.mappedProperties = new String[mappedProperties.length + 3];
+            this.mappedProperties = new String[mappedProperties.length + 6];
             Arrays.setAll(this.mappedProperties, i -> {
                 switch (i) {
                     case 0:
@@ -247,8 +260,14 @@ public final class Constants {
                         return Property.__eid.name();
                     case 2:
                         return Property.__cp.name();
+                    case 3:
+                        return Property.__from.name();
+                    case 4:
+                        return Property.__to.name();
+                    case 5:
+                        return Property.__deleted.name();
                     default:
-                        return mappedProperties[i - 3].name();
+                        return mappedProperties[i - 6].name();
                 }
             });
         }
@@ -398,10 +417,14 @@ public final class Constants {
         public String[] getMappedProperties() {
             return mappedProperties;
         }
+
+        public static List<String> getIdentityVertexProperties() {
+            return identityVertexProperties;
+        }
     }
 
     public enum InternalEdge {
-        __withIdentityHash, __containsIdentityHash
+        __withIdentityHash, __containsIdentityHash, __inState
     }
 
     public enum InternalType {

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/src/main/java/org/hawkular/inventory/impl/tinkerpop/spi/Constants.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/src/main/java/org/hawkular/inventory/impl/tinkerpop/spi/Constants.java
@@ -17,6 +17,7 @@
 package org.hawkular.inventory.impl.tinkerpop.spi;
 
 import static org.hawkular.inventory.impl.tinkerpop.spi.Constants.Property.__contentHash;
+import static org.hawkular.inventory.impl.tinkerpop.spi.Constants.Property.__from;
 import static org.hawkular.inventory.impl.tinkerpop.spi.Constants.Property.__identityHash;
 import static org.hawkular.inventory.impl.tinkerpop.spi.Constants.Property.__metric_data_type;
 import static org.hawkular.inventory.impl.tinkerpop.spi.Constants.Property.__metric_interval;
@@ -34,6 +35,7 @@ import static org.hawkular.inventory.impl.tinkerpop.spi.Constants.Property.__syn
 import static org.hawkular.inventory.impl.tinkerpop.spi.Constants.Property.__targetCp;
 import static org.hawkular.inventory.impl.tinkerpop.spi.Constants.Property.__targetEid;
 import static org.hawkular.inventory.impl.tinkerpop.spi.Constants.Property.__targetType;
+import static org.hawkular.inventory.impl.tinkerpop.spi.Constants.Property.__to;
 import static org.hawkular.inventory.impl.tinkerpop.spi.Constants.Property.__unit;
 import static org.hawkular.inventory.impl.tinkerpop.spi.Constants.Property.name;
 
@@ -236,7 +238,8 @@ public final class Constants {
         resource(Resource.class, name, __identityHash, __contentHash, __syncHash),
         metric(Metric.class, name, __metric_interval, __identityHash, __contentHash, __syncHash),
         metadatapack(MetadataPack.class, name),
-        relationship(Relationship.class, __sourceType, __targetType, __sourceCp, __targetCp, __sourceEid, __targetEid),
+        relationship(Relationship.class, __sourceType, __targetType, __sourceCp, __targetCp, __sourceEid, __targetEid,
+                __from, __to),
         dataEntity(DataEntity.class, name, __identityHash, __contentHash, __syncHash),
         structuredData(StructuredData.class, __structuredDataType,
                 __structuredDataValue_b, __structuredDataValue_i, __structuredDataValue_f, __structuredDataValue_s,
@@ -250,7 +253,7 @@ public final class Constants {
 
         Type(Class<?> entityType, Property... mappedProperties) {
             this.entityType = entityType;
-            this.mappedProperties = new String[mappedProperties.length + 5];
+            this.mappedProperties = new String[mappedProperties.length + 3];
             Arrays.setAll(this.mappedProperties, i -> {
                 switch (i) {
                     case 0:
@@ -259,12 +262,8 @@ public final class Constants {
                         return Property.__eid.name();
                     case 2:
                         return Property.__cp.name();
-                    case 3:
-                        return Property.__from.name();
-                    case 4:
-                        return Property.__to.name();
                     default:
-                        return mappedProperties[i - 5].name();
+                        return mappedProperties[i - 3].name();
                 }
             });
         }

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/src/main/java/org/hawkular/inventory/impl/tinkerpop/spi/Constants.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/src/main/java/org/hawkular/inventory/impl/tinkerpop/spi/Constants.java
@@ -415,6 +415,14 @@ public final class Constants {
             return mappedProperties;
         }
 
+        public String identityVertexLabel() {
+            return name();
+        }
+
+        public String stateVertexLabel() {
+            return identityVertexLabel() + "_state";
+        }
+
         public static List<String> getIdentityVertexProperties() {
             return identityVertexProperties;
         }

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/src/main/java/org/hawkular/inventory/impl/tinkerpop/spi/Constants.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/src/main/java/org/hawkular/inventory/impl/tinkerpop/spi/Constants.java
@@ -168,7 +168,9 @@ public final class Constants {
 
         __to(Long.class),
 
-        __deleted(Boolean.class)
+        __deleted(Boolean.class),
+
+        __changeKind(int.class)
 
         ;
 

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/src/main/java/org/hawkular/inventory/impl/tinkerpop/spi/Constants.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/src/main/java/org/hawkular/inventory/impl/tinkerpop/spi/Constants.java
@@ -168,8 +168,6 @@ public final class Constants {
 
         __to(Long.class),
 
-        __deleted(Boolean.class),
-
         __changeKind(int.class)
 
         ;
@@ -248,12 +246,11 @@ public final class Constants {
         private final Class<?> entityType;
 
         private static final List<String> identityVertexProperties =
-                Arrays.asList(Property.__type.name(), Property.__eid.name(), Property.__cp.name(),
-                        Property.__deleted.name());
+                Arrays.asList(Property.__type.name(), Property.__eid.name(), Property.__cp.name());
 
         Type(Class<?> entityType, Property... mappedProperties) {
             this.entityType = entityType;
-            this.mappedProperties = new String[mappedProperties.length + 6];
+            this.mappedProperties = new String[mappedProperties.length + 5];
             Arrays.setAll(this.mappedProperties, i -> {
                 switch (i) {
                     case 0:
@@ -266,10 +263,8 @@ public final class Constants {
                         return Property.__from.name();
                     case 4:
                         return Property.__to.name();
-                    case 5:
-                        return Property.__deleted.name();
                     default:
-                        return mappedProperties[i - 6].name();
+                        return mappedProperties[i - 5].name();
                 }
             });
         }

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-sql-provider/pom.xml
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-sql-provider/pom.xml
@@ -120,6 +120,24 @@
       <artifactId>javax.mail-api</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-sql-provider/pom.xml
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-sql-provider/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>hawkular-inventory-impl-tinkerpop-parent</artifactId>
     <groupId>org.hawkular.inventory</groupId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -118,24 +118,6 @@
     <dependency>
       <groupId>javax.mail</groupId>
       <artifactId>javax.mail-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-tinkergraph-provider/pom.xml
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-tinkergraph-provider/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hawkular-inventory-impl-tinkerpop-parent</artifactId>
     <groupId>org.hawkular.inventory</groupId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-impl-tinkerpop-tinkergraph-provider</artifactId>

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-tinkergraph-provider/src/test/java/org/hawkular/inventory/impl/tinkerpop/provider/BigTransactionsTinkerGraphTest.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-tinkergraph-provider/src/test/java/org/hawkular/inventory/impl/tinkerpop/provider/BigTransactionsTinkerGraphTest.java
@@ -19,8 +19,12 @@ package org.hawkular.inventory.impl.tinkerpop.provider;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.hawkular.inventory.base.BaseInventory;
 import org.hawkular.inventory.impl.tinkerpop.TinkerpopInventory;
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 /**
  * @author Lukas Krejci
@@ -28,6 +32,8 @@ import org.junit.BeforeClass;
  */
 public class BigTransactionsTinkerGraphTest extends AbstractTinkerGraphTest {
     private static TinkerpopInventory INVENTORY;
+
+    @Rule public TestName name = new TestName();
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -43,6 +49,16 @@ public class BigTransactionsTinkerGraphTest extends AbstractTinkerGraphTest {
     public static void teardownData() throws Exception {
         teardownData(INVENTORY);
         teardown(INVENTORY);
+    }
+
+    @Before
+    public void reportStart() {
+        System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>> " + name.getMethodName());
+    }
+
+    @After
+    public void reportEnd() {
+        System.out.println("<<<<<<<<<<<<<<<<<<<<<<<<<< " + name.getMethodName());
     }
 
     @Override

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-tinkergraph-provider/src/test/java/org/hawkular/inventory/impl/tinkerpop/provider/SmallTransactionsTinkerGraphTest.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-tinkergraph-provider/src/test/java/org/hawkular/inventory/impl/tinkerpop/provider/SmallTransactionsTinkerGraphTest.java
@@ -19,8 +19,12 @@ package org.hawkular.inventory.impl.tinkerpop.provider;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.hawkular.inventory.base.BaseInventory;
 import org.hawkular.inventory.impl.tinkerpop.TinkerpopInventory;
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 /**
  * @author Lukas Krejci
@@ -28,6 +32,8 @@ import org.junit.BeforeClass;
  */
 public class SmallTransactionsTinkerGraphTest extends AbstractTinkerGraphTest {
     private static TinkerpopInventory INVENTORY;
+
+    @Rule public TestName name = new TestName();
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -43,6 +49,16 @@ public class SmallTransactionsTinkerGraphTest extends AbstractTinkerGraphTest {
     public static void teardownData() throws Exception {
         teardownData(INVENTORY);
         teardown(INVENTORY);
+    }
+
+    @Before
+    public void reportStart() {
+        System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>> " + name.getMethodName());
+    }
+
+    @After
+    public void reportEnd() {
+        System.out.println("<<<<<<<<<<<<<<<<<<<<<<<<<< " + name.getMethodName());
     }
 
     @Override

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-titan-provider/pom.xml
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-titan-provider/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hawkular-inventory-impl-tinkerpop-parent</artifactId>
     <groupId>org.hawkular.inventory</groupId>
-    <version>0.19.3.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-impl-tinkerpop-titan-provider</artifactId>

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/pom.xml
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular.inventory</groupId>
     <artifactId>hawkular-inventory-impl-tinkerpop-parent</artifactId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-impl-tinkerpop</artifactId>

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/ChangeKind.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/ChangeKind.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.impl.tinkerpop;
+
+/**
+ * We represent a change kind on the __inState edges as ordinals of this enum. We need 2 values for a delete because
+ * a delete is represented as just an explicit to date coupled with a change kind. We need to distinguish between a
+ * delete after create and delete after update so that we can correctly reconstruct the history of mutations on an
+ * entity.
+ *
+ * @author Lukas Krejci
+ * @since 0.20.0
+ */
+enum ChangeKind {
+    create, update,
+
+    /**
+     * represents a delete for an entity right after it has been created with no intermediate update
+     */
+    delete_after_create,
+
+    /**
+     * represents a delete following an update
+     */
+    delete_after_update;
+
+    static ChangeKind deleteOf(ChangeKind priorState) {
+        switch (priorState) {
+            case create:
+                return delete_after_create;
+            case update:
+                return delete_after_update;
+            default:
+                throw new IllegalArgumentException("Delete of a delete is definitely unexpected.");
+        }
+    }
+}

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterApplicator.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterApplicator.java
@@ -128,12 +128,14 @@ abstract class FilterApplicator<T extends Filter> {
      * @param <S>        type of the source of the query
      * @param <E>        type of the output of the query
      */
-    public static <S, E> void applyAll(Discriminator discriminator, Query filterTree, HawkularTraversal<S, E> q) {
+    public static <S, E> void applyAll(Discriminator discriminator, Query filterTree, HawkularTraversal<S, E> q,
+                                       boolean inEdges) {
         if (filterTree == null) {
             return;
         }
 
         QueryTranslationState state = new QueryTranslationState();
+        state.setInEdges(inEdges);
 
         applyAll(discriminator, filterTree, q, false, state);
     }
@@ -388,7 +390,7 @@ abstract class FilterApplicator<T extends Filter> {
         }
 
         public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
-            visitor.visit(query, filter, state);
+            visitor.visit(discriminator, query, filter, state);
         }
     }
 

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterApplicator.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterApplicator.java
@@ -424,7 +424,7 @@ abstract class FilterApplicator<T extends Filter> {
 
         @Override
         public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
-            visitor.visit(query, filter, state);
+            visitor.visit(discriminator, query, filter, state);
         }
     }
 
@@ -448,7 +448,7 @@ abstract class FilterApplicator<T extends Filter> {
 
         @Override
         public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
-            visitor.visit(query, filter, state);
+            visitor.visit(discriminator, query, filter, state);
         }
     }
 
@@ -508,7 +508,7 @@ abstract class FilterApplicator<T extends Filter> {
 
         @Override
         public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
-            visitor.visit(query, filter, state);
+            visitor.visit(discriminator, query, filter, state);
         }
     }
 

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterApplicator.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterApplicator.java
@@ -16,6 +16,8 @@
  */
 package org.hawkular.inventory.impl.tinkerpop;
 
+import static org.hawkular.inventory.impl.tinkerpop.HawkularTraversal.hwk__;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -26,7 +28,6 @@ import java.util.Map;
 
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeOtherVertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.EdgeVertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
@@ -43,6 +44,7 @@ import org.hawkular.inventory.api.filters.Related;
 import org.hawkular.inventory.api.filters.RelationWith;
 import org.hawkular.inventory.api.filters.SwitchElementType;
 import org.hawkular.inventory.api.filters.With;
+import org.hawkular.inventory.base.spi.Discriminator;
 import org.hawkular.inventory.base.spi.NoopFilter;
 
 /**
@@ -126,14 +128,14 @@ abstract class FilterApplicator<T extends Filter> {
      * @param <S>        type of the source of the query
      * @param <E>        type of the output of the query
      */
-    public static <S, E> void applyAll(Query filterTree, GraphTraversal<S, E> q) {
+    public static <S, E> void applyAll(Discriminator discriminator, Query filterTree, HawkularTraversal<S, E> q) {
         if (filterTree == null) {
             return;
         }
 
         QueryTranslationState state = new QueryTranslationState();
 
-        applyAll(filterTree, q, false, state);
+        applyAll(discriminator, filterTree, q, false, state);
     }
 
     /**
@@ -142,21 +144,21 @@ abstract class FilterApplicator<T extends Filter> {
      * next positions in the inventory traversal or a filter ({@code isFilter == true}) which merely trims down the
      * number of the elements at the current "tail" of the traversal by applying filters to them.
      *
-     * @param query    the query
-     * @param pipeline the Gremlin pipeline that the query gets translated to
-     * @param isFilter whether we are currently processing filters as filters or path elements
      * @param <S>      the start element type of the pipeline
      * @param <E>      the end element type of the pipeline
-     * @return true if after applying the filters, we're the filtering state or false if we are in path-progression
+     * @param discriminator
+     * @param query    the query
+     * @param pipeline the Gremlin pipeline that the query gets translated to
+     * @param isFilter whether we are currently processing filters as filters or path elements    @return true if after applying the filters, we're the filtering state or false if we are in path-progression
      * state.
      */
     @SuppressWarnings("unchecked")
-    private static <S, E> boolean applyAll(Query query, GraphTraversal<S, E> pipeline, boolean isFilter,
-                                           QueryTranslationState state) {
+    private static <S, E> boolean applyAll(Discriminator discriminator, Query query, HawkularTraversal<S, E> pipeline,
+                                           boolean isFilter, QueryTranslationState state) {
 
         QueryTranslationState origState = state.clone();
 
-        GraphTraversal<E, E> workingPipeline = __.start();
+        HawkularTraversal<E, E> workingPipeline = hwk__();
 
         for (QueryFragment qf : query.getFragments()) {
             boolean thisIsFilter = qf instanceof FilterFragment;
@@ -179,10 +181,10 @@ abstract class FilterApplicator<T extends Filter> {
                         workingPipeline.asAdmin().getSteps().forEach(admin::addStep);
                     }
                 }
-                workingPipeline = __.start();
+                workingPipeline = hwk__();
             }
 
-            FilterApplicator.of(qf.getFilter()).applyTo(workingPipeline, state);
+            FilterApplicator.of(qf.getFilter()).applyTo(discriminator, workingPipeline, state);
         }
 
         finishPipeline(workingPipeline, state, origState);
@@ -199,22 +201,22 @@ abstract class FilterApplicator<T extends Filter> {
         }
 
         if (query.getSubTrees().size() == 1) {
-            return applyAll(query.getSubTrees().get(0), pipeline, isFilter, state);
+            return applyAll(discriminator, query.getSubTrees().get(0), pipeline, isFilter, state);
         } else {
             List<GraphTraversal<E, ?>> branches = new ArrayList<>();
             Iterator<Query> it = query.getSubTrees().iterator();
 
             // apply the first branch - in here, we know there are at least 2 actually
-            GraphTraversal<E, ?> branch = __.start();
+            HawkularTraversal<E, ?> branch = hwk__();
 
             // the branch is a brand new pipeline, so it doesn't make sense for it to inherit
             // our current filter state.
-            applyAll(it.next(), branch, false, state.clone());
+            applyAll(discriminator, it.next(), branch, false, state.clone());
             branches.add(branch);
 
             while (it.hasNext()) {
-                branch = __.start();
-                applyAll(it.next(), branch, false, state.clone());
+                branch = hwk__();
+                applyAll(discriminator, it.next(), branch, false, state.clone());
                 branches.add(branch);
             }
 
@@ -276,10 +278,12 @@ abstract class FilterApplicator<T extends Filter> {
     /**
      * To be implemented by inheritors, this applies the filter this applicator holds to the provided query taking into
      * the account the type of the filter.
-     *
+     *  @param discriminator the discriminator to apply to the query
      * @param query the query to update with filter
+     * @param state the query traversal translation state
      */
-    public abstract void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state);
+    public abstract void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query,
+                                 QueryTranslationState state);
 
     public Filter filter() {
         return filter;
@@ -296,8 +300,8 @@ abstract class FilterApplicator<T extends Filter> {
             super(filter);
         }
 
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
-            visitor.visit(query, filter, state);
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
+            visitor.visit(discriminator, query, filter, state);
         }
     }
 
@@ -306,8 +310,8 @@ abstract class FilterApplicator<T extends Filter> {
             super(filter);
         }
 
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
-            visitor.visit(query, filter, state);
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
+            visitor.visit(discriminator, query, filter, state);
         }
     }
 
@@ -316,8 +320,8 @@ abstract class FilterApplicator<T extends Filter> {
             super(filter);
         }
 
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
-            visitor.visit(query, filter, state);
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
+            visitor.visit(discriminator, query, filter, state);
         }
     }
 
@@ -326,8 +330,8 @@ abstract class FilterApplicator<T extends Filter> {
             super(filter);
         }
 
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
-            visitor.visit(query, filter, state);
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
+            visitor.visit(discriminator, query, filter, state);
         }
     }
 
@@ -337,8 +341,8 @@ abstract class FilterApplicator<T extends Filter> {
             super(filter);
         }
 
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
-            visitor.visit(query, filter, state);
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
+            visitor.visit(discriminator, query, filter, state);
         }
     }
 
@@ -349,8 +353,8 @@ abstract class FilterApplicator<T extends Filter> {
             super(filter);
         }
 
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
-            visitor.visit(query, filter, state);
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
+            visitor.visit(discriminator, query, filter, state);
         }
     }
 
@@ -361,8 +365,8 @@ abstract class FilterApplicator<T extends Filter> {
             super(filter);
         }
 
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
-            visitor.visit(query, filter, state);
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
+            visitor.visit(discriminator, query, filter, state);
         }
 
     }
@@ -373,8 +377,8 @@ abstract class FilterApplicator<T extends Filter> {
             super(filter);
         }
 
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
-            visitor.visit(query, filter, state);
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
+            visitor.visit(discriminator, query, filter, state);
         }
     }
 
@@ -383,7 +387,7 @@ abstract class FilterApplicator<T extends Filter> {
             super(filter);
         }
 
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
             visitor.visit(query, filter, state);
         }
     }
@@ -393,7 +397,7 @@ abstract class FilterApplicator<T extends Filter> {
             super(filter);
         }
 
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
             visitor.visit(query, filter, state);
         }
     }
@@ -405,8 +409,8 @@ abstract class FilterApplicator<T extends Filter> {
         }
 
         @Override
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
-            visitor.visit(query, filter, state);
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
+            visitor.visit(discriminator, query, filter, state);
         }
     }
 
@@ -417,7 +421,7 @@ abstract class FilterApplicator<T extends Filter> {
         }
 
         @Override
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
             visitor.visit(query, filter, state);
         }
     }
@@ -429,8 +433,8 @@ abstract class FilterApplicator<T extends Filter> {
         }
 
         @Override
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
-            visitor.visit(query, filter, state);
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
+            visitor.visit(discriminator, query, filter, state);
         }
     }
 
@@ -441,7 +445,7 @@ abstract class FilterApplicator<T extends Filter> {
         }
 
         @Override
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
             visitor.visit(query, filter, state);
         }
     }
@@ -453,8 +457,8 @@ abstract class FilterApplicator<T extends Filter> {
         }
 
         @Override
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
-            visitor.visit(query, filter, state);
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
+            visitor.visit(discriminator, query, filter, state);
         }
     }
 
@@ -465,7 +469,7 @@ abstract class FilterApplicator<T extends Filter> {
         }
 
         @Override
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
             visitor.visit(query, filter, state);
         }
     }
@@ -477,7 +481,7 @@ abstract class FilterApplicator<T extends Filter> {
         }
 
         @Override
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
             visitor.visit(query, filter, state);
         }
     }
@@ -489,8 +493,8 @@ abstract class FilterApplicator<T extends Filter> {
         }
 
         @Override
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
-            visitor.visit(query, filter, state);
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
+            visitor.visit(discriminator, query, filter, state);
         }
     }
 
@@ -501,7 +505,7 @@ abstract class FilterApplicator<T extends Filter> {
         }
 
         @Override
-        public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
+        public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
             visitor.visit(query, filter, state);
         }
     }
@@ -512,8 +516,8 @@ abstract class FilterApplicator<T extends Filter> {
             super(names);
         }
 
-        @Override public void applyTo(GraphTraversal<?, ?> query, QueryTranslationState state) {
-            visitor.visit(query, filter, state);
+        @Override public void applyTo(Discriminator discriminator, HawkularTraversal<?, ?> query, QueryTranslationState state) {
+            visitor.visit(discriminator, query, filter, state);
         }
     }
 }

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterVisitor.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterVisitor.java
@@ -366,13 +366,15 @@ class FilterVisitor {
         if (filter.getPaths().length == 1) {
             //this only works if we are on vertices, so check for that
             if (prop.equals(__cp.name())) {
-                query.has(T.label, Constants.Type.of(filter.getPaths()[0].getSegment().getElementType()).name());
+                query.has(T.label, Constants.Type.of(filter.getPaths()[0].getSegment().getElementType())
+                        .identityVertexLabel());
             }
 
             query.has(prop, filter.getPaths()[0].toString());
         } else {
             if (prop.equals(__cp.name())) {
-                String[] labels = Stream.of(filter.getPaths()).map(p -> p.getSegment().getElementType())
+                String[] labels = Stream.of(filter.getPaths())
+                        .map(p -> Constants.Type.of(p.getSegment().getElementType()).identityVertexLabel())
                         .toArray(String[]::new);
 
                 query.has(T.label, P.within(labels));
@@ -572,10 +574,11 @@ class FilterVisitor {
                 pipeline.inE(contains.name()).restrictTo(discriminator).outV();
                 pipeline.existsAt(discriminator);
             } else {
+                Constants.Type targetType = Constants.Type.of(s.getElementType());
                 pipeline.outE(contains.name()).restrictTo(discriminator)
-                        .has(__targetType.name(),
-                                Constants.Type.of(Entity.typeFromSegmentType(s.getElementType())).name())
-                        .has(__targetEid.name(), s.getElementId()).inV();
+                        .has(__targetType.name(), targetType.name())
+                        .has(__targetEid.name(), s.getElementId()).inV()
+                        .hasLabel(targetType.identityVertexLabel());
                 pipeline.existsAt(discriminator);
             }
         }

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterVisitor.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterVisitor.java
@@ -536,7 +536,7 @@ class FilterVisitor {
 
             for (Filter f : recurseFilter.getLoopChains()[0]) {
                 FilterApplicator<?> applicator = FilterApplicator.of(f);
-                applicator.applyTo(discriminator, descend, state);
+                applicator.applyTo(discriminator, descend, descendState);
             }
 
             goBackFromEdges(descend, descendState);

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterVisitor.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/FilterVisitor.java
@@ -143,10 +143,9 @@ class FilterVisitor {
 
         if (ids.getIds().length == 1) {
             query.has(prop, ids.getIds()[0]);
-            return;
+        } else {
+            query.has(prop, P.within(ids.getIds()));
         }
-
-        query.has(prop, P.within(ids.getIds()));
 
         goBackFromEdges(query, state);
         query.existsAt(discriminator);

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/HawkularTraversal.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/HawkularTraversal.java
@@ -30,23 +30,31 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
+import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Path;
 import org.apache.tinkerpop.gremlin.process.traversal.Pop;
 import org.apache.tinkerpop.gremlin.process.traversal.Scope;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalSideEffects;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.TraverserGenerator;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.TraverserSet;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalExplanation;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalMetrics;
 import org.apache.tinkerpop.gremlin.structure.Column;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -58,7 +66,7 @@ import org.hawkular.inventory.impl.tinkerpop.spi.Constants;
  * @author Lukas Krejci
  * @since 0.20.0
  */
-public class HawkularTraversal<S, E> implements GraphTraversal<S, E> {
+public class HawkularTraversal<S, E> implements GraphTraversal<S, E>, GraphTraversal.Admin<S, E> {
 
     private final GraphTraversal<S, E> delegate;
 
@@ -87,8 +95,9 @@ public class HawkularTraversal<S, E> implements GraphTraversal<S, E> {
         return this.has(Constants.Property.__from.name(), P.lte(time)).has(Constants.Property.__to.name(), P.gt(time));
     }
 
+    @SuppressWarnings("unchecked")
     private <A, B> HawkularTraversal<A, B> castThis(GraphTraversal<A, B> that) {
-        return (HawkularTraversal<A, B>) that;
+        return (HawkularTraversal<A, B>) this;
     }
 
     ////// DELEGATED methods
@@ -865,5 +874,121 @@ public class HawkularTraversal<S, E> implements GraphTraversal<S, E> {
 
     @Override public void remove() {
         delegate.remove();
+    }
+
+    @Override public Admin<S, E> clone() {
+        return ((Admin<S, E>) delegate).clone();
+    }
+
+    @Override public Bytecode getBytecode() {
+        return ((Admin<S, E>) delegate).getBytecode();
+    }
+
+    @Override public List<Step> getSteps() {
+        return ((Admin<S, E>) delegate).getSteps();
+    }
+
+    @Override public <S2, E2> Traversal.Admin<S2, E2> addStep(int index, Step<?, ?> step) throws IllegalStateException {
+        return ((Admin<S, E>) delegate).addStep(index, step);
+    }
+
+    @Override public <S2, E2> Traversal.Admin<S2, E2> removeStep(int index) throws IllegalStateException {
+        return ((Admin<S, E>) delegate).removeStep(index);
+    }
+
+    @Override public void applyStrategies() throws IllegalStateException {
+        ((Admin<S, E>) delegate).applyStrategies();
+    }
+
+    @Override public TraverserGenerator getTraverserGenerator() {
+        return ((Admin<S, E>) delegate).getTraverserGenerator();
+    }
+
+    @Override public Set<TraverserRequirement> getTraverserRequirements() {
+        return ((Admin<S, E>) delegate).getTraverserRequirements();
+    }
+
+    @Override public void setSideEffects(TraversalSideEffects sideEffects) {
+        ((Admin<S, E>) delegate).setSideEffects(sideEffects);
+    }
+
+    @Override public TraversalSideEffects getSideEffects() {
+        return ((Admin<S, E>) delegate).getSideEffects();
+    }
+
+    @Override public void setStrategies(TraversalStrategies strategies) {
+        ((Admin<S, E>) delegate).setStrategies(strategies);
+    }
+
+    @Override public TraversalStrategies getStrategies() {
+        return ((Admin<S, E>) delegate).getStrategies();
+    }
+
+    @Override public void setParent(TraversalParent step) {
+        ((Admin<S, E>) delegate).setParent(step);
+    }
+
+    @Override public TraversalParent getParent() {
+        return ((Admin<S, E>) delegate).getParent();
+    }
+
+    @Override public boolean isLocked() {
+        return ((Admin<S, E>) delegate).isLocked();
+    }
+
+    @Override public Optional<Graph> getGraph() {
+        return ((Admin<S, E>) delegate).getGraph();
+    }
+
+    @Override public void setGraph(Graph graph) {
+        ((Admin<S, E>) delegate).setGraph(graph);
+    }
+
+    @Override public <E2> Admin<S, E2> addStep(Step<?, E2> step) {
+        return ((Admin<S, E>) delegate).addStep(step);
+    }
+
+    @Override public void addStarts(Iterator<Traverser.Admin<S>> starts) {
+        ((Admin<S, E>) delegate).addStarts(starts);
+    }
+
+    @Override public void addStart(Traverser.Admin<S> start) {
+        ((Admin<S, E>) delegate).addStart(start);
+    }
+
+    @Override public <S2, E2> Traversal.Admin<S2, E2> removeStep(Step<?, ?> step) throws IllegalStateException {
+        return ((Admin<S, E>) delegate).removeStep(step);
+    }
+
+    @Override public Step<S, ?> getStartStep() {
+        return ((Admin<S, E>) delegate).getStartStep();
+    }
+
+    @Override public Step<?, E> getEndStep() {
+        return ((Admin<S, E>) delegate).getEndStep();
+    }
+
+    @Override public void reset() {
+        ((Admin<S, E>) delegate).reset();
+    }
+
+    @Override public boolean equals(Object obj) {
+        return delegate.equals(obj);
+    }
+
+    @Override public boolean equals(Traversal.Admin<S, E> other) {
+        return ((Admin<S, E>) delegate).equals(other);
+    }
+
+    @Override public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override public Traverser.Admin<E> nextTraverser() {
+        return ((Admin<S, E>) delegate).nextTraverser();
+    }
+
+    @Override public String toString() {
+        return delegate.toString();
     }
 }

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/HawkularTraversal.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/HawkularTraversal.java
@@ -1,0 +1,869 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.impl.tinkerpop;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.Path;
+import org.apache.tinkerpop.gremlin.process.traversal.Pop;
+import org.apache.tinkerpop.gremlin.process.traversal.Scope;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.Tree;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.util.TraverserSet;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalExplanation;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalMetrics;
+import org.apache.tinkerpop.gremlin.structure.Column;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Property;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
+import org.hawkular.inventory.base.spi.Discriminator;
+import org.hawkular.inventory.impl.tinkerpop.spi.Constants;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.20.0
+ */
+public class HawkularTraversal<S, E> implements GraphTraversal<S, E> {
+
+    private final GraphTraversal<S, E> delegate;
+
+    public static <A, B> HawkularTraversal<A, B> hwk(GraphTraversal<A, B> tr) {
+        return new HawkularTraversal<>(tr);
+    }
+
+    public static <A> HawkularTraversal<A, A> hwk__() {
+        return hwk(__.<A>start());
+    }
+
+    public static <A> HawkularTraversal<A, A> hwk__(A... starts) {
+        return hwk(__.__(starts));
+    }
+
+    public HawkularTraversal(GraphTraversal<S, E> delegate) {
+        this.delegate = delegate;
+    }
+
+    public HawkularTraversal<S, E> discriminate(Discriminator discriminator) {
+        if (discriminator == null || discriminator.getTime() == null) {
+            return this;
+        }
+
+        long time = discriminator.getTime().toEpochMilli();
+        return this.has(Constants.Property.__from.name(), P.lte(time)).has(Constants.Property.__to.name(), P.gt(time));
+    }
+
+    private <A, B> HawkularTraversal<A, B> castThis(GraphTraversal<A, B> that) {
+        return (HawkularTraversal<A, B>) that;
+    }
+
+    ////// DELEGATED methods
+
+    @Override public Admin<S, E> asAdmin() {
+        return delegate.asAdmin();
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> map(Function<Traverser<E>, E2> function) {
+        return castThis(delegate.map(function));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> map(Traversal<?, E2> mapTraversal) {
+        return castThis(delegate.map(mapTraversal));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> flatMap(
+            Function<Traverser<E>, Iterator<E2>> function) {
+        return castThis(delegate.flatMap(function));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> flatMap(
+            Traversal<?, E2> flatMapTraversal) {
+        return castThis(delegate.flatMap(flatMapTraversal));
+    }
+
+    @Override public HawkularTraversal<S, Object> id() {
+        return castThis(delegate.id());
+    }
+
+    @Override public HawkularTraversal<S, String> label() {
+        return castThis(delegate.label());
+    }
+
+    @Override public HawkularTraversal<S, E> identity() {
+        return castThis(delegate.identity());
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> constant(E2 e) {
+        return castThis(delegate.constant(e));
+    }
+
+    @Override public HawkularTraversal<S, Vertex> V(Object... vertexIdsOrElements) {
+        return castThis(delegate.V(vertexIdsOrElements));
+    }
+
+    @Override public HawkularTraversal<S, Vertex> to(
+            Direction direction, String... edgeLabels) {
+        return castThis(delegate.to(direction, edgeLabels));
+    }
+
+    @Override public HawkularTraversal<S, Vertex> out(String... edgeLabels) {
+        return castThis(delegate.out(edgeLabels));
+    }
+
+    @Override public HawkularTraversal<S, Vertex> in(String... edgeLabels) {
+        return castThis(delegate.in(edgeLabels));
+    }
+
+    @Override public HawkularTraversal<S, Vertex> both(String... edgeLabels) {
+        return castThis(delegate.both(edgeLabels));
+    }
+
+    @Override public HawkularTraversal<S, Edge> toE(
+            Direction direction, String... edgeLabels) {
+        return castThis(delegate.toE(direction, edgeLabels));
+    }
+
+    @Override public HawkularTraversal<S, Edge> outE(String... edgeLabels) {
+        return castThis(delegate.outE(edgeLabels));
+    }
+
+    @Override public HawkularTraversal<S, Edge> inE(String... edgeLabels) {
+        return castThis(delegate.inE(edgeLabels));
+    }
+
+    @Override public HawkularTraversal<S, Edge> bothE(String... edgeLabels) {
+        return castThis(delegate.bothE(edgeLabels));
+    }
+
+    @Override public HawkularTraversal<S, Vertex> toV(
+            Direction direction) {
+        return castThis(delegate.toV(direction));
+    }
+
+    @Override public HawkularTraversal<S, Vertex> inV() {
+        return castThis(delegate.inV());
+    }
+
+    @Override public HawkularTraversal<S, Vertex> outV() {
+        return castThis(delegate.outV());
+    }
+
+    @Override public HawkularTraversal<S, Vertex> bothV() {
+        return castThis(delegate.bothV());
+    }
+
+    @Override public HawkularTraversal<S, Vertex> otherV() {
+        return castThis(delegate.otherV());
+    }
+
+    @Override public HawkularTraversal<S, E> order() {
+        return castThis(delegate.order());
+    }
+
+    @Override public HawkularTraversal<S, E> order(Scope scope) {
+        return castThis(delegate.order(scope));
+    }
+
+    @Override public <E2> HawkularTraversal<S, ? extends Property<E2>> properties(String... propertyKeys) {
+        return castThis(delegate.<E2>properties(propertyKeys));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> values(String... propertyKeys) {
+        return castThis(delegate.values(propertyKeys));
+    }
+
+    @Override public <E2> HawkularTraversal<S, Map<String, E2>> propertyMap(String... propertyKeys) {
+        return castThis(delegate.propertyMap(propertyKeys));
+    }
+
+    @Override public <E2> HawkularTraversal<S, Map<String, E2>> valueMap(String... propertyKeys) {
+        return castThis(delegate.valueMap(propertyKeys));
+    }
+
+    @Override public <E2> HawkularTraversal<S, Map<String, E2>> valueMap(boolean includeTokens, String... propertyKeys) {
+        return castThis(delegate.valueMap(includeTokens, propertyKeys));
+    }
+
+    @Override public <E2> HawkularTraversal<S, Collection<E2>> select(Column column) {
+        return castThis(delegate.select(column));
+    }
+
+    @Override @Deprecated public <E2> HawkularTraversal<S, E2> mapValues() {
+        return castThis(delegate.mapValues());
+    }
+
+    @Override @Deprecated public <E2> HawkularTraversal<S, E2> mapKeys() {
+        return castThis(delegate.mapKeys());
+    }
+
+    @Override public HawkularTraversal<S, String> key() {
+        return castThis(delegate.key());
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> value() {
+        return castThis(delegate.value());
+    }
+
+    @Override public HawkularTraversal<S, Path> path() {
+        return castThis(delegate.path());
+    }
+
+    @Override public <E2> HawkularTraversal<S, Map<String, E2>> match(
+            Traversal<?, ?>... matchTraversals) {
+        return castThis(delegate.match(matchTraversals));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> sack() {
+        return castThis(delegate.sack());
+    }
+
+    @Override public HawkularTraversal<S, Integer> loops() {
+        return castThis(delegate.loops());
+    }
+
+    @Override public <E2> HawkularTraversal<S, Map<String, E2>> project(String projectKey, String... otherProjectKeys) {
+        return castThis(delegate.project(projectKey, otherProjectKeys));
+    }
+
+    @Override public <E2> HawkularTraversal<S, Map<String, E2>> select(Pop pop,
+                                                                    String selectKey1, String selectKey2,
+                                                                    String... otherSelectKeys) {
+        return castThis(delegate.select(pop, selectKey1, selectKey2, otherSelectKeys));
+    }
+
+    @Override public <E2> HawkularTraversal<S, Map<String, E2>> select(String selectKey1, String selectKey2,
+                                                                    String... otherSelectKeys) {
+        return castThis(delegate.select(selectKey1, selectKey2, otherSelectKeys));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> select(Pop pop,
+                                                       String selectKey) {
+        return castThis(delegate.select(pop, selectKey));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> select(String selectKey) {
+        return castThis(delegate.select(selectKey));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> unfold() {
+        return castThis(delegate.unfold());
+    }
+
+    @Override public HawkularTraversal<S, List<E>> fold() {
+        return castThis(delegate.fold());
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> fold(E2 seed, BiFunction<E2, E, E2> foldFunction) {
+        return castThis(delegate.fold(seed, foldFunction));
+    }
+
+    @Override public HawkularTraversal<S, Long> count() {
+        return castThis(delegate.count());
+    }
+
+    @Override public HawkularTraversal<S, Long> count(Scope scope) {
+        return castThis(delegate.count(scope));
+    }
+
+    @Override public <E2 extends Number> HawkularTraversal<S, E2> sum() {
+        return castThis(delegate.sum());
+    }
+
+    @Override public <E2 extends Number> HawkularTraversal<S, E2> sum(Scope scope) {
+        return castThis(delegate.sum(scope));
+    }
+
+    @Override public <E2 extends Number> HawkularTraversal<S, E2> max() {
+        return castThis(delegate.max());
+    }
+
+    @Override public <E2 extends Number> HawkularTraversal<S, E2> max(Scope scope) {
+        return castThis(delegate.max(scope));
+    }
+
+    @Override public <E2 extends Number> HawkularTraversal<S, E2> min() {
+        return castThis(delegate.min());
+    }
+
+    @Override public <E2 extends Number> HawkularTraversal<S, E2> min(Scope scope) {
+        return castThis(delegate.min(scope));
+    }
+
+    @Override public <E2 extends Number> HawkularTraversal<S, E2> mean() {
+        return castThis(delegate.mean());
+    }
+
+    @Override public <E2 extends Number> HawkularTraversal<S, E2> mean(Scope scope) {
+        return castThis(delegate.mean(scope));
+    }
+
+    @Override public <K, V> HawkularTraversal<S, Map<K, V>> group() {
+        return castThis(delegate.group());
+    }
+
+    @Override @Deprecated public <K, V> HawkularTraversal<S, Map<K, V>> groupV3d0() {
+        return castThis(delegate.groupV3d0());
+    }
+
+    @Override public <K> HawkularTraversal<S, Map<K, Long>> groupCount() {
+        return castThis(delegate.groupCount());
+    }
+
+    @Override public HawkularTraversal<S, Tree> tree() {
+        return castThis(delegate.tree());
+    }
+
+    @Override public HawkularTraversal<S, Vertex> addV(String vertexLabel) {
+        return castThis(delegate.addV(vertexLabel));
+    }
+
+    @Override public HawkularTraversal<S, Vertex> addV() {
+        return castThis(delegate.addV());
+    }
+
+    @Override @Deprecated public HawkularTraversal<S, Vertex> addV(Object... propertyKeyValues) {
+        return castThis(delegate.addV(propertyKeyValues));
+    }
+
+    @Override public HawkularTraversal<S, Edge> addE(String edgeLabel) {
+        return castThis(delegate.addE(edgeLabel));
+    }
+
+    @Override public HawkularTraversal<S, E> to(String toStepLabel) {
+        return castThis(delegate.to(toStepLabel));
+    }
+
+    @Override public HawkularTraversal<S, E> from(String fromStepLabel) {
+        return castThis(delegate.from(fromStepLabel));
+    }
+
+    @Override public HawkularTraversal<S, E> to(
+            Traversal<E, Vertex> toVertex) {
+        return castThis(delegate.to(toVertex));
+    }
+
+    @Override public HawkularTraversal<S, E> from(
+            Traversal<E, Vertex> fromVertex) {
+        return castThis(delegate.from(fromVertex));
+    }
+
+    @Override @Deprecated public HawkularTraversal<S, Edge> addE(
+            Direction direction, String firstVertexKeyOrEdgeLabel,
+            String edgeLabelOrSecondVertexKey, Object... propertyKeyValues) {
+        return castThis(delegate.addE(direction, firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey, propertyKeyValues));
+    }
+
+    @Override @Deprecated public HawkularTraversal<S, Edge> addOutE(String firstVertexKeyOrEdgeLabel,
+                                                                 String edgeLabelOrSecondVertexKey,
+                                                                 Object... propertyKeyValues) {
+        return castThis(delegate.addOutE(firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey, propertyKeyValues));
+    }
+
+    @Override @Deprecated public HawkularTraversal<S, Edge> addInE(String firstVertexKeyOrEdgeLabel,
+                                                                String edgeLabelOrSecondVertexKey,
+                                                                Object... propertyKeyValues) {
+        return castThis(delegate.addInE(firstVertexKeyOrEdgeLabel, edgeLabelOrSecondVertexKey, propertyKeyValues));
+    }
+
+    @Override public HawkularTraversal<S, E> filter(
+            Predicate<Traverser<E>> predicate) {
+        return castThis(delegate.filter(predicate));
+    }
+
+    @Override public HawkularTraversal<S, E> filter(Traversal<?, ?> filterTraversal) {
+        return castThis(delegate.filter(filterTraversal));
+    }
+
+    @Override public HawkularTraversal<S, E> or(Traversal<?, ?>... orTraversals) {
+        return castThis(delegate.or(orTraversals));
+    }
+
+    @Override public HawkularTraversal<S, E> and(Traversal<?, ?>... andTraversals) {
+        return castThis(delegate.and(andTraversals));
+    }
+
+    @Override public HawkularTraversal<S, E> inject(E... injections) {
+        return castThis(delegate.inject(injections));
+    }
+
+    @Override public HawkularTraversal<S, E> dedup(Scope scope,
+                                                String... dedupLabels) {
+        return castThis(delegate.dedup(scope, dedupLabels));
+    }
+
+    @Override public HawkularTraversal<S, E> dedup(String... dedupLabels) {
+        return castThis(delegate.dedup(dedupLabels));
+    }
+
+    @Override public HawkularTraversal<S, E> where(String startKey,
+                                                P<String> predicate) {
+        return castThis(delegate.where(startKey, predicate));
+    }
+
+    @Override public HawkularTraversal<S, E> where(P<String> predicate) {
+        return castThis(delegate.where(predicate));
+    }
+
+    @Override public HawkularTraversal<S, E> where(Traversal<?, ?> whereTraversal) {
+        return castThis(delegate.where(whereTraversal));
+    }
+
+    @Override public HawkularTraversal<S, E> has(String propertyKey, P<?> predicate) {
+        return castThis(delegate.has(propertyKey, predicate));
+    }
+
+    @Override public HawkularTraversal<S, E> has(T accessor,
+                                              P<?> predicate) {
+        return castThis(delegate.has(accessor, predicate));
+    }
+
+    @Override public HawkularTraversal<S, E> has(String propertyKey, Object value) {
+        return castThis(delegate.has(propertyKey, value));
+    }
+
+    @Override public HawkularTraversal<S, E> has(T accessor, Object value) {
+        return castThis(delegate.has(accessor, value));
+    }
+
+    @Override public HawkularTraversal<S, E> has(String label, String propertyKey,
+                                              P<?> predicate) {
+        return castThis(delegate.has(label, propertyKey, predicate));
+    }
+
+    @Override public HawkularTraversal<S, E> has(String label, String propertyKey, Object value) {
+        return castThis(delegate.has(label, propertyKey, value));
+    }
+
+    @Override public HawkularTraversal<S, E> has(T accessor,
+                                              Traversal<?, ?> propertyTraversal) {
+        return castThis(delegate.has(accessor, propertyTraversal));
+    }
+
+    @Override public HawkularTraversal<S, E> has(String propertyKey,
+                                              Traversal<?, ?> propertyTraversal) {
+        return castThis(delegate.has(propertyKey, propertyTraversal));
+    }
+
+    @Override public HawkularTraversal<S, E> has(String propertyKey) {
+        return castThis(delegate.has(propertyKey));
+    }
+
+    @Override public HawkularTraversal<S, E> hasNot(String propertyKey) {
+        return castThis(delegate.hasNot(propertyKey));
+    }
+
+    @Override public HawkularTraversal<S, E> has(T accessor, Object value,
+                                              Object... values) {
+        return castThis(delegate.has(accessor, value, values));
+    }
+
+    @Override public HawkularTraversal<S, E> hasLabel(Object value, Object... values) {
+        return castThis(delegate.hasLabel(value, values));
+    }
+
+    @Override public HawkularTraversal<S, E> hasId(Object value, Object... values) {
+        return castThis(delegate.hasId(value, values));
+    }
+
+    @Override public HawkularTraversal<S, E> hasKey(Object value, Object... values) {
+        return castThis(delegate.hasKey(value, values));
+    }
+
+    @Override public HawkularTraversal<S, E> hasValue(Object value, Object... values) {
+        return castThis(delegate.hasValue(value, values));
+    }
+
+    @Override public HawkularTraversal<S, E> is(P<E> predicate) {
+        return castThis(delegate.is(predicate));
+    }
+
+    @Override public HawkularTraversal<S, E> is(Object value) {
+        return castThis(delegate.is(value));
+    }
+
+    @Override public HawkularTraversal<S, E> not(Traversal<?, ?> notTraversal) {
+        return castThis(delegate.not(notTraversal));
+    }
+
+    @Override public HawkularTraversal<S, E> coin(double probability) {
+        return castThis(delegate.coin(probability));
+    }
+
+    @Override public HawkularTraversal<S, E> range(long low, long high) {
+        return castThis(delegate.range(low, high));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> range(Scope scope, long low, long high) {
+        return castThis(delegate.range(scope, low, high));
+    }
+
+    @Override public HawkularTraversal<S, E> limit(long limit) {
+        return castThis(delegate.limit(limit));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> limit(Scope scope, long limit) {
+        return castThis(delegate.limit(scope, limit));
+    }
+
+    @Override public HawkularTraversal<S, E> tail() {
+        return castThis(delegate.tail());
+    }
+
+    @Override public HawkularTraversal<S, E> tail(long limit) {
+        return castThis(delegate.tail(limit));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> tail(Scope scope) {
+        return castThis(delegate.tail(scope));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> tail(Scope scope, long limit) {
+        return castThis(delegate.tail(scope, limit));
+    }
+
+    @Override public HawkularTraversal<S, E> timeLimit(long timeLimit) {
+        return castThis(delegate.timeLimit(timeLimit));
+    }
+
+    @Override public HawkularTraversal<S, E> simplePath() {
+        return castThis(delegate.simplePath());
+    }
+
+    @Override public HawkularTraversal<S, E> cyclicPath() {
+        return castThis(delegate.cyclicPath());
+    }
+
+    @Override public HawkularTraversal<S, E> sample(int amountToSample) {
+        return castThis(delegate.sample(amountToSample));
+    }
+
+    @Override public HawkularTraversal<S, E> sample(Scope scope, int amountToSample) {
+        return castThis(delegate.sample(scope, amountToSample));
+    }
+
+    @Override public HawkularTraversal<S, E> drop() {
+        return castThis(delegate.drop());
+    }
+
+    @Override public HawkularTraversal<S, E> sideEffect(
+            Consumer<Traverser<E>> consumer) {
+        return castThis(delegate.sideEffect(consumer));
+    }
+
+    @Override public HawkularTraversal<S, E> sideEffect(
+            Traversal<?, ?> sideEffectTraversal) {
+        return castThis(delegate.sideEffect(sideEffectTraversal));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> cap(String sideEffectKey, String... sideEffectKeys) {
+        return castThis(delegate.cap(sideEffectKey, sideEffectKeys));
+    }
+
+    @Override public HawkularTraversal<S, Edge> subgraph(String sideEffectKey) {
+        return castThis(delegate.subgraph(sideEffectKey));
+    }
+
+    @Override public HawkularTraversal<S, E> aggregate(String sideEffectKey) {
+        return castThis(delegate.aggregate(sideEffectKey));
+    }
+
+    @Override public HawkularTraversal<S, E> group(String sideEffectKey) {
+        return castThis(delegate.group(sideEffectKey));
+    }
+
+    @Override public HawkularTraversal<S, E> groupV3d0(String sideEffectKey) {
+        return castThis(delegate.groupV3d0(sideEffectKey));
+    }
+
+    @Override public HawkularTraversal<S, E> groupCount(String sideEffectKey) {
+        return castThis(delegate.groupCount(sideEffectKey));
+    }
+
+    @Override public HawkularTraversal<S, E> tree(String sideEffectKey) {
+        return castThis(delegate.tree(sideEffectKey));
+    }
+
+    @Override public <V, U> HawkularTraversal<S, E> sack(BiFunction<V, U, V> sackOperator) {
+        return castThis(delegate.sack(sackOperator));
+    }
+
+    @Override @Deprecated public <V, U> HawkularTraversal<S, E> sack(BiFunction<V, U, V> sackOperator,
+                                                                  String elementPropertyKey) {
+        return castThis(delegate.sack(sackOperator, elementPropertyKey));
+    }
+
+    @Override public HawkularTraversal<S, E> store(String sideEffectKey) {
+        return castThis(delegate.store(sideEffectKey));
+    }
+
+    @Override public HawkularTraversal<S, E> profile(String sideEffectKey) {
+        return castThis(delegate.profile(sideEffectKey));
+    }
+
+    @Override public HawkularTraversal<S, TraversalMetrics> profile() {
+        return castThis(delegate.profile());
+    }
+
+    @Override public HawkularTraversal<S, E> property(VertexProperty.Cardinality cardinality,
+                                                   Object key, Object value, Object... keyValues) {
+        return castThis(delegate.property(cardinality, key, value, keyValues));
+    }
+
+    @Override public HawkularTraversal<S, E> property(Object key, Object value, Object... keyValues) {
+        return castThis(delegate.property(key, value, keyValues));
+    }
+
+    @Override public <M, E2> HawkularTraversal<S, E2> branch(
+            Traversal<?, M> branchTraversal) {
+        return castThis(delegate.branch(branchTraversal));
+    }
+
+    @Override public <M, E2> HawkularTraversal<S, E2> branch(
+            Function<Traverser<E>, M> function) {
+        return castThis(delegate.branch(function));
+    }
+
+    @Override public <M, E2> HawkularTraversal<S, E2> choose(
+            Traversal<?, M> choiceTraversal) {
+        return castThis(delegate.choose(choiceTraversal));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> choose(
+            Traversal<?, ?> traversalPredicate,
+            Traversal<?, E2> trueChoice,
+            Traversal<?, E2> falseChoice) {
+        return castThis(delegate.choose(traversalPredicate, trueChoice, falseChoice));
+    }
+
+    @Override public <M, E2> HawkularTraversal<S, E2> choose(Function<E, M> choiceFunction) {
+        return castThis(delegate.choose(choiceFunction));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> choose(Predicate<E> choosePredicate,
+                                                       Traversal<?, E2> trueChoice,
+                                                       Traversal<?, E2> falseChoice) {
+        return castThis(delegate.choose(choosePredicate, trueChoice, falseChoice));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> optional(
+            Traversal<?, E2> optionalTraversal) {
+        return castThis(delegate.optional(optionalTraversal));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> union(
+            Traversal<?, E2>... unionTraversals) {
+        return castThis(delegate.union(unionTraversals));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> coalesce(
+            Traversal<?, E2>... coalesceTraversals) {
+        return castThis(delegate.coalesce(coalesceTraversals));
+    }
+
+    @Override public HawkularTraversal<S, E> repeat(Traversal<?, E> repeatTraversal) {
+        return castThis(delegate.repeat(repeatTraversal));
+    }
+
+    @Override public HawkularTraversal<S, E> emit(Traversal<?, ?> emitTraversal) {
+        return castThis(delegate.emit(emitTraversal));
+    }
+
+    @Override public HawkularTraversal<S, E> emit(
+            Predicate<Traverser<E>> emitPredicate) {
+        return castThis(delegate.emit(emitPredicate));
+    }
+
+    @Override public HawkularTraversal<S, E> emit() {
+        return castThis(delegate.emit());
+    }
+
+    @Override public HawkularTraversal<S, E> until(Traversal<?, ?> untilTraversal) {
+        return castThis(delegate.until(untilTraversal));
+    }
+
+    @Override public HawkularTraversal<S, E> until(
+            Predicate<Traverser<E>> untilPredicate) {
+        return castThis(delegate.until(untilPredicate));
+    }
+
+    @Override public HawkularTraversal<S, E> times(int maxLoops) {
+        return castThis(delegate.times(maxLoops));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E2> local(Traversal<?, E2> localTraversal) {
+        return castThis(delegate.local(localTraversal));
+    }
+
+    @Override public HawkularTraversal<S, E> pageRank() {
+        return castThis(delegate.pageRank());
+    }
+
+    @Override public HawkularTraversal<S, E> pageRank(double alpha) {
+        return castThis(delegate.pageRank(alpha));
+    }
+
+    @Override public HawkularTraversal<S, E> peerPressure() {
+        return castThis(delegate.peerPressure());
+    }
+
+    @Override public HawkularTraversal<S, E> program(VertexProgram<?> vertexProgram) {
+        return castThis(delegate.program(vertexProgram));
+    }
+
+    @Override public HawkularTraversal<S, E> as(String stepLabel, String... stepLabels) {
+        return castThis(delegate.as(stepLabel, stepLabels));
+    }
+
+    @Override public HawkularTraversal<S, E> barrier() {
+        return castThis(delegate.barrier());
+    }
+
+    @Override public HawkularTraversal<S, E> barrier(int maxBarrierSize) {
+        return castThis(delegate.barrier(maxBarrierSize));
+    }
+
+    @Override public HawkularTraversal<S, E> barrier(
+            Consumer<TraverserSet<Object>> barrierConsumer) {
+        return castThis(delegate.barrier(barrierConsumer));
+    }
+
+    @Override public HawkularTraversal<S, E> by() {
+        return castThis(delegate.by());
+    }
+
+    @Override public HawkularTraversal<S, E> by(Traversal<?, ?> traversal) {
+        return castThis(delegate.by(traversal));
+    }
+
+    @Override public HawkularTraversal<S, E> by(T token) {
+        return castThis(delegate.by(token));
+    }
+
+    @Override public HawkularTraversal<S, E> by(String key) {
+        return castThis(delegate.by(key));
+    }
+
+    @Override public <V> HawkularTraversal<S, E> by(Function<V, Object> function) {
+        return castThis(delegate.by(function));
+    }
+
+    @Override public <V> HawkularTraversal<S, E> by(Traversal<?, ?> traversal,
+                                                 Comparator<V> comparator) {
+        return castThis(delegate.by(traversal, comparator));
+    }
+
+    @Override public HawkularTraversal<S, E> by(Comparator<E> comparator) {
+        return castThis(delegate.by(comparator));
+    }
+
+    @Override public HawkularTraversal<S, E> by(Order order) {
+        return castThis(delegate.by(order));
+    }
+
+    @Override public <V> HawkularTraversal<S, E> by(String key, Comparator<V> comparator) {
+        return castThis(delegate.by(key, comparator));
+    }
+
+    @Override public <U> HawkularTraversal<S, E> by(Function<U, Object> function, Comparator comparator) {
+        return castThis(delegate.by(function, comparator));
+    }
+
+    @Override public <M, E2> HawkularTraversal<S, E> option(M pickToken,
+                                                         Traversal<E, E2> traversalOption) {
+        return castThis(delegate.option(pickToken, traversalOption));
+    }
+
+    @Override public <E2> HawkularTraversal<S, E> option(Traversal<E, E2> traversalOption) {
+        return castThis(delegate.option(traversalOption));
+    }
+
+    @Override public HawkularTraversal<S, E> iterate() {
+        return castThis(delegate.iterate());
+    }
+
+    @Override public Optional<E> tryNext() {
+        return delegate.tryNext();
+    }
+
+    @Override public List<E> next(int amount) {
+        return delegate.next(amount);
+    }
+
+    @Override public List<E> toList() {
+        return delegate.toList();
+    }
+
+    @Override public Set<E> toSet() {
+        return delegate.toSet();
+    }
+
+    @Override public BulkSet<E> toBulkSet() {
+        return delegate.toBulkSet();
+    }
+
+    @Override public Stream<E> toStream() {
+        return delegate.toStream();
+    }
+
+    @Override public <C extends Collection<E>> C fill(C collection) {
+        return delegate.fill(collection);
+    }
+
+    @Override public TraversalExplanation explain() {
+        return delegate.explain();
+    }
+
+    @Override public <E2> void forEachRemaining(Class<E2> endType, Consumer<E2> consumer) {
+        delegate.forEachRemaining(endType, consumer);
+    }
+
+    @Override public void forEachRemaining(Consumer<? super E> action) {
+        delegate.forEachRemaining(action);
+    }
+
+    @Override public boolean hasNext() {
+        return delegate.hasNext();
+    }
+
+    @Override public E next() {
+        return delegate.next();
+    }
+
+    @Override public void remove() {
+        delegate.remove();
+    }
+}

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/HawkularTraversal.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/HawkularTraversal.java
@@ -97,22 +97,33 @@ public class HawkularTraversal<S, E> implements GraphTraversal<S, E>, GraphTrave
         long time = discriminator.getTime().toEpochMilli();
 
         if (inInterval) {
-            t.or(
-                    __.has(__from.name(), P.lte(time)).has(__to.name(), P.gt(time)),
-                    __.has(__from.name(), P.eq(time)).has(__to.name(), P.eq(time))
-            );
+            if (discriminator.isPreferExistence()) {
+                t.or(
+                        __.has(__from.name(), P.lte(time)).has(__to.name(), P.gt(time)),
+                        __.has(__from.name(), P.eq(time)).has(__to.name(), P.eq(time))
+                );
+            } else {
+                t.has(__from.name(), P.lte(time)).has(__to.name(), P.gt(time));
+            }
         } else {
             //negation of the above
-            t.and(
-                    __.or(
-                            __.has(__from.name(), P.gt(time)),
-                            __.has(__to.name(), P.lte(time))
-                    ),
-                    __.or(
-                            __.has(__from.name(), P.neq(time)),
-                            __.has(__to.name(), P.neq(time))
-                    )
-            );
+            if (discriminator.isPreferExistence()) {
+                t.and(
+                        __.or(
+                                __.has(__from.name(), P.gt(time)),
+                                __.has(__to.name(), P.lte(time))
+                        ),
+                        __.or(
+                                __.has(__from.name(), P.neq(time)),
+                                __.has(__to.name(), P.neq(time))
+                        )
+                );
+            } else {
+                t.or(
+                        __.has(__from.name(), P.gt(time)),
+                        __.has(__to.name(), P.lte(time))
+                );
+            }
         }
     }
 

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
@@ -995,7 +995,7 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
                         }
                     });
 
-                    Vertex state = context.getGraph().addVertex(type.name() + "_state");
+                    Vertex state = context.getGraph().addVertex(type.stateVertexLabel());
                     setNonNullProperty(state, Constants.Property.name.name(), name);
 
                     if (properties != null) {
@@ -1233,7 +1233,7 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
 
                 Vertex oldState = lastStateEdge.inVertex();
 
-                Vertex state = context.getGraph().addVertex(Constants.Type.of(actualType).name() + "_state");
+                Vertex state = context.getGraph().addVertex(Constants.Type.of(actualType).stateVertexLabel());
                 ElementHelper.propertyValueMap(oldState).forEach(state::property);
 
                 setNonNullProperty(state, Constants.Property.name.name(), name);

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
@@ -930,6 +930,7 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
                 created.second.property(Constants.Property.__metric_data_type.name(), type.getMetricDataType()
                         .getDisplayName());
                 created.second.property(Constants.Property.__metric_interval.name(), type.getCollectionInterval());
+                created.second.property(Constants.Property.__unit.name(), type.getUnit().getDisplayName());
 
                 return created.first;
             }

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopBackend.java
@@ -979,10 +979,12 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
 
                     checkProperties(properties, type.getMappedProperties());
 
+                    String cp = path.toString();
+
                     //check that there is no deleted vertex on our path...
                     Iterator<Vertex> check = hwk(context.getGraph().traversal().V())
                             .hasLabel(type.name())
-                            .has(__cp.name(), path.toString())
+                            .has(__cp.name(), cp)
                             .doesntExistAt(discriminator);
 
                     Vertex identity = closeAfter(check, () -> {
@@ -990,7 +992,7 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
                             return check.next();
                         } else {
                             Vertex ret = context.getGraph().addVertex(type.name());
-                            ret.property(__cp.name(), path.toString());
+                            ret.property(__cp.name(), cp);
                             ret.property(__type.name(), Constants.Type.of(cls).name());
                             ret.property(__eid.name(), path.getSegment().getElementId());
 
@@ -1232,7 +1234,10 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
                 }
 
                 Edge lastStateEdge = lastStateEdgeIt.next();
-                lastStateEdge.property(__to.name(), discriminator.getTime().toEpochMilli());
+
+                long time = discriminator.getTime().toEpochMilli();
+
+                lastStateEdge.property(__to.name(), time);
 
                 Vertex oldState = lastStateEdge.inVertex();
 
@@ -1243,7 +1248,7 @@ final class TinkerpopBackend implements InventoryBackend<Element> {
                 updateProperties(state, properties, disallowedProperties);
 
                 Edge newStateEdge = ((Vertex) entity).addEdge(__inState.name(), state);
-                newStateEdge.property(__from.name(), discriminator.getTime().toEpochMilli());
+                newStateEdge.property(__from.name(), time);
                 newStateEdge.property(__to.name(), Long.MAX_VALUE);
                 newStateEdge.property(__changeKind.name(), Action.updated().asEnum().ordinal());
 

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopInventory.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop/src/main/java/org/hawkular/inventory/impl/tinkerpop/TinkerpopInventory.java
@@ -184,7 +184,22 @@ public final class TinkerpopInventory extends BaseInventory<Element> {
                                 .withName(Constants.Property.__targetIdentityHash.name())
                                 .withType(String.class)
                                 .build())
+                        .build(),
+                IndexSpec.builder()
+                        .withElementType(Edge.class)
+                        .withProperty(IndexSpec.Property.builder()
+                                .withName(Constants.Property.__from.name())
+                                .withType(Long.class)
+                                .build())
+                        .build(),
+                IndexSpec.builder()
+                        .withElementType(Edge.class)
+                        .withProperty(IndexSpec.Property.builder()
+                                .withName(Constants.Property.__to.name())
+                                .withType(Long.class)
+                                .build())
                         .build());
+
         return graph;
     }
 

--- a/hawkular-inventory-impl-tinkerpop-parent/pom.xml
+++ b/hawkular-inventory-impl-tinkerpop-parent/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hawkular-inventory-parent</artifactId>
     <groupId>org.hawkular.inventory</groupId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-impl-tinkerpop-parent</artifactId>

--- a/hawkular-inventory-itest/pom.xml
+++ b/hawkular-inventory-itest/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular.inventory</groupId>
     <artifactId>hawkular-inventory-parent</artifactId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-itest</artifactId>

--- a/hawkular-inventory-itest/src/test/java/org/hawkular/inventory/rest/test/AbstractTestBase.java
+++ b/hawkular-inventory-itest/src/test/java/org/hawkular/inventory/rest/test/AbstractTestBase.java
@@ -121,6 +121,15 @@ public class AbstractTestBase {
         return response;
     }
 
+    protected static Response put(String path, Object payload) throws Throwable {
+        String json = mapper.writeValueAsString(payload);
+        String url = baseURI + path;
+        System.out.println("putting "+ url);
+        Request request =
+                newAuthRequest().url(url).put(RequestBody.create(MEDIA_TYPE_JSON, json)).build();
+        return client.newCall(request).execute();
+    }
+
     @SuppressWarnings("unchecked")
     protected static <T> T getWithRetries(String path, Class<T> type, int attemptCount, long attemptDelay)
             throws Throwable {

--- a/hawkular-inventory-itest/src/test/java/org/hawkular/inventory/rest/test/InventoryITest.java
+++ b/hawkular-inventory-itest/src/test/java/org/hawkular/inventory/rest/test/InventoryITest.java
@@ -1487,7 +1487,7 @@ public class InventoryITest extends AbstractTestBase {
         Response response = get(basePath + "/entity/e;" + environmentId + "/treeHash");
         assertEquals(400, response.code());
     }
-    
+
     public void testHistory_onEntity() throws Exception {
         //TODO implement
     }

--- a/hawkular-inventory-itest/src/test/java/org/hawkular/inventory/rest/test/InventoryITest.java
+++ b/hawkular-inventory-itest/src/test/java/org/hawkular/inventory/rest/test/InventoryITest.java
@@ -20,8 +20,13 @@ import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
 import static org.hawkular.inventory.api.Relationships.WellKnown.defines;
 import static org.hawkular.inventory.api.Relationships.WellKnown.incorporates;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,7 +44,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.hawkular.inventory.api.Action;
 import org.hawkular.inventory.api.Inventory;
+import org.hawkular.inventory.api.model.Change;
 import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.model.Environment;
 import org.hawkular.inventory.api.model.Feed;
@@ -52,6 +59,7 @@ import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.Resource;
 import org.hawkular.inventory.api.model.ResourceType;
 import org.hawkular.inventory.api.model.SyncHash;
+import org.hawkular.inventory.api.model.Tenant;
 import org.hawkular.inventory.json.InventoryJacksonConfig;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.Path;
@@ -1488,28 +1496,240 @@ public class InventoryITest extends AbstractTestBase {
         assertEquals(400, response.code());
     }
 
-    public void testHistory_onEntity() throws Exception {
-        //TODO implement
+    @Test
+    public void testHistory_onEntity() throws Throwable {
+
+        Instant beforeCreate = Instant.now();
+
+        Response response = post(basePath + "/entity/environment",
+                mapper.writeValueAsString(Environment.Blueprint.builder().withId("testHistory_onEntity").build()));
+        assertEquals(201, response.code());
+        Thread.sleep(10);
+        Instant afterCreate = Instant.now();
+
+        //do 2 updates
+        response = put(basePath + "/entity/e;testHistory_onEntity",
+                Environment.Update.builder().withName("My Env").build());
+        assertEquals(204, response.code());
+        Thread.sleep(10);
+        Instant afterFirstUpdate = Instant.now();
+
+        response = put(basePath + "/entity/e;testHistory_onEntity",
+                Environment.Update.builder().withName("My Env, like").build());
+        assertEquals(204, response.code());
+        Thread.sleep(10);
+        Instant afterSecondUpdate = Instant.now();
+
+        response = client.newCall(newAuthRequest().url(baseURI + basePath + "/entity/e;testHistory_onEntity").delete()
+                .build()).execute();
+        assertEquals(204, response.code());
+        Thread.sleep(10);
+        Instant afterDelete = Instant.now();
+
+        response = get(basePath + "/entity/e;testHistory_onEntity/history");
+        assertEquals(200, response.code());
+        List<Change<?>> changes = mapper.readValue(response.body().byteStream(),
+                new TypeReference<List<Change<?>>>() {});
+
+        assertEquals(4, changes.size());
+        Change<?> createChange = changes.get(0);
+        Change<?> firstUpdateChange = changes.get(1);
+        Change<?> secondUpdateChange = changes.get(2);
+        Change<?> deleteChange = changes.get(3);
+
+        assertEquals(Action.created().asEnum(), createChange.getAction().asEnum());
+        assertTrue(createChange.getTime().compareTo(beforeCreate) > 0);
+        assertTrue(createChange.getTime().compareTo(afterCreate) < 0);
+        assertEquals("testHistory_onEntity", ((Environment) createChange.getActionContext()).getId());
+
+        assertEquals(Action.updated().asEnum(), firstUpdateChange.getAction().asEnum());
+        assertTrue(firstUpdateChange.getTime().compareTo(afterCreate) > 0);
+        assertTrue(firstUpdateChange.getTime().compareTo(afterFirstUpdate) < 0);
+        assertEquals("testHistory_onEntity",
+                ((Action.Update<Environment, Environment.Update>) firstUpdateChange.getActionContext())
+                        .getOriginalEntity().getId());
+        assertNull(((Action.Update<Environment, Environment.Update>) firstUpdateChange.getActionContext())
+                .getOriginalEntity().getName());
+        assertEquals("My Env", ((Action.Update<Environment, Environment.Update>) firstUpdateChange.getActionContext())
+                .getUpdate().getName());
+
+        assertEquals(Action.updated().asEnum(), secondUpdateChange.getAction().asEnum());
+        assertTrue(secondUpdateChange.getTime().compareTo(afterFirstUpdate) > 0);
+        assertTrue(secondUpdateChange.getTime().compareTo(afterSecondUpdate) < 0);
+        assertEquals("testHistory_onEntity", ((Action.Update<Environment, Environment.Update>) firstUpdateChange.getActionContext())
+                .getOriginalEntity().getId());
+        assertEquals("My Env", ((Action.Update<Environment, Environment.Update>) secondUpdateChange.getActionContext())
+                .getOriginalEntity().getName());
+        assertEquals("My Env, like", ((Action.Update<Environment, Environment.Update>) secondUpdateChange
+                .getActionContext()).getUpdate().getName());
+
+        assertEquals(Action.deleted().asEnum(), deleteChange.getAction().asEnum());
+        assertTrue(deleteChange.getTime().compareTo(afterSecondUpdate) > 0);
+        assertTrue(deleteChange.getTime().compareTo(afterDelete) < 0);
+        assertEquals("testHistory_onEntity", ((Environment) createChange.getActionContext()).getId());
+        assertEquals("My Env, like", ((Environment) deleteChange.getActionContext()).getName());
+
+        response = get(basePath + "/entity/e;testHistory_onEntity/history",
+                "to", Long.toString(afterFirstUpdate.toEpochMilli()));
+        assertEquals(200, response.code());
+        changes = mapper.readValue(response.body().byteStream(), new TypeReference<List<Change<?>>>() {});
+        assertEquals(2, changes.size());
+        assertEquals(Action.created().asEnum(), changes.get(0).getAction().asEnum());
+        assertEquals(Action.updated().asEnum(), changes.get(1).getAction().asEnum());
+
+        response = get(basePath + "/entity/e;testHistory_onEntity/history",
+                "from", Long.toString(afterSecondUpdate.toEpochMilli()));
+        assertEquals(200, response.code());
+        changes = mapper.readValue(response.body().byteStream(), new TypeReference<List<Change<?>>>() {});
+        assertEquals(1, changes.size());
+        assertEquals(Action.deleted().asEnum(), changes.get(0).getAction().asEnum());
+
+        response = get(basePath + "/entity/e;testHistory_onEntity/history",
+                "from", Long.toString(afterCreate.toEpochMilli()),
+                "to", Long.toString(afterSecondUpdate.toEpochMilli()));
+        assertEquals(200, response.code());
+        changes = mapper.readValue(response.body().byteStream(), new TypeReference<List<Change<?>>>() {});
+        assertEquals(2, changes.size());
+        assertEquals(Action.updated().asEnum(), changes.get(0).getAction().asEnum());
+        assertEquals(Action.updated().asEnum(), changes.get(0).getAction().asEnum());
     }
 
     @Test
-    public void testHistory_onTenant() throws Exception {
-        //TODO implement
+    public void testHistory_onTenant() throws Throwable {
+        Instant beforeUpdate = Instant.now();
+
+        //do 2 updates
+        Response response = put(basePath + "/tenant",
+                Tenant.Update.builder().withName("My Tenant").build());
+        assertEquals(204, response.code());
+        Instant afterFirstUpdate = Instant.now();
+
+        response = put(basePath + "/tenant",
+                Tenant.Update.builder().withName("My Tenant, like").build());
+        assertEquals(204, response.code());
+        Instant afterSecondUpdate = Instant.now();
+
+        response = get(basePath + "/tenant/history");
+        assertEquals(200, response.code());
+        List<Change<?>> changes = mapper.readValue(response.body().byteStream(),
+                new TypeReference<List<Change<?>>>() {});
+
+        //we need to have at least 3 changes - 1 create and two of our updates. There might be other if other tests
+        //changed the tenant, too.
+        assertTrue(changes.size() > 2);
+        //first is the initial create... we don't care about it here
+        Change<?> firstUpdateChange = changes.get(changes.size() - 2);
+        Change<?> secondUpdateChange = changes.get(changes.size() - 1);
+
+        assertEquals(Action.updated().asEnum(), firstUpdateChange.getAction().asEnum());
+        assertTrue(firstUpdateChange.getTime().compareTo(beforeUpdate) > 0);
+        assertTrue(firstUpdateChange.getTime().compareTo(afterFirstUpdate) < 0);
+        assertEquals(tenantId,
+                ((Action.Update<Tenant, Tenant.Update>) firstUpdateChange.getActionContext())
+                        .getOriginalEntity().getId());
+        assertNull(((Action.Update<Tenant, Tenant.Update>) firstUpdateChange.getActionContext())
+                .getOriginalEntity().getName());
+        assertEquals("My Tenant", ((Action.Update<Tenant, Tenant.Update>) firstUpdateChange.getActionContext())
+                .getUpdate().getName());
+
+        assertEquals(Action.updated().asEnum(), secondUpdateChange.getAction().asEnum());
+        assertTrue(secondUpdateChange.getTime().compareTo(afterFirstUpdate) > 0);
+        assertTrue(secondUpdateChange.getTime().compareTo(afterSecondUpdate) < 0);
+        assertEquals(tenantId, ((Action.Update<Tenant, Tenant.Update>) firstUpdateChange.getActionContext())
+                .getOriginalEntity().getId());
+        assertEquals("My Tenant", ((Action.Update<Tenant, Tenant.Update>) secondUpdateChange.getActionContext())
+                .getOriginalEntity().getName());
+        assertEquals("My Tenant, like", ((Action.Update<Tenant, Tenant.Update>) secondUpdateChange
+                .getActionContext()).getUpdate().getName());
+
+        response = get(basePath + "/tenant/history",
+                "to", Long.toString(afterFirstUpdate.toEpochMilli()));
+        assertEquals(200, response.code());
+        changes = mapper.readValue(response.body().byteStream(), new TypeReference<List<Change<?>>>() {});
+        assertTrue(changes.size() > 1);
+        //again, the first one is the create
+        assertEquals(Action.updated().asEnum(), changes.get(changes.size() - 1).getAction().asEnum());
+
+        response = get(basePath + "/tenant/history",
+                "from", Long.toString(beforeUpdate.toEpochMilli()),
+                "to", Long.toString(afterSecondUpdate.toEpochMilli()));
+        assertEquals(200, response.code());
+        changes = mapper.readValue(response.body().byteStream(), new TypeReference<List<Change<?>>>() {});
+        assertEquals(2, changes.size());
+        assertEquals(Action.updated().asEnum(), changes.get(0).getAction().asEnum());
+        assertEquals(Action.updated().asEnum(), changes.get(1).getAction().asEnum());
     }
 
     @Test
-    public void testTimeConstraint_onEntity() throws Exception {
-        //TODO implement
+    public void testTimeConstraint_onEntity() throws Throwable {
+        Response response = get(basePath + "/entity/rt;" + urlTypeId, "at", "0");
+        assertEquals(404, response.code());
+
+        Instant beforeUpdate = Instant.now();
+
+        response = put(basePath + "/entity/rt;" + urlTypeId, ResourceType.Update.builder().withName("Changed name")
+                .build());
+        assertEquals(204, response.code());
+
+        Instant afterUpdate = Instant.now();
+
+        response = get(basePath + "/entity/rt;" + urlTypeId, "at", Long.toString(beforeUpdate.toEpochMilli()));
+        assertEquals(200, response.code());
+        ResourceType rt = mapper.readValue(response.body().byteStream(), ResourceType.class);
+        assertNotEquals("Changed name", rt.getName());
+
+        //try passing the time as a string instead of a numeric timestamp
+        response = get(basePath + "/entity/rt;" + urlTypeId, "at", afterUpdate.toString());
+        assertEquals(200, response.code());
+        rt = mapper.readValue(response.body().byteStream(), ResourceType.class);
+        assertEquals("Changed name", rt.getName());
+
+        //check the current state without any time specification
+        response = get(basePath + "/entity/rt;" + urlTypeId);
+        assertEquals(200, response.code());
+        rt = mapper.readValue(response.body().byteStream(), ResourceType.class);
+        assertEquals("Changed name", rt.getName());
     }
 
     @Test
-    public void testTimeConstraint_onTraversal() throws Exception {
-        //TODO implement
+    public void testTimeConstraint_onTraversal() throws Throwable {
+        Response response = get(basePath + "/traversal/type=rt", "at", "0");
+        assertEquals(200, response.code());
+        List<ResourceType> res = mapper.readValue(response.body().byteStream(),
+                new TypeReference<List<ResourceType>>() {});
+        assertTrue(res.isEmpty());
+
+        response = get(basePath + "/traversal/type=rt", "at", Instant.now().toString());
+        assertEquals(200, response.code());
+        res = mapper.readValue(response.body().byteStream(),
+                new TypeReference<List<ResourceType>>() {});
+        assertFalse(res.isEmpty());
     }
 
     @Test
-    public void testTimeConstraint_onTenant() throws Exception {
-        //TODO implement
+    public void testTimeConstraint_onTenant() throws Throwable {
+        Response response = get(basePath + "/tenant");
+        assertEquals(200, response.code());
+
+        Tenant origTenant = mapper.readValue(response.body().byteStream(), Tenant.class);
+
+        Instant beforeUpdate = Instant.now();
+
+        response = put(basePath + "/tenant", Tenant.Update.builder().withName(UUID.randomUUID().toString()).build());
+        assertEquals(204, response.code());
+
+        response = get(basePath + "/tenant");
+        assertEquals(200, response.code());
+
+        Tenant newTenant = mapper.readValue(response.body().byteStream(), Tenant.class);
+
+        assertNotEquals(newTenant.getName(), origTenant.getName());
+
+        response = get(basePath + "/tenant", "at", beforeUpdate.toString());
+        assertEquals(200, response.code());
+        Tenant checkTenant = mapper.readValue(response.body().byteStream(), Tenant.class);
+
+        assertEquals(origTenant.getName(), checkTenant.getName());
     }
 
     private <T> T readAs(String path, ObjectMapper mapper, Class<T> type) throws Throwable {

--- a/hawkular-inventory-itest/src/test/java/org/hawkular/inventory/rest/test/InventoryITest.java
+++ b/hawkular-inventory-itest/src/test/java/org/hawkular/inventory/rest/test/InventoryITest.java
@@ -1487,6 +1487,30 @@ public class InventoryITest extends AbstractTestBase {
         Response response = get(basePath + "/entity/e;" + environmentId + "/treeHash");
         assertEquals(400, response.code());
     }
+    
+    public void testHistory_onEntity() throws Exception {
+        //TODO implement
+    }
+
+    @Test
+    public void testHistory_onTenant() throws Exception {
+        //TODO implement
+    }
+
+    @Test
+    public void testTimeConstraint_onEntity() throws Exception {
+        //TODO implement
+    }
+
+    @Test
+    public void testTimeConstraint_onTraversal() throws Exception {
+        //TODO implement
+    }
+
+    @Test
+    public void testTimeConstraint_onTenant() throws Exception {
+        //TODO implement
+    }
 
     private <T> T readAs(String path, ObjectMapper mapper, Class<T> type) throws Throwable {
         Response response = get(basePath + path);

--- a/hawkular-inventory-json-helper/pom.xml
+++ b/hawkular-inventory-json-helper/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hawkular-inventory-parent</artifactId>
     <groupId>org.hawkular.inventory</groupId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-json-helper</artifactId>

--- a/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/InventoryJacksonConfig.java
+++ b/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/InventoryJacksonConfig.java
@@ -16,6 +16,7 @@
  */
 package org.hawkular.inventory.json;
 
+import org.hawkular.inventory.api.Action;
 import org.hawkular.inventory.api.FilterFragment;
 import org.hawkular.inventory.api.PathFragment;
 import org.hawkular.inventory.api.QueryFragment;
@@ -28,6 +29,7 @@ import org.hawkular.inventory.api.filters.RelationWith;
 import org.hawkular.inventory.api.filters.SwitchElementType;
 import org.hawkular.inventory.api.filters.With;
 import org.hawkular.inventory.api.model.AbstractElement;
+import org.hawkular.inventory.api.model.Change;
 import org.hawkular.inventory.api.model.DataEntity;
 import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.model.Environment;
@@ -58,7 +60,9 @@ import org.hawkular.inventory.json.mixins.filters.RelationWithMixin;
 import org.hawkular.inventory.json.mixins.filters.SwitchElementTypeMixin;
 import org.hawkular.inventory.json.mixins.filters.WithMixin;
 import org.hawkular.inventory.json.mixins.model.AbstractElementMixin;
+import org.hawkular.inventory.json.mixins.model.ActionUpdateMixin;
 import org.hawkular.inventory.json.mixins.model.CanonicalPathMixin;
+import org.hawkular.inventory.json.mixins.model.ChangeMixin;
 import org.hawkular.inventory.json.mixins.model.DataEntityMixin;
 import org.hawkular.inventory.json.mixins.model.EntityBlueprintMixin;
 import org.hawkular.inventory.json.mixins.model.EnvironmentMixin;
@@ -141,6 +145,8 @@ public final class InventoryJacksonConfig {
         objectMapper.addMixIn(IdentityHash.Tree.class, IdentityHashTreeMixin.class);
         objectMapper.addMixIn(SyncHash.Tree.class, SyncHashTreeMixin.class);
         objectMapper.addMixIn(MetricType.Blueprint.class, MetricTypeBlueprintMixin.class);
+        objectMapper.addMixIn(Change.class, ChangeMixin.class);
+        objectMapper.addMixIn(Action.Update.class, ActionUpdateMixin.class);
 
         /**
          * Query

--- a/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/mixins/model/ActionUpdateMixin.java
+++ b/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/mixins/model/ActionUpdateMixin.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.json.mixins.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.20.0
+ */
+public final class ActionUpdateMixin {
+
+    @JsonCreator
+    public ActionUpdateMixin(@JsonProperty("originalEntity") Object originalEntity,
+                             @JsonProperty("update") Object update) {
+
+    }
+}

--- a/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/mixins/model/ChangeMixin.java
+++ b/hawkular-inventory-json-helper/src/main/java/org/hawkular/inventory/json/mixins/model/ChangeMixin.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.inventory.json.mixins.model;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import org.hawkular.inventory.api.Action;
+import org.hawkular.inventory.api.Inventory;
+import org.hawkular.inventory.api.model.Blueprint;
+import org.hawkular.inventory.api.model.Change;
+import org.hawkular.inventory.api.model.Entity;
+import org.hawkular.inventory.paths.CanonicalPath;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.type.SimpleType;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.20.0
+ */
+@JsonSerialize(using = ChangeMixin.Serializer.class)
+@JsonDeserialize(using = ChangeMixin.Deserializer.class)
+public final class ChangeMixin {
+
+    public static final class Serializer extends JsonSerializer<Change<?>> {
+
+        @Override public void serialize(Change<?> value, JsonGenerator gen, SerializerProvider serializers)
+                throws IOException {
+            gen.writeStartObject();
+            gen.writeNumberField("time", value.getTime().toEpochMilli());
+            gen.writeStringField("action", value.getAction().asEnum().name().toLowerCase());
+            gen.writeObjectField("context", value.getActionContext());
+            gen.writeEndObject();
+        }
+    }
+
+    public static final class Deserializer extends JsonDeserializer<Change<?>> {
+
+        @Override public Change<?> deserialize(JsonParser p, DeserializationContext ctxt)
+                throws IOException {
+
+            Instant time = null;
+            String action = null;
+            JsonNode actionContext = null;
+
+            String currentField = "";
+            readFields: while (p.nextToken() != null) {
+                switch (p.getCurrentToken()) {
+                    case END_OBJECT:
+                        break readFields;
+                    case FIELD_NAME:
+                        currentField = p.getCurrentName();
+                        break;
+                    default:
+                        switch (currentField) {
+                            case "time":
+                                long timestamp = p.readValueAs(Long.class);
+                                time = Instant.ofEpochMilli(timestamp);
+                                break;
+                            case "action":
+                                action = p.readValueAs(String.class);
+                                break;
+                            case "context":
+                                actionContext = p.readValueAsTree();
+                                break;
+                        }
+                }
+            }
+
+            if (time == null || action == null || actionContext == null) {
+                throw new JsonParseException("Incomplete change object.", JsonLocation.NA);
+            }
+
+            CanonicalPath cp = findCp(action, actionContext);
+            @SuppressWarnings("unchecked")
+            Class<? extends Entity<?, ?>> et = (Class<? extends Entity<?, ?>>)
+                    Inventory.types().bySegment(cp.getSegment().getElementType()).getElementType();
+
+            return construct(ctxt, (Class) et, action, time, actionContext);
+        }
+
+        private CanonicalPath findCp(String action, JsonNode context) {
+            String cpStr;
+            if ("updated".equals(action)) {
+                cpStr = context.get("originalEntity").get("path").asText();
+            } else {
+                cpStr = context.get("path").asText();
+            }
+
+            return CanonicalPath.fromString(cpStr);
+        }
+
+        private <E extends Entity<B, U>, U extends Entity.Update, B extends Blueprint> Change<E>
+        construct(DeserializationContext ctx, Class<E> entityType, String action, Instant time, JsonNode contextNode)
+                throws IOException {
+
+            JsonParser p = ctx.getParser();
+
+            E entity;
+            switch (action) {
+                case "created":
+                    entity = p.getCodec().treeToValue(contextNode, entityType);
+                    return new Change<>(time, Action.created(), entity);
+                case "updated":
+                    Class<U> updateType = Inventory.types().byElement(entityType).getUpdateType();
+                    JavaType updateJavaType = ctx.getTypeFactory()
+                            .constructSimpleType(Action.Update.class, Action.Update.class,
+                                    new JavaType[] {SimpleType.construct(entityType), SimpleType.construct(updateType)});
+
+                    Action.Update<E, U> update = p.getCodec()
+                            .readValue(p.getCodec().treeAsTokens(contextNode), updateJavaType);
+                    return new Change<E>(time, Action.updated(), update);
+                case "deleted":
+                    entity = p.getCodec().treeToValue(contextNode, entityType);
+                    return new Change<>(time, Action.deleted(), entity);
+            }
+
+            throw new JsonParseException("Unknown action in change descriptor: " + action, JsonLocation.NA);
+        }
+    }
+}

--- a/hawkular-inventory-json-helper/src/test/java/org/hawkular/inventory/json/SerializationTest.java
+++ b/hawkular-inventory-json-helper/src/test/java/org/hawkular/inventory/json/SerializationTest.java
@@ -32,6 +32,7 @@ import java.beans.PropertyDescriptor;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.lang.reflect.Array;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -41,6 +42,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
 
+import org.hawkular.inventory.api.Action;
 import org.hawkular.inventory.api.FilterFragment;
 import org.hawkular.inventory.api.Query;
 import org.hawkular.inventory.api.filters.Contained;
@@ -52,6 +54,7 @@ import org.hawkular.inventory.api.filters.Related;
 import org.hawkular.inventory.api.filters.RelationWith;
 import org.hawkular.inventory.api.filters.SwitchElementType;
 import org.hawkular.inventory.api.filters.With;
+import org.hawkular.inventory.api.model.Change;
 import org.hawkular.inventory.api.model.DataEntity;
 import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.model.Environment;
@@ -653,6 +656,21 @@ public class SerializationTest {
         SyncHash.Tree t = SyncHash.treeOf(s, CanonicalPath.of().tenant("tnt").feed("feed").get());
 
         test(t);
+    }
+
+    @Test
+    public void testChange() throws Exception {
+        Tenant t = new Tenant("tenant", CanonicalPath.of().tenant("tnt").get(), "contentHash");
+
+        Change<Tenant> c = new Change<>(Instant.now(), Action.created(), t);
+        test(c);
+
+        c = new Change<Tenant>(Instant.now(), Action.updated(),
+                new Action.Update<>(t, Tenant.Update.builder().withName("kachna").build()));
+        test(c);
+
+        c = new Change<>(Instant.now(), Action.deleted(), t);
+        test(c);
     }
 
     private void testDetyped(Entity<?, ?> orig, String serialized) throws Exception {

--- a/hawkular-inventory-load-tests/pom.xml
+++ b/hawkular-inventory-load-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular.inventory</groupId>
     <artifactId>hawkular-inventory-parent</artifactId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-load-tests</artifactId>

--- a/hawkular-inventory-rest-api/pom.xml
+++ b/hawkular-inventory-rest-api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular.inventory</groupId>
     <artifactId>hawkular-inventory-parent</artifactId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-rest-api</artifactId>

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestBulk.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestBulk.java
@@ -359,17 +359,17 @@ public class RestBulk extends RestBase {
 
         CanonicalPath rootPath = CanonicalPath.of().tenant(getTenantId()).get();
 
-        Map<ElementType, Map<CanonicalPath, Integer>> statuses = bulkCreate(entities, rootPath);
+        Map<ElementType, Map<CanonicalPath, Integer>> statuses = bulkCreate(entities, rootPath, uriInfo);
 
         return Response.status(CREATED).entity(statuses).build();
     }
 
     private Map<ElementType, Map<CanonicalPath, Integer>> bulkCreate(Map<String, Map<ElementType,
-            List<Object>>> entities, CanonicalPath rootPath) {
+            List<Object>>> entities, CanonicalPath rootPath, UriInfo uriInfo) {
 
         Map<ElementType, Map<CanonicalPath, Integer>> statuses = new HashMap<>();
 
-        TransactionFrame transaction = inventory.newTransactionFrame();
+        TransactionFrame transaction = inventory(uriInfo).newTransactionFrame();
         Inventory binv = transaction.boundInventory();
 
         IdExtractor idExtractor = new IdExtractor();

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestBulk.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestBulk.java
@@ -50,7 +50,7 @@ import org.hawkular.inventory.api.OperationTypes;
 import org.hawkular.inventory.api.RelationAlreadyExistsException;
 import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.ResolvableToSingle;
-import org.hawkular.inventory.api.ResolvableToSingleWithRelationships;
+import org.hawkular.inventory.api.ResolvableToSingleEntity;
 import org.hawkular.inventory.api.ResourceTypes;
 import org.hawkular.inventory.api.Resources;
 import org.hawkular.inventory.api.Tenants;
@@ -394,7 +394,7 @@ public class RestBulk extends RestBase {
 
                     if (elementType == ElementType.relationship) {
                         bulkCreateRelationships(statuses, parentPath,
-                                (ResolvableToSingleWithRelationships<?, ?>) single, elementType, blueprints);
+                                (ResolvableToSingleEntity<?, ?>) single, elementType, blueprints);
                     } else {
                         bulkCreateEntity(statuses, idExtractor, parentPath, single, elementType, blueprints);
                     }
@@ -478,7 +478,7 @@ public class RestBulk extends RestBase {
     }
 
     private void bulkCreateRelationships(Map<ElementType, Map<CanonicalPath, Integer>> statuses,
-                                         CanonicalPath parentPath, ResolvableToSingleWithRelationships<?, ?> single,
+                                         CanonicalPath parentPath, ResolvableToSingleEntity<?, ?> single,
                                          ElementType elementType, List<Blueprint> blueprints) {
         if (!hasBeenCreatedInBulk(parentPath, statuses)) {
             if (!security.canAssociateFrom(parentPath)) {

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestSync.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestSync.java
@@ -74,7 +74,7 @@ public class RestSync extends RestBase {
                     + " are not synchronizable.");
         }
 
-        inventory.inspect(cp, Synced.SingleWithRelationships.class).synchronize(req);
+        inventory.inspect(cp, Synced.SingleEntity.class).synchronize(req);
 
         return Response.noContent().build();
     }

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestSync.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestSync.java
@@ -26,8 +26,10 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
 import org.hawkular.inventory.api.Synced;
 import org.hawkular.inventory.api.model.InventoryStructure;
@@ -66,7 +68,8 @@ public class RestSync extends RestBase {
             @ApiResponse(code = 500, message = "Internal server error", response = ApiError.class)
     })
     @SuppressWarnings("unchecked")
-    public Response sync(@Encoded @PathParam("path") List<PathSegment> path, SyncRequest<?> req) {
+    public Response sync(@Encoded @PathParam("path") List<PathSegment> path, SyncRequest<?> req,
+                         @Context UriInfo uriInfo) {
         CanonicalPath cp = parsePath(path);
 
         if (!InventoryStructure.EntityType.supports(cp.getSegment().getElementType())) {
@@ -74,7 +77,7 @@ public class RestSync extends RestBase {
                     + " are not synchronizable.");
         }
 
-        inventory.inspect(cp, Synced.SingleEntity.class).synchronize(req);
+        inventory(uriInfo).inspect(cp, Synced.SingleEntity.class).synchronize(req);
 
         return Response.noContent().build();
     }

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestTraversal.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestTraversal.java
@@ -55,7 +55,7 @@ public class RestTraversal extends RestBase {
         Pager pager = RequestUtil.extractPaging(uriInfo);
 
         @SuppressWarnings("unchecked")
-        Page<AbstractElement<?, ?>> results = inventory.execute(q, (Class) AbstractElement.class, pager);
+        Page<AbstractElement<?, ?>> results = inventory(uriInfo).execute(q, (Class) AbstractElement.class, pager);
 
         return pagedResponse(Response.ok(), uriInfo, results).build();
     }

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/Utils.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/Utils.java
@@ -24,7 +24,7 @@ import org.hawkular.inventory.api.MetricTypes;
 import org.hawkular.inventory.api.Metrics;
 import org.hawkular.inventory.api.OperationTypes;
 import org.hawkular.inventory.api.ResolvableToSingle;
-import org.hawkular.inventory.api.ResolvableToSingleWithRelationships;
+import org.hawkular.inventory.api.ResolvableToSingleEntity;
 import org.hawkular.inventory.api.ResourceTypes;
 import org.hawkular.inventory.api.Resources;
 import org.hawkular.inventory.api.Tenants;
@@ -142,8 +142,8 @@ public final class Utils {
                 }
                 break;
             case rl:
-                if (access instanceof ResolvableToSingleWithRelationships) {
-                    return createRelationship((ResolvableToSingleWithRelationships<?, ?>) access, childBlueprint);
+                if (access instanceof ResolvableToSingleEntity) {
+                    return createRelationship((ResolvableToSingleEntity<?, ?>) access, childBlueprint);
                 }
                 break;
             case rt:
@@ -158,7 +158,7 @@ public final class Utils {
                 + parent + "'.");
     }
 
-    private static Relationship createRelationship(ResolvableToSingleWithRelationships<?, ?> access,
+    private static Relationship createRelationship(ResolvableToSingleEntity<?, ?> access,
                                                    Object blueprint) {
 
         Relationship.Blueprint bl = (Relationship.Blueprint) blueprint;

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/cdi/AutoTenantInventoryProducer.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/cdi/AutoTenantInventoryProducer.java
@@ -171,8 +171,8 @@ public class AutoTenantInventoryProducer {
                 }
 
                 @Override
-                public void delete(String id, Instant time) throws EntityNotFoundException {
-                    actual.delete(id, time);
+                public void delete(String id) throws EntityNotFoundException {
+                    actual.delete(id);
                 }
 
                 @Override public void eradicate(String id) throws EntityNotFoundException {

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/cdi/AutoTenantInventoryProducer.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/cdi/AutoTenantInventoryProducer.java
@@ -17,6 +17,7 @@
 package org.hawkular.inventory.rest.cdi;
 
 import java.io.InputStream;
+import java.time.Instant;
 import java.util.Iterator;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -67,6 +68,10 @@ public class AutoTenantInventoryProducer {
 
         private AutotenantInventory(Inventory inventory) {
             this.inventory = inventory;
+        }
+
+        @Override public AutotenantInventory at(Instant time) {
+            return new AutotenantInventory(inventory.at(time));
         }
 
         @Override
@@ -166,8 +171,12 @@ public class AutoTenantInventoryProducer {
                 }
 
                 @Override
-                public void delete(String id) throws EntityNotFoundException {
-                    actual.delete(id);
+                public void delete(String id, Instant time) throws EntityNotFoundException {
+                    actual.delete(id, time);
+                }
+
+                @Override public void eradicate(String id) throws EntityNotFoundException {
+                    actual.eradicate(id);
                 }
             };
         }

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/deprecated/RestPath.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/deprecated/RestPath.java
@@ -36,7 +36,7 @@ import javax.ws.rs.ext.Providers;
 
 import org.hawkular.inventory.api.Relationships;
 import org.hawkular.inventory.api.ResolvableToSingle;
-import org.hawkular.inventory.api.ResolvableToSingleWithRelationships;
+import org.hawkular.inventory.api.ResolvableToSingleEntity;
 import org.hawkular.inventory.api.filters.RelationFilter;
 import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.model.Relationship;
@@ -125,9 +125,9 @@ public class RestPath extends RestBase {
         Pager pager = extractPaging(uriInfo);
 
         @SuppressWarnings("unchecked")
-        ResolvableToSingleWithRelationships<Relationship, Relationship.Update> resolvable =
-                (ResolvableToSingleWithRelationships<Relationship, Relationship.Update>) inventory.inspect(path,
-                        ResolvableToSingleWithRelationships.class);
+        ResolvableToSingleEntity<?, ?> resolvable =
+                (ResolvableToSingleEntity<?, ?>) inventory.inspect(path,
+                        ResolvableToSingleEntity.class);
         Page<Relationship> relations =
                 resolvable.relationships(Relationships.Direction.valueOf(direction)).getAll(filters).entities(pager);
 

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/deprecated/RestRelationships.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/deprecated/RestRelationships.java
@@ -45,10 +45,9 @@ import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.Providers;
 
 import org.hawkular.inventory.api.Relationships;
-import org.hawkular.inventory.api.ResolvableToSingleWithRelationships;
+import org.hawkular.inventory.api.ResolvableToSingleEntity;
 import org.hawkular.inventory.api.filters.RelationFilter;
 import org.hawkular.inventory.api.filters.RelationWith;
-import org.hawkular.inventory.api.model.AbstractElement;
 import org.hawkular.inventory.api.model.Entity;
 import org.hawkular.inventory.api.model.Environment;
 import org.hawkular.inventory.api.model.Feed;
@@ -133,7 +132,7 @@ public class RestRelationships extends RestBase {
         if (!cPath.isDefined()) {
             return Response.status(NOT_FOUND).build();
         }
-        ResolvableToSingleWithRelationships<Relationship, Relationship.Update> resolvable =
+        ResolvableToSingleEntity<?, ?> resolvable =
                 getResolvableFromCanonicalPath(cPath);
         Pager pager = extractPaging(uriInfo);
         RelationFilter[] filters = extractFilters(propertyName, propertyValue, named, sourceType,
@@ -183,7 +182,7 @@ public class RestRelationships extends RestBase {
         if (!cPath.isDefined()) {
             return Response.status(NOT_FOUND).build();
         }
-        ResolvableToSingleWithRelationships<Relationship, Relationship.Update> resolvable =
+        ResolvableToSingleEntity<?, ?> resolvable =
                 getResolvableFromCanonicalPath(cPath);
 
         // delete the relationship
@@ -216,7 +215,7 @@ public class RestRelationships extends RestBase {
         if (!cPath.isDefined()) {
             return Response.status(NOT_FOUND).build();
         }
-        ResolvableToSingleWithRelationships<Relationship, Relationship.Update> resolvable =
+        ResolvableToSingleEntity<?, ?> resolvable =
                 getResolvableFromCanonicalPath(cPath);
 
         Relationships.Direction directed;
@@ -266,7 +265,7 @@ public class RestRelationships extends RestBase {
         if (!cPath.isDefined()) {
             return Response.status(NOT_FOUND).build();
         }
-        ResolvableToSingleWithRelationships<Relationship, Relationship.Update> resolvable =
+        ResolvableToSingleEntity<?, ?> resolvable =
                 getResolvableFromCanonicalPath(cPath);
 
         // update the relationship
@@ -286,9 +285,9 @@ public class RestRelationships extends RestBase {
     }
 
     @SuppressWarnings("unchecked")
-    private <E extends AbstractElement<?, U>, U extends AbstractElement.Update>
-    ResolvableToSingleWithRelationships<E, U> getResolvableFromCanonicalPath(CanonicalPath cPath) {
-        return inventory.inspect(cPath, ResolvableToSingleWithRelationships.class);
+    private <E extends Entity<?, U>, U extends Entity.Update>
+    ResolvableToSingleEntity<E, U> getResolvableFromCanonicalPath(CanonicalPath cPath) {
+        return inventory.inspect(cPath, ResolvableToSingleEntity.class);
     }
 
     public static RelationFilter[] extractFilters(String propertyName,

--- a/hawkular-inventory-rest-api/src/main/rest-doc/swagger.json
+++ b/hawkular-inventory-rest-api/src/main/rest-doc/swagger.json
@@ -65,6 +65,11 @@
               }
             }
           }
+        }, {
+          "in" : "query",
+          "name" : "at",
+          "description" : "Specifies the time to mark the entity as having been created. Either a Unix epoch timestamp in milliseconds, or an ISO-8601 formatted date and time in UTC timezone.",
+          "required" : false
         } ],
         "responses" : {
           "201" : {
@@ -87,6 +92,11 @@
           "required": true,
           "type": "string",
           "description": "See the documentation above for the format of the path."
+        }, {
+          "in" : "query",
+          "name" : "at",
+          "description" : "Look at the entity as it looked at the provided time. Either a Unix epoch timestamp in milliseconds, or an ISO-8601 formatted date and time in UTC timezone.",
+          "required" : false
         } ],
         "responses" : {
           "200" : {
@@ -116,10 +126,18 @@
           "required" : true,
           "type": "string",
           "description" : "See the documentation above for the format of the path."
+        }, {
+          "in" : "query",
+          "name" : "at",
+          "description" : "Specifies the time to mark the entity as having been deleted. Either a Unix epoch timestamp in milliseconds, or an ISO-8601 formatted date and time in UTC timezone.",
+          "required" : false
         } ],
         "responses" : {
           "204" : {
             "description" : "Entity deleted."
+          },
+          "400" : {
+            "description" : "There has been an update to the entity since the time it is requested to be deleted."
           },
           "404" : {
             "description" : "No entity found on given traversal URI."
@@ -149,13 +167,18 @@
           "schema" : {
             "$ref" : "#/definitions/AbstractElementUpdate"
           }
+        }, {
+          "in" : "query",
+          "name" : "at",
+          "description" : "Specifies the time to mark the entity as having been updated. Either a Unix epoch timestamp in milliseconds, or an ISO-8601 formatted date and time in UTC timezone.",
+          "required" : false
         } ],
         "responses" : {
           "204" : {
             "description" : "Entity updated."
           },
           "400" : {
-            "description" : "Data in wrong format"
+            "description" : "Data in wrong format or update requested at a time, after which the entity was already changed"
           },
           "403" : {
             "description" : "Unauthorized access"
@@ -197,6 +220,11 @@
           "schema" : {
             "$ref" : "#/definitions/AbstractElementBlueprint"
           }
+        }, {
+          "in" : "query",
+          "name" : "at",
+          "description" : "Specifies the time to mark the entity as having been created at. Either a Unix epoch timestamp in milliseconds, or an ISO-8601 formatted date and time in UTC timezone.",
+          "required" : false
         } ],
         "responses" : {
           "201" : {
@@ -234,6 +262,11 @@
           "required" : true,
           "type": "string",
           "description" : "See the documentation above for the format of the path."
+        }, {
+          "in" : "query",
+          "name" : "at",
+          "description" : "Look at the entity as it looked at the provided time. Either a Unix epoch timestamp in milliseconds, or an ISO-8601 formatted date and time in UTC timezone.",
+          "required" : false
         } ],
         "responses" : {
           "200" : {
@@ -244,6 +277,47 @@
           },
           "400" : {
             "description" : "The entity doesn't support identity hashing."
+          },
+          "404" : {
+            "description" : "No entity found on given traversal URI."
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
+    "/entity/{path}/history" : {
+      "get" : {
+        "tags" : [ "Single Entity" ],
+        "summary" : "Obtains the history of the entity.",
+        "description" : "",
+        "operationId" : "getHistory",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "path",
+          "in" : "path",
+          "required" : true,
+          "type": "string",
+          "description" : "See the documentation above for the format of the path."
+        }, {
+          "in" : "query",
+          "name" : "from",
+          "description" : "Either a Unix epoch timestamp in milliseconds, or an ISO-8601 formatted date and time in UTC timezone.",
+          "required" : false
+        }, {
+          "in" : "query",
+          "name" : "to",
+          "description" : "Either a Unix epoch timestamp in milliseconds, or an ISO-8601 formatted date and time in UTC timezone.",
+          "required" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "History returned.",
+            "schema" : {
+              "$ref" : "#/definitions/History"
+            }
           },
           "404" : {
             "description" : "No entity found on given traversal URI."
@@ -348,6 +422,11 @@
           "schema" : {
             "$ref" : "#/definitions/SyncRequest"
           }
+        }, {
+          "in" : "query",
+          "name" : "at",
+          "description" : "The time at which to mark the creates/updates/deletes as having occured. Either a Unix epoch timestamp in milliseconds, or an ISO-8601 formatted date and time in UTC timezone.",
+          "required" : false
         } ],
         "responses" : {
           "204" : {
@@ -380,6 +459,12 @@
         "summary" : "Retrieves the details of the current tenant.",
         "description" : "",
         "operationId" : "getTenant",
+        "parameters" : [ {
+          "in" : "query",
+          "name" : "at",
+          "description" : "Look at the tenant as it looked at the provided time. Either a Unix epoch timestamp in milliseconds, or an ISO-8601 formatted date and time in UTC timezone.",
+          "required" : false
+        }],
         "responses" : {
           "200" : {
             "description" : "Tenant obtained",
@@ -413,6 +498,11 @@
           "schema" : {
             "$ref" : "#/definitions/TenantUpdate"
           }
+        }, {
+          "in" : "query",
+          "name" : "at",
+          "description" : "The time to mark the update as having occured at. Either a Unix epoch timestamp in milliseconds, or an ISO-8601 formatted date and time in UTC timezone.",
+          "required" : false
         } ],
         "responses" : {
           "204" : {
@@ -439,6 +529,12 @@
         "summary" : "Creates new relationship(s) on a tenant",
         "description" : "As all POSTs, this can also accept an array of blueprints to create more than 1 relationship at a time.",
         "operationId" : "createRelationships",
+        "parameters" : [ {
+          "in" : "query",
+          "name" : "at",
+          "description" : "The time to mark the relationship as having been created at. Either a Unix epoch timestamp in milliseconds, or an ISO-8601 formatted date and time in UTC timezone.",
+          "required" : false
+        }],
         "responses" : {
           "201" : {
             "description" : "Relationship(s) created.",
@@ -467,6 +563,12 @@
         "summary" : "Retrieves tenant's relationships",
         "description" : "By default, all the outgoing relationships are returned. This can be modified using the same techniques as in the entity graph traversal.",
         "operationId" : "getRelationships",
+        "parameters" : [ {
+          "in" : "query",
+          "name" : "at",
+          "description" : "Look at the relationships as they were at the provided time. Either a Unix epoch timestamp in milliseconds, or an ISO-8601 formatted date and time in UTC timezone.",
+          "required" : false
+        }],
         "responses" : {
           "200" : {
             "description" : "Relationships returned",
@@ -492,6 +594,44 @@
         }
       }
     },
+    "/tenant/history" : {
+      "get" : {
+        "tags" : [ "Tenant information" ],
+        "summary" : "Obtains the history of the updates to the tenant.",
+        "description" : "",
+        "operationId" : "getTenantHistory",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "path",
+          "in" : "path",
+          "required" : true,
+          "type": "string",
+          "description" : "See the documentation above for the format of the path."
+        }, {
+          "in" : "query",
+          "name" : "from",
+          "description" : "Either a Unix epoch timestamp in milliseconds, or an ISO-8601 formatted date and time in UTC timezone.",
+          "required" : false
+        }, {
+          "in" : "query",
+          "name" : "to",
+          "description" : "Either a Unix epoch timestamp in milliseconds, or an ISO-8601 formatted date and time in UTC timezone.",
+          "required" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "History returned.",
+            "schema" : {
+              "$ref" : "#/definitions/History"
+            }
+          },
+          "500" : {
+            "description" : "Internal server error"
+          }
+        }
+      }
+    },
     "/traversal/{traversal}" : {
       "get" : {
         "tags" : [ "Entity Graph Traversal" ],
@@ -506,6 +646,11 @@
           "required" : true,
           "type": "string",
           "description" : "See the documentation above for the format of the traversal."
+        }, {
+          "in" : "query",
+          "name" : "at",
+          "description" : "Look at the entities and relationships as they existed at the provided time. Either a Unix epoch timestamp in milliseconds, or an ISO-8601 formatted date and time in UTC timezone.",
+          "required" : false
         } ],
         "responses" : {
           "200" : {
@@ -1142,6 +1287,46 @@
             "type" : "string",
             "enum" : ["f", "rt", "mt", "ot", "r", "m", "d"]
           }
+        }
+      }
+    },
+    "History" : {
+      "type" : "array",
+      "items" : {
+        "type" : "Change"
+      }
+    },
+    "Change" : {
+      "type" : "object",
+      "properties" : {
+        "time" : {
+          "type" : "integer",
+          "description" : "A Unix epoch timestamp in milliseconds."
+        },
+        "action" : {
+          "type" : "string",
+          "enum" : ["created", "updated", "deleted"]
+        },
+        "context" : {
+          "anyOf" : [
+            {
+              "$ref" : "#/definitions/Entity"
+            },
+            {
+              "$ref" : "#definitions/ActionUpdate"
+            }
+          ]
+        }
+      }
+    },
+    "ActionUpdate": {
+      "type" : "object",
+      "properties" : {
+        "originalEntity" : {
+          "$ref" : "#/definitions/Entity"
+        },
+        "update" : {
+          "$ref" : "#/definitions/EntityUpdate"
         }
       }
     }

--- a/hawkular-inventory-security-parent/hawkular-inventory-security-accounts/pom.xml
+++ b/hawkular-inventory-security-parent/hawkular-inventory-security-accounts/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular.inventory</groupId>
     <artifactId>hawkular-inventory-security-parent</artifactId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-security-accounts</artifactId>

--- a/hawkular-inventory-security-parent/hawkular-inventory-security-permissive/pom.xml
+++ b/hawkular-inventory-security-parent/hawkular-inventory-security-permissive/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular.inventory</groupId>
     <artifactId>hawkular-inventory-security-parent</artifactId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-security-permissive</artifactId>

--- a/hawkular-inventory-security-parent/hawkular-inventory-security-spi/pom.xml
+++ b/hawkular-inventory-security-parent/hawkular-inventory-security-spi/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular.inventory</groupId>
     <artifactId>hawkular-inventory-security-parent</artifactId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-security-spi</artifactId>

--- a/hawkular-inventory-security-parent/pom.xml
+++ b/hawkular-inventory-security-parent/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.hawkular.inventory</groupId>
     <artifactId>hawkular-inventory-parent</artifactId>
-    <version>0.19.4.Final-SNAPSHOT</version>
+    <version>0.20.0.Final-SNAPSHOT</version>
   </parent>
 
   <artifactId>hawkular-inventory-security-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <groupId>org.hawkular.inventory</groupId>
   <artifactId>hawkular-inventory-parent</artifactId>
-  <version>0.19.4.Final-SNAPSHOT</version>
+  <version>0.20.0.Final-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <inceptionYear>2015</inceptionYear>
@@ -101,9 +101,6 @@
 
     <!-- integration tests distribution properties -->
     <test-dist-version.org.hawkular.commons>${version.org.hawkular.commons}</test-dist-version.org.hawkular.commons> <!-- C* -->
-
-    <!-- tests -->
-    <version.org.powermock>1.6.5</version.org.powermock>
   </properties>
 
 
@@ -214,17 +211,6 @@
         <type>zip</type>
       </dependency>
 
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-module-junit4</artifactId>
-        <version>${version.org.powermock}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-api-mockito</artifactId>
-        <version>${version.org.powermock}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,9 @@
 
     <!-- integration tests distribution properties -->
     <test-dist-version.org.hawkular.commons>${version.org.hawkular.commons}</test-dist-version.org.hawkular.commons> <!-- C* -->
+
+    <!-- tests -->
+    <version.org.powermock>1.6.5</version.org.powermock>
   </properties>
 
 
@@ -211,6 +214,17 @@
         <type>zip</type>
       </dependency>
 
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <version>${version.org.powermock}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito</artifactId>
+        <version>${version.org.powermock}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Work in progress on versioning.

Main principles:
- Nothing gets deleted, merely is marked as such (a new `eradicate()` method can truly delete stuff, but the backwards compatible `delete()` methods merely mark the elements as deleted from certain point in time onwards). 
- Entities are stored in 2 vertices - an identity vertex containing identifying info on the entity (its canonical path, type, etc) and state vertex that contains the rest of the entity properties as they exist at some point in time.
- The identity and state vertex are connected using an `__inState` edge that has `from` and `to` properties containing time stamps. Those define from and until when is given state valid.
- The current state has `to` set to `Long.MAX_VALUE` - a distant future.
- An entity is non-existent at some point in time if there is no identity vertex at all or there is no valid `__inState` edge for given point in time.
- All relationships have `from` and `to` properties, too, that define from and until when those relationships "exist".
- Relationship edges connect the identity vertices.
- All querying has been updated to take into account the `from` and `to` props.
- The "current" time is either left undefined, in which case we use `Instant.now()`, or is defined using `Inventory.at()` method.
- The current time is passed down to the backend as a `Discriminator` - the reasoning being that in future the discriminator might hold more than just time.

Still to do:
- [x] unit tests for `eradicate()` and "looking into the past"
- [x] /history REST
- [x] `?at=<time>` query param
- [x] create indices for time-related properties and update the pre-created schema with them
- [x] integration tests
