### PR TITLE
Use wildfly-server-provisioning-maven-plugin

### DIFF
--- a/hawkular-inventory-feature-pack/pom.xml
+++ b/hawkular-inventory-feature-pack/pom.xml
@@ -251,4 +251,30 @@
 
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>server-provisioning</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.wildfly.build</groupId>
+            <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>server-provisioning</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <config-file>server-provisioning.xml</config-file>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/hawkular-inventory-feature-pack/server-provisioning.xml
+++ b/hawkular-inventory-feature-pack/server-provisioning.xml
@@ -1,0 +1,25 @@
+<!--
+
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<server-provisioning xmlns="urn:wildfly:server-provisioning:1.1" extract-schemas="true"
+  copy-module-artifacts="true">
+  <feature-packs>
+    <feature-pack groupId="org.hawkular.inventory" artifactId="hawkular-inventory-feature-pack"
+                  version="${project.version}" />
+  </feature-packs>
+</server-provisioning>


### PR DESCRIPTION
Create a full distribution under hawkular-inventory-feature-pack when profile "server-provisioning" is active.

So that inventory can run out of the box, without Services, with all wildfly dependencies provided.
