### PR TITLE
[HWKINVENT-187] Remove unnecessary deps gremlin-groovy

### DIFF
--- a/hawkular-inventory-dist/pom.xml
+++ b/hawkular-inventory-dist/pom.xml
@@ -140,18 +140,45 @@
       <groupId>org.umlg</groupId>
       <artifactId>sqlg-hsqldb</artifactId>
       <version>${version.org.umlg}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tinkerpop</groupId>
+          <artifactId>gremlin-groovy</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.umlg</groupId>
       <artifactId>sqlg-postgres</artifactId>
       <version>${version.org.umlg}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tinkerpop</groupId>
+          <artifactId>gremlin-groovy</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.umlg</groupId>
       <artifactId>sqlg-h2</artifactId>
       <version>${version.org.umlg}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tinkerpop</groupId>
+          <artifactId>gremlin-groovy</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- This dependency is necessary due to exclusion of gremlin-groovy,
+    since sqlg-core uses commons-lang3 which is included by transitivity
+    in gremlin-groovy -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${version.commons-lang3}</version>
     </dependency>
 
     <!-- Logging -->

--- a/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-sql-provider/pom.xml
+++ b/hawkular-inventory-impl-tinkerpop-parent/hawkular-inventory-impl-tinkerpop-sql-provider/pom.xml
@@ -47,18 +47,25 @@
       <version>${version.org.apache.tinkerpop}</version>
     </dependency>
 
-    <!-- Need to redeclare this, because Sqlg depends on it and transitively we could not get a correct version in our
-         dist. -->
-    <dependency>
-      <groupId>org.apache.tinkerpop</groupId>
-      <artifactId>gremlin-groovy</artifactId>
-      <version>${version.org.apache.tinkerpop}</version>
-    </dependency>
-
     <dependency>
       <groupId>org.umlg</groupId>
       <artifactId>sqlg-core</artifactId>
       <version>${version.org.umlg}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tinkerpop</groupId>
+          <artifactId>gremlin-groovy</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- This dependency is necessary due to exclusion of gremlin-groovy,
+    since sqlg-core uses commons-lang3 which is included by transitivity
+    in gremlin-groovy -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${version.commons-lang3}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,8 @@
     <version.commons-io>2.4</version.commons-io>
     <!-- keep in sync with the WF module modules/system/layers/base/org/apache/commons/lang/main/ -->
     <version.commons-lang>2.6</version.commons-lang>
+    <!-- keep in sync with the required version in sqlg -->
+    <version.commons-lang3>3.3.1</version.commons-lang3>
     <!-- keep in sync with the WF module modules/system/layers/base/org/apache/commons/logging/main/ -->
     <version.commons-logging>1.1.1</version.commons-logging>
     <!-- keep in sync with the WF module modules/system/layers/base/org/apache/commons/pool/main/ -->


### PR DESCRIPTION
This dependency isn't used in sqlg for our purpose and brings a lot of groovy jars
WAR size decreased by 12MB (35 to 23)

(Note: I will suggest some change directly in sqlg to avoid doing exclusion here)
