### PR TITLE
Pre-create the Inventory schema in SQL so that it is not dynamically

### DIFF
--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/src/main/java/org/hawkular/inventory/impl/tinkerpop/spi/Constants.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-spi/src/main/java/org/hawkular/inventory/impl/tinkerpop/spi/Constants.java
@@ -81,100 +81,106 @@ public final class Constants {
          * The user-defined human-readable name of the entity. We don't use the "__" prefix here as with the rest of
          * the properties, because this is not really hidden.
          */
-        name,
+        name(String.class),
 
         /**
          * This is the name of the property that we use to store the type of the entity represented by the vertex
          */
-        __type("type"),
+        __type("type", String.class),
 
         /**
          * This is the name of the property that we use to store the user-defined ID of the entity represented by the
          * vertex. These ID are required to be unique only amongst their "siblings" as determined by the "contains"
          * hierarchy.
          */
-        __eid("id"),
+        __eid("id", String.class),
 
         /**
          * Present on metric type, this is the name of the propety that we use to store the unit of the metric type
          * represented by the vertex.
          */
-        __unit("unit"),
+        __unit("unit", String.class),
 
         /**
          * Property used on metric type to distinguish type of metric e.g. gauge, counter...
          */
-        __metric_data_type("metricDataType"),
+        __metric_data_type("metricDataType", String.class),
 
         /**
          * Property used to store interval in seconds at which metrics are collected
          */
-        __metric_interval("collectionInterval"),
+        __metric_interval("collectionInterval", Long.class),
 
         /**
          * Property used to store the canonical path of an element.
          */
-        __cp("path"),
+        __cp("path", String.class),
 
         /**
          * The type of the data stored by the structured data vertex
          */
-        __structuredDataType,
+        __structuredDataType(String.class),
 
         /**
          * The key using which a structured data value is stored in a map.
          */
-        __structuredDataKey,
+        __structuredDataKey(String.class),
 
         /**
          * The index on which a structured data value is stored in a list.
          */
-        __structuredDataIndex,
+        __structuredDataIndex(Integer.class),
 
         /**
          * The name of the property on the structured data vertex that holds the primitive value of that vertex.
          * List and maps don't hold the value directly but instead have edges going out to the child vertices.
          */
-        __structuredDataValue_b,
+        __structuredDataValue_b(Boolean.class),
 
-        __structuredDataValue_i,
+        __structuredDataValue_i(Long.class),
 
-        __structuredDataValue_f,
+        __structuredDataValue_f(Double.class),
 
-        __structuredDataValue_s,
+        __structuredDataValue_s(String.class),
 
-        __sourceType("sourceType"),
+        __sourceType("sourceType", String.class),
 
-        __targetType("targetType"),
+        __targetType("targetType", String.class),
 
-        __sourceCp("source"),
+        __sourceCp("source", String.class),
 
-        __targetCp("target"),
+        __targetCp("target", String.class),
 
-        __sourceEid,
+        __sourceEid(String.class),
 
-        __targetEid,
+        __targetEid(String.class),
 
-        __identityHash("identityHash"),
+        __identityHash("identityHash", String.class),
 
-        __targetIdentityHash,
+        __targetIdentityHash(String.class),
 
-        __contentHash("contentHash"),
+        __contentHash("contentHash", String.class),
 
-        __syncHash("syncHash");
+        __syncHash("syncHash", String.class);
 
         private final String sortName;
+        private final Class<?> propertyType;
 
-        Property() {
-            this(null);
+        Property(Class<?> type) {
+            this(null, type);
         }
 
-        Property(String sortName) {
+        Property(String sortName, Class<?> type) {
             this.sortName = sortName;
+            this.propertyType = type;
         }
 
         public String getSortName() {
             return sortName;
+        }
+
+        public Class<?> getPropertyType() {
+            return propertyType;
         }
 
         private static final HashSet<String> MIRRORED_PROPERTIES = new HashSet<>(Arrays.asList(__type.name(),

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-sql-provider/src/main/java/org/hawkular/inventory/impl/tinkerpop/sql/SqlGraphProvider.java
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-sql-provider/src/main/java/org/hawkular/inventory/impl/tinkerpop/sql/SqlGraphProvider.java
@@ -18,6 +18,15 @@ package org.hawkular.inventory.impl.tinkerpop.sql;
 
 import static java.util.stream.Collectors.toMap;
 
+import static org.hawkular.inventory.api.Relationships.WellKnown.contains;
+import static org.hawkular.inventory.api.Relationships.WellKnown.defines;
+import static org.hawkular.inventory.api.Relationships.WellKnown.hasData;
+import static org.hawkular.inventory.api.Relationships.WellKnown.incorporates;
+import static org.hawkular.inventory.impl.tinkerpop.spi.Constants.InternalEdge.__containsIdentityHash;
+import static org.hawkular.inventory.impl.tinkerpop.spi.Constants.InternalEdge.__withIdentityHash;
+import static org.hawkular.inventory.impl.tinkerpop.spi.Constants.Property.__identityHash;
+import static org.hawkular.inventory.impl.tinkerpop.spi.Constants.Property.__type;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -38,6 +48,7 @@ import org.hawkular.inventory.impl.tinkerpop.spi.Constants;
 import org.hawkular.inventory.impl.tinkerpop.spi.GraphProvider;
 import org.hawkular.inventory.impl.tinkerpop.spi.IndexSpec;
 import org.hawkular.inventory.paths.CanonicalPath;
+import org.umlg.sqlg.structure.SchemaTable;
 import org.umlg.sqlg.structure.SqlgExceptions;
 import org.umlg.sqlg.structure.SqlgGraph;
 
@@ -85,6 +96,8 @@ public class SqlGraphProvider implements GraphProvider {
     @Override public void ensureIndices(Graph graph, IndexSpec... indexSpecs) {
         SqlgGraph sqlg = (SqlgGraph) graph;
 
+        ensureSchema(sqlg);
+
         ArrayList<IndexSpec> specs = new ArrayList<>(Arrays.asList(indexSpecs));
 
         String[] entityLabels =
@@ -126,6 +139,114 @@ public class SqlGraphProvider implements GraphProvider {
         sqlg.tx().commit();
     }
 
+    private static void ensureSchema(SqlgGraph graph) {
+        String schema = graph.getSqlDialect().getPublicSchema();
+
+        Function<String, Object> propertySampleValue = p ->
+                sampleValue(Constants.Property.valueOf(p).getPropertyType());
+
+        graph.tx().open();
+
+        //tables for entity types
+        for (Constants.Type t : Constants.Type.values()) {
+            if (t == Constants.Type.relationship) {
+                continue;
+            }
+            //get all the properties of this type and replace each with itself and a default value of it so that
+            //we can properly define the tables
+            Object[] props = Stream.of(t.getMappedProperties())
+                    .flatMap(p -> Stream.of(p, propertySampleValue.apply(p))).toArray();
+
+            graph.getSchemaManager().ensureVertexTableExist(schema, t.name(), props);
+        }
+
+        //table for the identity hash storage
+        graph.getSchemaManager()
+                .ensureVertexTableExist(schema, Constants.InternalType.__identityHash.name(), __type.name(), "",
+                        __identityHash.name(), "");
+
+
+        graph.tx().commit();
+
+        SchemaTable tenant = SchemaTable.from(graph, Constants.Type.tenant.name(), schema);
+        SchemaTable feed = SchemaTable.from(graph, Constants.Type.feed.name(), schema);
+        SchemaTable environment = SchemaTable.from(graph, Constants.Type.environment.name(), schema);
+        SchemaTable resourceType = SchemaTable.from(graph, Constants.Type.resourceType.name(), schema);
+        SchemaTable metricType = SchemaTable.from(graph, Constants.Type.metricType.name(), schema);
+        SchemaTable operationType = SchemaTable.from(graph, Constants.Type.operationType.name(), schema);
+        SchemaTable metadataPack = SchemaTable.from(graph, Constants.Type.metadatapack.name(), schema);
+        SchemaTable resource = SchemaTable.from(graph, Constants.Type.resource.name(), schema);
+        SchemaTable metric = SchemaTable.from(graph, Constants.Type.metric.name(), schema);
+        SchemaTable data = SchemaTable.from(graph, Constants.Type.dataEntity.name(), schema);
+        SchemaTable structuredData = SchemaTable.from(graph, Constants.Type.structuredData.name(), schema);
+        SchemaTable identityHash = SchemaTable.from(graph, Constants.InternalType.__identityHash.name(), schema);
+
+        Object[] relProps =
+                Stream.of(Constants.Type.relationship.getMappedProperties())
+                        .flatMap(p -> Stream.of(p, propertySampleValue.apply(p))).toArray();
+
+        AddEdgeHelper<SchemaTable, Enum<?>, SchemaTable> edges = (out, rel, in) ->
+                graph.getSchemaManager().ensureEdgeTableExist(schema, rel.name(), in, out, relProps);
+
+        graph.tx().open();
+
+        //tenant relationships
+        edges.add(tenant, contains, environment);
+        edges.add(tenant, contains, metadataPack);
+        edges.add(tenant, contains, feed);
+        edges.add(tenant, contains, resourceType);
+        edges.add(tenant, contains, metricType);
+        edges.add(tenant, __containsIdentityHash, identityHash);
+
+        //environment relationships
+        edges.add(environment, contains, resource);
+        edges.add(environment, contains, metric);
+        edges.add(environment, incorporates, feed);
+
+        //feed relationships
+        edges.add(feed, contains, resourceType);
+        edges.add(feed, contains, metricType);
+        edges.add(feed, contains, resource);
+        edges.add(feed, contains, metric);
+        edges.add(feed, __withIdentityHash, identityHash);
+
+        //resource type relationships
+        edges.add(resourceType, contains, operationType);
+        edges.add(resourceType, contains, data);
+        edges.add(resourceType, defines, resource);
+        edges.add(resourceType, __withIdentityHash, identityHash);
+
+        //metric type relationships
+        edges.add(metricType, __withIdentityHash, identityHash);
+
+        //operation type relationships
+        edges.add(operationType, contains, data);
+        edges.add(operationType, __withIdentityHash, identityHash);
+
+        //metadata pack relationships
+        edges.add(metadataPack, incorporates, resourceType);
+        edges.add(metadataPack, incorporates, metricType);
+
+        //resource relationships
+        edges.add(resource, contains, resource);
+        edges.add(resource, contains, data);
+        edges.add(resource, contains, metric);
+        edges.add(resource, incorporates, metric);
+        edges.add(resource, __withIdentityHash, identityHash);
+
+        //metric relationships
+        edges.add(metric, __withIdentityHash, identityHash);
+
+        //data entity relationships
+        edges.add(data, hasData, structuredData);
+        edges.add(data, __withIdentityHash, identityHash);
+
+        //structured data relationships
+        edges.add(structuredData, contains, structuredData);
+
+        graph.tx().commit();
+    }
+
     private static Set<Configuration.Property> sysPropsAsProperties() {
         return System.getProperties().entrySet().stream().map(e -> new Configuration.Property() {
             @Override public String getPropertyName() {
@@ -140,7 +261,23 @@ public class SqlGraphProvider implements GraphProvider {
 
     private static Object sampleValue(Class<?> type) {
         if (type == String.class) {
-            return "a";
+            return "";
+        } else if (type == Boolean.class || type == boolean.class) {
+            return true;
+        } else if (type == Character.class || type == char.class) {
+            return ' ';
+        } else if (type == Byte.class || type == byte.class) {
+            return (byte) 0;
+        } else if (type == Short.class || type == short.class) {
+            return (short) 0;
+        } else if (type == Integer.class || type == int.class) {
+            return 0;
+        } else if (type == Long.class || type == long.class) {
+            return 0L;
+        } else if (type == Float.class || type == float.class) {
+            return 0F;
+        } else if (type == Double.class || type == double.class) {
+            return 0D;
         } else {
             throw new IllegalArgumentException("Unhandled type of property: " + type);
         }
@@ -151,5 +288,10 @@ public class SqlGraphProvider implements GraphProvider {
             return new EntityAlreadyExistsException(inputException, affectedPath);
         }
         return inputException;
+    }
+
+    @FunctionalInterface
+    private interface AddEdgeHelper<T, U, V> {
+        void add(T t, U u, V v);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <version.com.thinkaurelius.titan>1.1.0-SNAPSHOT</version.com.thinkaurelius.titan>
     <version.com.tinkerpop.gremlin>2.6.0</version.com.tinkerpop.gremlin>
     <version.org.apache.tinkerpop>3.2.2</version.org.apache.tinkerpop>
-    <version.org.umlg>1.3.0-SRC-revision-93f751a0e784e03cc49ab952fe50633c962c6119</version.org.umlg>
+    <version.org.umlg>1.3.0-SRC-revision-46e6886ee1136bc275c25b164a27a457218e11ea</version.org.umlg>
 
     <version.org.antlr>4.5.3</version.org.antlr>
 
@@ -244,7 +244,7 @@
               <selectors>
                 <selector>org.umlg</selector>
               </selectors>
-              <url>scm:git:https://github.com/pietermartin/sqlg.git</url>
+              <url>scm:git:https://github.com/metlos/sqlg.git</url>
               <buildArgs>
                 <!-- the tests take a loooong time -->
                 <buildArg>-DskipTests</buildArg>


### PR DESCRIPTION
created during the heavy load the feeds can inflict on the DB during sync.

Also, use my fork of Sqlg so that the methods that we use for schema
creation are public (this will eventually go into Sqlg proper at which
point we can switch back).
