### PR TITLE
[HWKINVENT-204] Send Bad Request on treeHash / environment

### DIFF
--- a/hawkular-inventory-itest/src/test/java/org/hawkular/inventory/rest/test/InventoryITest.java
+++ b/hawkular-inventory-itest/src/test/java/org/hawkular/inventory/rest/test/InventoryITest.java
@@ -1482,6 +1482,12 @@ public class InventoryITest extends AbstractTestBase {
         assertEquals(tree.getChild(Path.Segment.from("r;table")).getHash(), table.getSyncHash());
     }
 
+    @Test
+    public void testInvalidTreeHash() throws Throwable {
+        Response response = get(basePath + "/entity/e;" + environmentId + "/treeHash");
+        assertEquals(400, response.code());
+    }
+
     private <T> T readAs(String path, ObjectMapper mapper, Class<T> type) throws Throwable {
         Response response = get(basePath + path);
         assertEquals(200, response.code());

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestEntity.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestEntity.java
@@ -42,6 +42,7 @@ import org.hawkular.inventory.api.Synced;
 import org.hawkular.inventory.api.model.AbstractElement;
 import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.SyncHash;
+import org.hawkular.inventory.api.model.Syncable;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.SegmentType;
 import org.jboss.resteasy.spi.BadRequestException;
@@ -72,8 +73,9 @@ public class RestEntity extends RestBase {
         CanonicalPath path = CanonicalPath.fromPartiallyUntypedString(getPath(uriInfo, "/treeHash".length()),
                 getTenantPath(), AbstractElement.class);
 
-        if (path.getSegment().getElementType() == SegmentType.e) {
-            throw new BadRequestException("Cannot get treeHash for environment");
+        Class<?> eltType = Inventory.types().byPath(path).getElementType();
+        if (!Syncable.class.isAssignableFrom(eltType)) {
+            throw new BadRequestException("Element not syncable - cannot get treeHash for path " + path);
         }
         return inventory.inspect(path, Synced.Single.class).treeHash();
     }

--- a/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestEntity.java
+++ b/hawkular-inventory-rest-api/src/main/java/org/hawkular/inventory/rest/RestEntity.java
@@ -44,6 +44,7 @@ import org.hawkular.inventory.api.model.Relationship;
 import org.hawkular.inventory.api.model.SyncHash;
 import org.hawkular.inventory.paths.CanonicalPath;
 import org.hawkular.inventory.paths.SegmentType;
+import org.jboss.resteasy.spi.BadRequestException;
 
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -71,6 +72,9 @@ public class RestEntity extends RestBase {
         CanonicalPath path = CanonicalPath.fromPartiallyUntypedString(getPath(uriInfo, "/treeHash".length()),
                 getTenantPath(), AbstractElement.class);
 
+        if (path.getSegment().getElementType() == SegmentType.e) {
+            throw new BadRequestException("Cannot get treeHash for environment");
+        }
         return inventory.inspect(path, Synced.Single.class).treeHash();
     }
 


### PR DESCRIPTION
Quick fix to send more explicit error (before that, user got a ClassCastException stack in his response)

@metlos I check here that the element type is not "environment", but is there other types that should be disallowed here?
