### PR TITLE
Synchronize the versions of the driver used by the JNDI datasources and the Sqlg managed ones.

### DIFF
--- a/hawkular-inventory-dist/pom.xml
+++ b/hawkular-inventory-dist/pom.xml
@@ -140,12 +140,24 @@
       <groupId>org.umlg</groupId>
       <artifactId>sqlg-hsqldb-dialect</artifactId>
       <version>${version.org.umlg}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hsqldb</groupId>
+          <artifactId>hsqldb</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.umlg</groupId>
       <artifactId>sqlg-postgres-dialect</artifactId>
       <version>${version.org.umlg}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.postgresql</groupId>
+          <artifactId>postgresql</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Commenting this out because we're shipping with HSQLDB as our embedded solution for now.
@@ -156,6 +168,19 @@
       <!--<artifactId>sqlg-h2-dialect</artifactId>-->
       <!--<version>${version.org.umlg}</version>-->
     <!--</dependency>-->
+
+    <!-- include the versions of the drivers we want -->
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${version.org.postgresql}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
+      <version>${version.org.hsqldb}</version>
+    </dependency>
 
     <!-- Logging -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -96,8 +96,8 @@
     <!-- keep in sync with the WF module modules/system/layers/base/org/codehaus/jettison/main/ -->
     <version.org.codehaus.jettison>1.3.3</version.org.codehaus.jettison>
 
-    <version.org.revapi.revapi-maven-plugin>0.4.1</version.org.revapi.revapi-maven-plugin>
-    <version.org.revapi.revapi-java>0.6.0</version.org.revapi.revapi-java>
+    <version.org.revapi.revapi-maven-plugin>0.6.1</version.org.revapi.revapi-maven-plugin>
+    <version.org.revapi.revapi-java>0.10.2</version.org.revapi.revapi-java>
 
     <!-- integration tests distribution properties -->
     <test-dist-version.org.hawkular.commons>${version.org.hawkular.commons}</test-dist-version.org.hawkular.commons> <!-- C* -->


### PR DESCRIPTION
Note that this PR is against the "stabilization branch" - 1.0.x that is based on 0.19.x - i.e. it does NOT include the versioning support.

This is because we don't need versioning for anything in hawkular yet and will not start using it until the components are stabilized.
