### PR TITLE
Upgrade rxjava 1.0.8 -> 1.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
   <properties>
     <version.org.hawkular.commons>0.7.4.Final</version.org.hawkular.commons>
 
-    <version.io.reactivex>1.0.8</version.io.reactivex>
+    <version.io.reactivex>1.1.7</version.io.reactivex>
     <!-- overrides 3.1.2 from parent which produces NPE -->
     <version.com.github.kongchen.swagger-maven-plugin>3.1.1</version.com.github.kongchen.swagger-maven-plugin>
     <version.com.github.fge>2.2.6</version.com.github.fge>


### PR DESCRIPTION
This syncs with metrics and the version can optionally be inherited from the next hawkular parent update.